### PR TITLE
include Python constraints for pure-Python conda packages

### DIFF
--- a/conda/recipes/cuopt-server/recipe.yaml
+++ b/conda/recipes/cuopt-server/recipe.yaml
@@ -40,9 +40,6 @@ requirements:
     - pandas>=2
     - python
     - uvicorn ${{ uvicorn_version }}
-  ignore_run_exports:
-    by_name:
-      - python_abi
 
 tests:
   - python:

--- a/conda/recipes/cuopt-sh-client/recipe.yaml
+++ b/conda/recipes/cuopt-sh-client/recipe.yaml
@@ -31,9 +31,6 @@ requirements:
     - msgpack-python =1.0.8
     - python
     - requests
-  ignore_run_exports:
-    by_name:
-      - python_abi
 
 tests:
   - python:


### PR DESCRIPTION
The `cuopt-sh-client` and `cuopt-server` packages are pure Python.

However, their conda packages are not technically built as `noarch: python` because of some historical limitations in RAPIDS build workflows (to be addresses as part of https://github.com/rapidsai/build-planning/issues/43).

As a result, 1 of those packages is published for each combination of `(Python minor version, CPU architecture)` supported by RAPIDS. See, for example, https://anaconda.org/nvidia/cuopt-server/files?version=25.05.00

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/a5c2db23-b282-4dd0-85a3-abb8c0757372" />

For as long as we're doing that, those packages should have a constraint on `python`, so that (for example) only 1 package matches for a given `(Python minor version, CPU architecture)`.

This does that.
