### PR TITLE
Pdlp fix batch cuda graph

### DIFF
--- a/cpp/include/cuopt/linear_programming/utilities/cython_solve.hpp
+++ b/cpp/include/cuopt/linear_programming/utilities/cython_solve.hpp
@@ -103,7 +103,8 @@ struct solver_ret_t {
 // Wrapper for solve to expose the API to cython.
 
 std::unique_ptr<solver_ret_t> call_solve(cuopt::mps_parser::data_model_view_t<int, double>*,
-                                         linear_programming::solver_settings_t<int, double>*);
+                                         linear_programming::solver_settings_t<int, double>*,
+                                         unsigned int flags = cudaStreamNonBlocking);
 
 std::pair<std::vector<std::unique_ptr<solver_ret_t>>, double> call_batch_solve(
   std::vector<cuopt::mps_parser::data_model_view_t<int, double>*>,


### PR DESCRIPTION
This PR aims at fixing the invalid operation while there is a graph capture we sometimes see when using batch solve.

Solution is to use a regular instead of a non-blocking stream to make sure that if any operation (like a cudaFree from Thrust) is being launched on the default stream, it will wait for all other operations on other stream to finish first, preventing any cudaMalloc/Free while another stream might be doing a CUDA Graph capture.