### PR TITLE
Write out mps file containing user problem. Useful for debugging

### DIFF
--- a/cpp/include/cuopt/linear_programming/constants.h
+++ b/cpp/include/cuopt/linear_programming/constants.h
@@ -59,6 +59,7 @@
 #define CUOPT_MIP_SCALING                 "mip_scaling"
 #define CUOPT_SOL_FILE                    "solution_file"
 #define CUOPT_NUM_CPU_THREADS             "num_cpu_threads"
+#define CUOPT_USER_PROBLEM_FILE           "user_problem_file"
 
 /* @brief LP/MIP termination status constants */
 #define CUOPT_TERIMINATION_STATUS_NO_TERMINATION   0

--- a/cpp/include/cuopt/linear_programming/constants.h
+++ b/cpp/include/cuopt/linear_programming/constants.h
@@ -57,7 +57,7 @@
 #define CUOPT_MIP_RELATIVE_GAP            "mip_relative_gap"
 #define CUOPT_MIP_HEURISTICS_ONLY         "mip_heuristics_only"
 #define CUOPT_MIP_SCALING                 "mip_scaling"
-#define CUOPT_SOL_FILE                    "solution_file"
+#define CUOPT_SOLUTION_FILE               "solution_file"
 #define CUOPT_NUM_CPU_THREADS             "num_cpu_threads"
 #define CUOPT_USER_PROBLEM_FILE           "user_problem_file"
 

--- a/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
@@ -92,6 +92,7 @@ class mip_solver_settings_t {
   bool log_to_console  = true;
   std::string log_file;
   std::string sol_file;
+  std::string user_problem_file;
 
   /** Initial primal solution */
   std::shared_ptr<rmm::device_uvector<f_t>> initial_solution_;

--- a/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
@@ -200,6 +200,7 @@ class pdlp_solver_settings_t {
   bool log_to_console{true};
   std::string log_file{""};
   std::string sol_file{""};
+  std::string user_problem_file{""};
   bool per_constraint_residual{false};
   bool crossover{false};
   bool save_best_primal_so_far{false};

--- a/cpp/src/linear_programming/solve.cu
+++ b/cpp/src/linear_programming/solve.cu
@@ -569,6 +569,11 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(optimization_problem_t<i_t, f
                    problem.presolve_data.objective_offset,
                    problem.presolve_data.objective_scaling_factor);
 
+    if (settings.user_problem_file != "") {
+      CUOPT_LOG_INFO("Writing user problem to file: %s", settings.user_problem_file.c_str());
+      problem.write_as_mps(settings.user_problem_file);
+    }
+
     // Set the hyper-parameters based on the solver_settings
     if (use_pdlp_solver_mode) { set_pdlp_solver_mode(settings); }
 

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -111,7 +111,9 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
     {CUOPT_LOG_FILE,  &mip_settings.log_file, ""},
     {CUOPT_LOG_FILE,  &pdlp_settings.log_file, ""},
     {CUOPT_SOL_FILE,  &mip_settings.sol_file, ""},
-    {CUOPT_SOL_FILE,  &pdlp_settings.sol_file, ""}
+    {CUOPT_SOL_FILE,  &pdlp_settings.sol_file, ""},
+    {CUOPT_USER_PROBLEM_FILE, &mip_settings.user_problem_file, ""},
+    {CUOPT_USER_PROBLEM_FILE, &pdlp_settings.user_problem_file, ""}
   };
   // clang-format on
 }

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -110,8 +110,8 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
   string_parameters = {
     {CUOPT_LOG_FILE,  &mip_settings.log_file, ""},
     {CUOPT_LOG_FILE,  &pdlp_settings.log_file, ""},
-    {CUOPT_SOL_FILE,  &mip_settings.sol_file, ""},
-    {CUOPT_SOL_FILE,  &pdlp_settings.sol_file, ""},
+    {CUOPT_SOLUTION_FILE,  &mip_settings.sol_file, ""},
+    {CUOPT_SOLUTION_FILE,  &pdlp_settings.sol_file, ""},
     {CUOPT_USER_PROBLEM_FILE, &mip_settings.user_problem_file, ""},
     {CUOPT_USER_PROBLEM_FILE, &pdlp_settings.user_problem_file, ""}
   };

--- a/cpp/src/mip/problem/write_mps.cu
+++ b/cpp/src/mip/problem/write_mps.cu
@@ -54,6 +54,8 @@ void problem_t<i_t, f_t>::write_as_mps(const std::string& path)
   // NAME section
   mps_file << "NAME          " << original_problem_ptr->get_problem_name() << "\n";
 
+  if (maximize) { mps_file << "OBJSENSE\n MAXIMIZE\n"; }
+
   // ROWS section
   mps_file << "ROWS\n";
   mps_file << " N  " << (objective_name.empty() ? "OBJ" : objective_name) << "\n";
@@ -86,7 +88,7 @@ void problem_t<i_t, f_t>::write_as_mps(const std::string& path)
     // Write objective coefficient if non-zero
     if (h_obj_coeffs[j] != 0.0) {
       mps_file << "    " << col_name << " " << (objective_name.empty() ? "OBJ" : objective_name)
-               << " " << h_obj_coeffs[j] << "\n";
+               << " " << (maximize ? -h_obj_coeffs[j] : h_obj_coeffs[j]) << "\n";
     }
 
     // Write constraint coefficients
@@ -146,7 +148,7 @@ void problem_t<i_t, f_t>::write_as_mps(const std::string& path)
         h_var_ub[j] == std::numeric_limits<f_t>::infinity()) {
       mps_file << " FR BOUND1    " << col_name << "\n";
     } else {
-      if (h_var_lb[j] != 0.0 || h_obj_coeffs[j] == 0.0) {
+      if (h_var_lb[j] != 0.0 || h_obj_coeffs[j] == 0.0 || h_var_types[j] != var_t::CONTINUOUS) {
         if (h_var_lb[j] == -std::numeric_limits<f_t>::infinity()) {
           mps_file << " MI BOUND1    " << col_name << "\n";
         } else {

--- a/cpp/src/mip/problem/write_mps.cu
+++ b/cpp/src/mip/problem/write_mps.cu
@@ -146,7 +146,7 @@ void problem_t<i_t, f_t>::write_as_mps(const std::string& path)
         h_var_ub[j] == std::numeric_limits<f_t>::infinity()) {
       mps_file << " FR BOUND1    " << col_name << "\n";
     } else {
-      if (h_var_lb[j] != 0.0) {
+      if (h_var_lb[j] != 0.0 || h_obj_coeffs[j] == 0.0) {
         if (h_var_lb[j] == -std::numeric_limits<f_t>::infinity()) {
           mps_file << " MI BOUND1    " << col_name << "\n";
         } else {

--- a/cpp/src/mip/solve.cu
+++ b/cpp/src/mip/solve.cu
@@ -161,6 +161,10 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
 
     // have solve, problem, solution, utils etc. in common dir
     detail::problem_t<i_t, f_t> problem(op_problem);
+    if (settings.user_problem_file != "") {
+      CUOPT_LOG_INFO("Writing user problem to file: %s", settings.user_problem_file.c_str());
+      problem.write_as_mps(settings.user_problem_file);
+    }
 
     // this is for PDLP, i think this should be part of pdlp solver
     setup_device_symbols(op_problem.get_handle_ptr()->get_stream());

--- a/docs/cuopt/source/cuopt-c/lp-milp/lp-milp-c-api.rst
+++ b/docs/cuopt/source/cuopt-c/lp-milp/lp-milp-c-api.rst
@@ -129,7 +129,7 @@ The following functions are used to set and get parameters. You can find more de
 
 
 Parameter Constants
-------------------- 
+-------------------
 
 These constants are used as the parameter name in the `cuOptSetParameter <lp-milp-c-api.html#c.cuOptSetParameter>`_ , `cuOptGetParameter <lp-milp-c-api.html#c.cuOptGetParameter>`_ and similar functions. More details on the parameters can be found in the `LP/MILP settings <../../lp-milp-settings.html>`_ section.
 
@@ -157,7 +157,9 @@ These constants are used as the parameter name in the `cuOptSetParameter <lp-mil
 .. doxygendefine:: CUOPT_MIP_INTEGRALITY_TOLERANCE
 .. doxygendefine:: CUOPT_MIP_SCALING
 .. doxygendefine:: CUOPT_MIP_HEURISTICS_ONLY
+.. doxygendefine:: CUOPT_SOL_FILE
 .. doxygendefine:: CUOPT_NUM_CPU_THREADS
+.. doxygendefine:: CUOPT_USER_PROBLEM_FILE
 
 PDLP Solver Mode Constants
 --------------------------
@@ -190,7 +192,7 @@ LP and MIP solves are performed by calling the `cuOptSolve` function
 Solution
 --------
 
-The output of a solve is a `cuOptSolution` object. 
+The output of a solve is a `cuOptSolution` object.
 
 .. doxygentypedef:: cuOptSolution
 

--- a/docs/cuopt/source/cuopt-c/lp-milp/lp-milp-c-api.rst
+++ b/docs/cuopt/source/cuopt-c/lp-milp/lp-milp-c-api.rst
@@ -157,7 +157,7 @@ These constants are used as the parameter name in the `cuOptSetParameter <lp-mil
 .. doxygendefine:: CUOPT_MIP_INTEGRALITY_TOLERANCE
 .. doxygendefine:: CUOPT_MIP_SCALING
 .. doxygendefine:: CUOPT_MIP_HEURISTICS_ONLY
-.. doxygendefine:: CUOPT_SOL_FILE
+.. doxygendefine:: CUOPT_SOLUTION_FILE
 .. doxygendefine:: CUOPT_NUM_CPU_THREADS
 .. doxygendefine:: CUOPT_USER_PROBLEM_FILE
 

--- a/docs/cuopt/source/lp-milp-settings.rst
+++ b/docs/cuopt/source/lp-milp-settings.rst
@@ -41,6 +41,17 @@ Log File
 
 Note: the default value is ``""`` and no log file is written.
 
+Solution File
+^^^^^^^^^^^^^
+``CUOPT_SOL_FILE`` controls the name of a file where cuOpt should write the solution.
+
+Note: the default value is ``""`` and no solution file is written.
+
+User Problem File
+^^^^^^^^^^^^^^^^
+``CUOPT_USER_PROBLEM_FILE`` controls the name of a file where cuOpt should write the user problem.
+
+Note: the default value is ``""`` and no user problem file is written.
 
 Num CPU Threads
 ^^^^^^^^^^^^^^^

--- a/python/cuopt/cuopt/linear_programming/solver/solver_parameters.pyx
+++ b/python/cuopt/cuopt/linear_programming/solver/solver_parameters.pyx
@@ -67,6 +67,7 @@ cdef extern from "cuopt/linear_programming/constants.h": # noqa
     cdef const char* c_CUOPT_MIP_HEURISTICS_ONLY "CUOPT_MIP_HEURISTICS_ONLY" # noqa
     cdef const char* c_CUOPT_MIP_SCALING "CUOPT_MIP_SCALING" # noqa
     cdef const char* c_CUOPT_NUM_CPU_THREADS "CUOPT_NUM_CPU_THREADS" # noqa
+    cdef const char* c_CUOPT_USER_PROBLEM_FILE "CUOPT_USER_PROBLEM_FILE" # noqa
 
 
 # Create Python string constants from C string literals
@@ -98,3 +99,4 @@ CUOPT_MIP_RELATIVE_GAP = c_CUOPT_MIP_RELATIVE_GAP.decode('utf-8') # noqa
 CUOPT_MIP_HEURISTICS_ONLY = c_CUOPT_MIP_HEURISTICS_ONLY.decode('utf-8') # noqa
 CUOPT_MIP_SCALING = c_CUOPT_MIP_SCALING.decode('utf-8') # noqa
 CUOPT_NUM_CPU_THREADS = c_CUOPT_NUM_CPU_THREADS.decode('utf-8') # noqa
+CUOPT_USER_PROBLEM_FILE = c_CUOPT_USER_PROBLEM_FILE.decode('utf-8') # noqa

--- a/python/cuopt/cuopt/linear_programming/solver/solver_parameters.pyx
+++ b/python/cuopt/cuopt/linear_programming/solver/solver_parameters.pyx
@@ -66,6 +66,7 @@ cdef extern from "cuopt/linear_programming/constants.h": # noqa
     cdef const char* c_CUOPT_MIP_RELATIVE_GAP "CUOPT_MIP_RELATIVE_GAP" # noqa
     cdef const char* c_CUOPT_MIP_HEURISTICS_ONLY "CUOPT_MIP_HEURISTICS_ONLY" # noqa
     cdef const char* c_CUOPT_MIP_SCALING "CUOPT_MIP_SCALING" # noqa
+    cdef const char* c_CUOPT_SOLUTION_FILE "CUOPT_SOLUTION_FILE" # noqa
     cdef const char* c_CUOPT_NUM_CPU_THREADS "CUOPT_NUM_CPU_THREADS" # noqa
     cdef const char* c_CUOPT_USER_PROBLEM_FILE "CUOPT_USER_PROBLEM_FILE" # noqa
 
@@ -98,5 +99,6 @@ CUOPT_MIP_ABSOLUTE_GAP = c_CUOPT_MIP_ABSOLUTE_GAP.decode('utf-8') # noqa
 CUOPT_MIP_RELATIVE_GAP = c_CUOPT_MIP_RELATIVE_GAP.decode('utf-8') # noqa
 CUOPT_MIP_HEURISTICS_ONLY = c_CUOPT_MIP_HEURISTICS_ONLY.decode('utf-8') # noqa
 CUOPT_MIP_SCALING = c_CUOPT_MIP_SCALING.decode('utf-8') # noqa
+CUOPT_SOLUTION_FILE = c_CUOPT_SOLUTION_FILE.decode('utf-8') # noqa
 CUOPT_NUM_CPU_THREADS = c_CUOPT_NUM_CPU_THREADS.decode('utf-8') # noqa
 CUOPT_USER_PROBLEM_FILE = c_CUOPT_USER_PROBLEM_FILE.decode('utf-8') # noqa


### PR DESCRIPTION
This PR adds the string parameter CUOPT_USER_PROBLEM_FILE = "user_problem_file".  By default the parameter is the empty string "". If the parameter is set by the user to something other than the empty string, we will write out an MPS file containing the LP or MIP. 

This is very useful when trying to debug interfaces like CVXPY where the interface between CVXPY and cuOpt may have performed transformation to the user problem. This allows us to reproduce failures on the engine side directly from the MPS file without needing Python scripts.
