### PR TITLE
Fix obj constant on max. Fix undefined memory access at root

### DIFF
--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -463,9 +463,9 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     global_variables::mutex_upper.unlock();
     // We should be done here
     uncrush_primal_solution(original_problem, original_lp, incumbent.x, solution.x);
-    solution.objective   = incumbent.objective;
-    solution.lower_bound = lower_bound;
-    solution.nodes_explored = 0;
+    solution.objective          = incumbent.objective;
+    solution.lower_bound        = lower_bound;
+    solution.nodes_explored     = 0;
     solution.simplex_iterations = root_relax_soln.iterations;
     settings.log.printf("Optimal solution found at root node. Objective %.16e. Time %.2f.\n",
                         compute_user_objective(original_lp, root_objective),

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -465,6 +465,8 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     uncrush_primal_solution(original_problem, original_lp, incumbent.x, solution.x);
     solution.objective   = incumbent.objective;
     solution.lower_bound = lower_bound;
+    solution.nodes_explored = 0;
+    solution.simplex_iterations = root_relax_soln.iterations;
     settings.log.printf("Optimal solution found at root node. Objective %.16e. Time %.2f.\n",
                         compute_user_objective(original_lp, root_objective),
                         toc(start_time));

--- a/cpp/src/linear_programming/utilities/logger_init.hpp
+++ b/cpp/src/linear_programming/utilities/logger_init.hpp
@@ -37,6 +37,8 @@ class init_logger_t {
       // TODO save the defaul sink and restore it
       cuopt::default_logger().sinks().push_back(
         std::make_shared<rapids_logger::basic_file_sink_mt>(log_file, true));
+      cuopt::default_logger().set_pattern("%v");
+      cuopt::default_logger().flush_on(rapids_logger::level_enum::info);
     }
   }
   ~init_logger_t() { cuopt::reset_default_logger(); }

--- a/cpp/src/mip/presolve/trivial_presolve.cuh
+++ b/cpp/src/mip/presolve/trivial_presolve.cuh
@@ -233,7 +233,8 @@ void update_from_csr(problem_t<i_t, f_t>& pb)
   }
 
   //  update objective_offset
-  pb.presolve_data.objective_offset += pb.presolve_data.objective_scaling_factor *
+  pb.presolve_data.objective_offset +=
+    pb.presolve_data.objective_scaling_factor *
     thrust::transform_reduce(handle_ptr->get_thrust_policy(),
                              thrust::counting_iterator<i_t>(0),
                              thrust::counting_iterator<i_t>(pb.n_variables),

--- a/cpp/src/mip/presolve/trivial_presolve.cuh
+++ b/cpp/src/mip/presolve/trivial_presolve.cuh
@@ -233,7 +233,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb)
   }
 
   //  update objective_offset
-  pb.presolve_data.objective_offset +=
+  pb.presolve_data.objective_offset += pb.presolve_data.objective_scaling_factor *
     thrust::transform_reduce(handle_ptr->get_thrust_policy(),
                              thrust::counting_iterator<i_t>(0),
                              thrust::counting_iterator<i_t>(pb.n_variables),


### PR DESCRIPTION
This PR fixes two bugs discovered while testing the AMPL interface:

1) We weren't correctly calculating the objective constant when presolve eliminated variables on a maximization problem.

Thanks to Alice for the quick fix!

2) We had an undefined memory access on the number of nodes and simplex iterations when solving a MIP at the root node. 
