### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/python/cuopt_self_hosted/cuopt_sh_client/cuopt_self_host_client.py
+++ b/python/cuopt_self_hosted/cuopt_sh_client/cuopt_self_host_client.py
@@ -659,7 +659,7 @@ class CuOptServiceSelfHostClient:
             Delete the solution when it is returned. Defaults to True.
         """
         if filepath and cuopt_problem_json_data.startswith("/"):
-            log.warn(
+            log.warning(
                 "Path of the data file on the server was specified, "
                 "but an absolute path was given. "
                 "Best practice is to specify the relative path of a "
@@ -782,7 +782,7 @@ class CuOptServiceSelfHostClient:
                 cuopt_data_model = _mps_parse(cuopt_data_model, solver_config)
 
             elif filepath and cuopt_data_model.startswith("/"):
-                log.warn(
+                log.warning(
                     "Path of the data file on the server was specified, "
                     "but an absolute path was given. "
                     "Best practice is to specify the relative path of a "
@@ -904,7 +904,7 @@ class CuOptServiceSelfHostClient:
                 pass
 
         except requests.exceptions.HTTPError as e:
-            log.warn(f"Deletion of solution {id} failed")
+            log.warning(f"Deletion of solution {id} failed")
             log.debug(str(e))
             err, _ = self._handle_request_exception(response)
             raise ValueError(err)

--- a/python/cuopt_server/cuopt_server/cuopt_service.py
+++ b/python/cuopt_server/cuopt_server/cuopt_service.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         # extract GPU id number from each line (looks like "GPU 0: ..."
         gpu_ids = [s.split(" ")[1][0:-1] for s in gpu_string]
 
-        # if for some reson the parse failed (nvidia-smi output changed)
+        # if for some reason the parse failed (nvidia-smi output changed)
         gpu_ids = [s for s in gpu_ids if s.isnumeric()]
     except Exception:
         gpu_string = None
@@ -391,7 +391,7 @@ if __name__ == "__main__":
         else:
             if gpu_count < 1:
                 gpu_count = 1
-                logging.warn("GPU count cannot be less than 1")
+                logging.warning("GPU count cannot be less than 1")
             if gpu_count < len(gpu_ids):
                 gpu_ids = gpu_ids[0:gpu_count]
 

--- a/python/cuopt_server/cuopt_server/utils/job_queue.py
+++ b/python/cuopt_server/cuopt_server/utils/job_queue.py
@@ -110,7 +110,7 @@ def check_client_version(client_vers):
             return []
         cv = client_vers.split(".")
         if len(cv) < 2:
-            logging.warn("Client version missing or bad format")
+            logging.warning("Client version missing or bad format")
             return [
                 f"Client version missing or not the current format. "
                 f"Please upgrade your cuOpt client to '{major}.{minor}', "
@@ -121,7 +121,7 @@ def check_client_version(client_vers):
             cmajor, cminor = cv[:2]
             matches = (cmajor, cminor) == (major, minor)
         if not matches:
-            logging.warn(f"Client version {cmajor}.{cminor} does not match")
+            logging.warning(f"Client version {cmajor}.{cminor} does not match")
             return [
                 f"Client version is '{cmajor}.{cminor}' but server "
                 f"version is '{major}.{minor}'. Please use a matching client."
@@ -569,7 +569,7 @@ class BaseResult:
         # we know when the list has reached empty again
         # we can send the sentinel value
         if self.is_done():
-            logging.warn("Incumbent added after job marked done!")
+            logging.warning("Incumbent added after job marked done!")
         sol["solution"] = sol["solution"].tolist()
         self.incumbents.append(sol)
 
@@ -636,7 +636,7 @@ class BinaryJobResult(BaseResult):
 
         # might as well make sure these match
         if rtype != self.rtype:
-            logging.warn(
+            logging.warning(
                 "in set_data_size_and_type result mime_type "
                 f"does not match, updating {rtype} {self.rtype}"
             )
@@ -872,7 +872,7 @@ class SolverJob(SolverBaseJob):
                 )
             logging.debug(
                 message(
-                    "feature check succeeeded for tier '%s', "
+                    "feature check succeeded for tier '%s', "
                     % request_filter.get_tier()
                 )
             )
@@ -1445,7 +1445,7 @@ class SolverBinaryJobPath(SolverBinaryJob):
                 "Pickle data format is deprecated. "
                 "Use zlib, msgpack, or plain JSON"
             )
-            logging.warn("pickle data is deprecated")
+            logging.warning("pickle data is deprecated")
             logging.debug("pickle data")
         else:
             raise ValueError(
@@ -1763,8 +1763,8 @@ class SolverBinaryResponse:
             res.set_result(exception_handler(e))
 
 
-# TOOD: ExitJob is meant for the solver, Shutdown and
-# CudaUnhealty are meant for the result thread
+# TODO: ExitJob is meant for the solver, Shutdown and
+# CudaUnhealthy are meant for the result thread
 # Probably should be in different class hierarchies.
 # The latter two probably ought to be SolveResponses
 class ExitJob:


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolves those warnings. It also fixes a few typos along the way.
