### PR TITLE
Switch to using v3.2 of argparser for wheels

### DIFF
--- a/python/libcuopt/CMakeLists.txt
+++ b/python/libcuopt/CMakeLists.txt
@@ -42,7 +42,7 @@ include(FetchContent)
 FetchContent_Declare(
   argparse
   GIT_REPOSITORY https://github.com/p-ranav/argparse.git
-  GIT_TAG v2.9
+  GIT_TAG v3.2
 )
 FetchContent_MakeAvailable(argparse)
 


### PR DESCRIPTION
We are using 3.2 version of cpp-argparser from conda.  This PR updates the version to 3.2 for wheel builds as well. 