### PR TITLE
allow long client version in service version check'

### DIFF
--- a/python/cuopt_server/cuopt_server/utils/job_queue.py
+++ b/python/cuopt_server/cuopt_server/utils/job_queue.py
@@ -109,7 +109,7 @@ def check_client_version(client_vers):
         if client_vers == "custom":
             return []
         cv = client_vers.split(".")
-        if len(cv) != 3:
+        if len(cv) < 2:
             logging.warn("Client version missing or bad format")
             return [
                 f"Client version missing or not the current format. "
@@ -118,7 +118,7 @@ def check_client_version(client_vers):
                 "if this is a custom client."
             ]
         else:
-            cmajor, cminor, _ = cv
+            cmajor, cminor = cv[:2]
             matches = (cmajor, cminor) == (major, minor)
         if not matches:
             logging.warn(f"Client version {cmajor}.{cminor} does not match")


### PR DESCRIPTION
Only consider the first two fields in the client version. Without this change the service will report that the version is a bad format, which is not necessary in this case.
