### PR TITLE
Fix inversion of constraint bounds in conditional bounds presolve

### DIFF
--- a/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
@@ -70,11 +70,12 @@ class mip_solver_settings_t {
   bool has_initial_solution() const;
 
   struct tolerances_t {
-    f_t absolute_tolerance    = 1.0e-4;
-    f_t relative_tolerance    = 1.0e-6;
-    f_t integrality_tolerance = 1.0e-5;
-    f_t absolute_mip_gap      = 1.0e-10;
-    f_t relative_mip_gap      = 1.0e-4;
+    f_t presolve_absolute_tolerance = 1.0e-6;
+    f_t absolute_tolerance          = 1.0e-4;
+    f_t relative_tolerance          = 1.0e-6;
+    f_t integrality_tolerance       = 1.0e-5;
+    f_t absolute_mip_gap            = 1.0e-10;
+    f_t relative_mip_gap            = 1.0e-4;
   };
 
   /**

--- a/cpp/src/mip/diversity/diversity_manager.cu
+++ b/cpp/src/mip/diversity/diversity_manager.cu
@@ -246,7 +246,7 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit)
   if (termination_criterion_t::NO_UPDATE != term_crit) {
     ls.constraint_prop.bounds_update.set_updated_bounds(*problem_ptr);
     trivial_presolve(*problem_ptr);
-    if (!problem_ptr->empty) { check_bounds_sanity(*problem_ptr); }
+    if (!problem_ptr->empty && !check_bounds_sanity(*problem_ptr)) { return false; }
   }
   if (!problem_ptr->empty) {
     // do the resizing no-matter what, bounds presolve might not change the bounds but initial
@@ -254,7 +254,7 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit)
     ls.constraint_prop.bounds_update.resize(*problem_ptr);
     ls.constraint_prop.conditional_bounds_update.update_constraint_bounds(
       *problem_ptr, ls.constraint_prop.bounds_update);
-    check_bounds_sanity(*problem_ptr);
+    if (!check_bounds_sanity(*problem_ptr)) { return false; }
   }
   stats.presolve_time = presolve_timer.elapsed_time();
   return true;

--- a/cpp/src/mip/presolve/bounds_update_helpers.cuh
+++ b/cpp/src/mip/presolve/bounds_update_helpers.cuh
@@ -143,6 +143,12 @@ __global__ void calc_activity_kernel(typename problem_t<i_t, f_t>::view_t pb,
 // Update bounds
 
 template <typename i_t, typename f_t>
+inline __device__ bool check_infeasibility(f_t min_a, f_t max_a, f_t cnst_lb, f_t cnst_ub, f_t eps)
+{
+  return (min_a > cnst_ub + eps) || (max_a < cnst_lb - eps);
+}
+
+template <typename i_t, typename f_t>
 inline __device__ bool check_infeasibility(
   f_t min_a, f_t max_a, f_t cnst_lb, f_t cnst_ub, f_t abs_tol, f_t rel_tol)
 {

--- a/cpp/src/mip/problem/problem.cu
+++ b/cpp/src/mip/problem/problem.cu
@@ -320,21 +320,31 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
 
   // Presolve reductions might trivially solve the problem to optimality/infeasibility.
   // In this case, it is exptected that the problem fields are empty.
-  cuopt_assert(!offsets.is_empty(), "A_offsets must never be empty.");
+  cuopt_expects(
+    !offsets.is_empty(), error_type_t::ValidationError, "A_offsets must never be empty.");
   if (check_transposed) {
-    cuopt_assert(!reverse_offsets.is_empty(), "A_offsets must never be empty.");
+    cuopt_expects(
+      !reverse_offsets.is_empty(), error_type_t::ValidationError, "A_offsets must never be empty.");
   }
   if (!empty) {
     // Check for empty fields
-    cuopt_assert(!coefficients.is_empty(), "A_values must be set before calling the solver.");
-    cuopt_assert(!variables.is_empty(), "A_indices must be set before calling the solver.");
+    cuopt_expects(!coefficients.is_empty(),
+                  error_type_t::ValidationError,
+                  "A_values must be set before calling the solver.");
+    cuopt_expects(!variables.is_empty(),
+                  error_type_t::ValidationError,
+                  "A_indices must be set before calling the solver.");
     if (check_transposed) {
-      cuopt_assert(!reverse_coefficients.is_empty(),
-                   "A_values must be set before calling the solver.");
-      cuopt_assert(!reverse_constraints.is_empty(),
-                   "A_indices must be set before calling the solver.");
+      cuopt_expects(!reverse_coefficients.is_empty(),
+                    error_type_t::ValidationError,
+                    "A_values must be set before calling the solver.");
+      cuopt_expects(!reverse_constraints.is_empty(),
+                    error_type_t::ValidationError,
+                    "A_indices must be set before calling the solver.");
     }
-    cuopt_assert(!objective_coefficients.is_empty(), "c must be set before calling the solver.");
+    cuopt_expects(!objective_coefficients.is_empty(),
+                  error_type_t::ValidationError,
+                  "c must be set before calling the solver.");
   }
 
   // Check CSR validity
@@ -348,47 +358,58 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
                              handle_ptr,
                              n_constraints,
                              n_variables);
-    cuopt_assert(check_transpose_validity(this->coefficients,
-                                          this->offsets,
-                                          this->variables,
-                                          this->reverse_coefficients,
-                                          this->reverse_offsets,
-                                          this->reverse_constraints,
-                                          handle_ptr),
-                 "Tranpose invalide");
+    cuopt_expects(check_transpose_validity(this->coefficients,
+                                           this->offsets,
+                                           this->variables,
+                                           this->reverse_coefficients,
+                                           this->reverse_offsets,
+                                           this->reverse_constraints,
+                                           handle_ptr),
+                  error_type_t::ValidationError,
+                  "Tranpose invalide");
   }
 
   // Check variable bounds are set and with the correct size
   if (!empty) {
-    cuopt_assert(!variable_lower_bounds.is_empty() && !variable_upper_bounds.is_empty(),
-                 "Variable lower bounds and variable upper bounds must be set.");
+    cuopt_expects(!variable_lower_bounds.is_empty() && !variable_upper_bounds.is_empty(),
+                  error_type_t::ValidationError,
+                  "Variable lower bounds and variable upper bounds must be set.");
   }
-  cuopt_assert(variable_lower_bounds.size() == objective_coefficients.size(),
-               "Sizes for vectors related to the variables are not the same.");
-  cuopt_assert(variable_upper_bounds.size() == objective_coefficients.size(),
-               "Sizes for vectors related to the variables are not the same");
-  cuopt_assert(variable_upper_bounds.size() == (std::size_t)n_variables,
-               "Sizes for vectors related to the variables are not the same.");
-  cuopt_assert(variable_types.size() == (std::size_t)n_variables,
-               "Sizes for vectors related to the variables are not the same.");
+  cuopt_expects(variable_lower_bounds.size() == objective_coefficients.size(),
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the variables are not the same.");
+  cuopt_expects(variable_upper_bounds.size() == objective_coefficients.size(),
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the variables are not the same");
+  cuopt_expects(variable_upper_bounds.size() == (std::size_t)n_variables,
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the variables are not the same.");
+  cuopt_expects(variable_types.size() == (std::size_t)n_variables,
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the variables are not the same.");
   // Check constraints bounds sizes
   if (!empty) {
-    cuopt_assert(!constraint_lower_bounds.is_empty() && !constraint_upper_bounds.is_empty(),
-                 "Constraints lower bounds and constraints upper bounds must be set.");
+    cuopt_expects(!constraint_lower_bounds.is_empty() && !constraint_upper_bounds.is_empty(),
+                  error_type_t::ValidationError,
+                  "Constraints lower bounds and constraints upper bounds must be set.");
   }
-  cuopt_assert(constraint_lower_bounds.size() == constraint_upper_bounds.size(),
-               "Sizes for vectors related to the constraints are not the same.");
-  cuopt_assert(constraint_lower_bounds.size() == (size_t)n_constraints,
-               "Sizes for vectors related to the constraints are not the same.");
-  cuopt_assert((offsets.size() - 1) == constraint_lower_bounds.size(),
-               "Sizes for vectors related to the constraints are not the same.");
+  cuopt_expects(constraint_lower_bounds.size() == constraint_upper_bounds.size(),
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the constraints are not the same.");
+  cuopt_expects(constraint_lower_bounds.size() == (size_t)n_constraints,
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the constraints are not the same.");
+  cuopt_expects((offsets.size() - 1) == constraint_lower_bounds.size(),
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the constraints are not the same.");
 
   // Check combined bounds
-  cuopt_assert(combined_bounds.size() == (size_t)n_constraints,
-               "Sizes for vectors related to the constraints are not the same.");
+  cuopt_expects(combined_bounds.size() == (size_t)n_constraints,
+                error_type_t::ValidationError,
+                "Sizes for vectors related to the constraints are not the same.");
 
   // Check the validity of bounds
-  cuopt_assert(
+  cuopt_expects(
     thrust::all_of(handle_ptr->get_thrust_policy(),
                    thrust::make_counting_iterator<i_t>(0),
                    thrust::make_counting_iterator<i_t>(n_variables),
@@ -396,8 +417,9 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
                     variable_upper_bounds = variable_upper_bounds.data()] __device__(i_t idx) {
                      return variable_lower_bounds[idx] <= variable_upper_bounds[idx];
                    }),
+    error_type_t::ValidationError,
     "Variable bounds are invalid");
-  cuopt_assert(
+  cuopt_expects(
     thrust::all_of(handle_ptr->get_thrust_policy(),
                    thrust::make_counting_iterator<i_t>(0),
                    thrust::make_counting_iterator<i_t>(n_constraints),
@@ -405,45 +427,57 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
                     constraint_upper_bounds = constraint_upper_bounds.data()] __device__(i_t idx) {
                      return constraint_lower_bounds[idx] <= constraint_upper_bounds[idx];
                    }),
+    error_type_t::ValidationError,
     "Constraints bounds are invalid");
 
   if (check_mip_related_data) {
-    cuopt_assert(n_integer_vars == integer_indices.size(), "incorrect integer indices structure");
-    cuopt_assert(is_binary_variable.size() == n_variables, "incorrect binary variable table size");
+    cuopt_expects(static_cast<size_t>(n_integer_vars) == integer_indices.size(),
+                  error_type_t::ValidationError,
+                  "incorrect integer indices structure");
+    cuopt_expects(is_binary_variable.size() == static_cast<size_t>(n_variables),
+                  error_type_t::ValidationError,
+                  "incorrect binary variable table size");
 
-    cuopt_assert(thrust::is_sorted(
-                   handle_ptr->get_thrust_policy(), binary_indices.begin(), binary_indices.end()),
-                 "binary indices are not sorted");
-    cuopt_assert(
+    cuopt_expects(thrust::is_sorted(
+                    handle_ptr->get_thrust_policy(), binary_indices.begin(), binary_indices.end()),
+                  error_type_t::ValidationError,
+                  "binary indices are not sorted");
+    cuopt_expects(
       thrust::is_sorted(
         handle_ptr->get_thrust_policy(), nonbinary_indices.begin(), nonbinary_indices.end()),
+      error_type_t::ValidationError,
       "nonbinary indices are not sorted");
-    cuopt_assert(thrust::is_sorted(
-                   handle_ptr->get_thrust_policy(), integer_indices.begin(), integer_indices.end()),
-                 "integer indices are not sorted");
+    cuopt_expects(
+      thrust::is_sorted(
+        handle_ptr->get_thrust_policy(), integer_indices.begin(), integer_indices.end()),
+      error_type_t::ValidationError,
+      "integer indices are not sorted");
     // check precomputed helpers
-    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                integer_indices.cbegin(),
-                                integer_indices.cend(),
-                                [types = variable_types.data()] __device__(i_t idx) {
-                                  return types[idx] == var_t::INTEGER;
-                                }),
-                 "The integer indices table contains references to non-integer variables.");
-    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                binary_indices.cbegin(),
-                                binary_indices.cend(),
-                                [bin_table = is_binary_variable.data()] __device__(i_t idx) {
-                                  return bin_table[idx];
-                                }),
-                 "The binary indices table contains references to non-binary variables.");
-    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                nonbinary_indices.cbegin(),
-                                nonbinary_indices.cend(),
-                                [bin_table = is_binary_variable.data()] __device__(i_t idx) {
-                                  return !bin_table[idx];
-                                }),
-                 "The non-binary indices table contains references to binary variables.");
-    cuopt_assert(
+    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                 integer_indices.cbegin(),
+                                 integer_indices.cend(),
+                                 [types = variable_types.data()] __device__(i_t idx) {
+                                   return types[idx] == var_t::INTEGER;
+                                 }),
+                  error_type_t::ValidationError,
+                  "The integer indices table contains references to non-integer variables.");
+    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                 binary_indices.cbegin(),
+                                 binary_indices.cend(),
+                                 [bin_table = is_binary_variable.data()] __device__(i_t idx) {
+                                   return bin_table[idx];
+                                 }),
+                  error_type_t::ValidationError,
+                  "The binary indices table contains references to non-binary variables.");
+    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                 nonbinary_indices.cbegin(),
+                                 nonbinary_indices.cend(),
+                                 [bin_table = is_binary_variable.data()] __device__(i_t idx) {
+                                   return !bin_table[idx];
+                                 }),
+                  error_type_t::ValidationError,
+                  "The non-binary indices table contains references to binary variables.");
+    cuopt_expects(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -475,8 +509,9 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
+      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_assert(
+    cuopt_expects(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -508,8 +543,9 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
+      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_assert(
+    cuopt_expects(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -541,8 +577,9 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
+      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_assert(
+    cuopt_expects(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_zip_iterator(thrust::make_counting_iterator<i_t>(0),
@@ -558,13 +595,15 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           return pred == (types[idx] != var_t::CONTINUOUS && v.integer_equal(lb[idx], 0.) &&
                           v.integer_equal(ub[idx], 1.));
         }),
+      error_type_t::ValidationError,
       "The binary variable table is incorrect.");
     if (!empty) {
-      cuopt_assert(is_binary_pb == (n_variables == thrust::count(handle_ptr->get_thrust_policy(),
-                                                                 is_binary_variable.begin(),
-                                                                 is_binary_variable.end(),
-                                                                 1)),
-                   "is_binary_pb is incorrectly set");
+      cuopt_expects(is_binary_pb == (n_variables == thrust::count(handle_ptr->get_thrust_policy(),
+                                                                  is_binary_variable.begin(),
+                                                                  is_binary_variable.end(),
+                                                                  1)),
+                    error_type_t::ValidationError,
+                    "is_binary_pb is incorrectly set");
     }
   }
 }

--- a/cpp/src/mip/problem/problem.cu
+++ b/cpp/src/mip/problem/problem.cu
@@ -320,31 +320,21 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
 
   // Presolve reductions might trivially solve the problem to optimality/infeasibility.
   // In this case, it is exptected that the problem fields are empty.
-  cuopt_expects(
-    !offsets.is_empty(), error_type_t::ValidationError, "A_offsets must never be empty.");
+  cuopt_assert(!offsets.is_empty(), "A_offsets must never be empty.");
   if (check_transposed) {
-    cuopt_expects(
-      !reverse_offsets.is_empty(), error_type_t::ValidationError, "A_offsets must never be empty.");
+    cuopt_assert(!reverse_offsets.is_empty(), "A_offsets must never be empty.");
   }
   if (!empty) {
     // Check for empty fields
-    cuopt_expects(!coefficients.is_empty(),
-                  error_type_t::ValidationError,
-                  "A_values must be set before calling the solver.");
-    cuopt_expects(!variables.is_empty(),
-                  error_type_t::ValidationError,
-                  "A_indices must be set before calling the solver.");
+    cuopt_assert(!coefficients.is_empty(), "A_values must be set before calling the solver.");
+    cuopt_assert(!variables.is_empty(), "A_indices must be set before calling the solver.");
     if (check_transposed) {
-      cuopt_expects(!reverse_coefficients.is_empty(),
-                    error_type_t::ValidationError,
-                    "A_values must be set before calling the solver.");
-      cuopt_expects(!reverse_constraints.is_empty(),
-                    error_type_t::ValidationError,
-                    "A_indices must be set before calling the solver.");
+      cuopt_assert(!reverse_coefficients.is_empty(),
+                   "A_values must be set before calling the solver.");
+      cuopt_assert(!reverse_constraints.is_empty(),
+                   "A_indices must be set before calling the solver.");
     }
-    cuopt_expects(!objective_coefficients.is_empty(),
-                  error_type_t::ValidationError,
-                  "c must be set before calling the solver.");
+    cuopt_assert(!objective_coefficients.is_empty(), "c must be set before calling the solver.");
   }
 
   // Check CSR validity
@@ -358,55 +348,44 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
                              handle_ptr,
                              n_constraints,
                              n_variables);
-    cuopt_expects(check_transpose_validity(this->coefficients,
-                                           this->offsets,
-                                           this->variables,
-                                           this->reverse_coefficients,
-                                           this->reverse_offsets,
-                                           this->reverse_constraints,
-                                           handle_ptr),
-                  error_type_t::ValidationError,
-                  "Tranpose invalide");
+    cuopt_assert(check_transpose_validity(this->coefficients,
+                                          this->offsets,
+                                          this->variables,
+                                          this->reverse_coefficients,
+                                          this->reverse_offsets,
+                                          this->reverse_constraints,
+                                          handle_ptr),
+                 "Tranpose invalide");
   }
 
   // Check variable bounds are set and with the correct size
   if (!empty) {
-    cuopt_expects(!variable_lower_bounds.is_empty() && !variable_upper_bounds.is_empty(),
-                  error_type_t::ValidationError,
-                  "Variable lower bounds and variable upper bounds must be set.");
+    cuopt_assert(!variable_lower_bounds.is_empty() && !variable_upper_bounds.is_empty(),
+                 "Variable lower bounds and variable upper bounds must be set.");
   }
-  cuopt_expects(variable_lower_bounds.size() == objective_coefficients.size(),
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the variables are not the same.");
-  cuopt_expects(variable_upper_bounds.size() == objective_coefficients.size(),
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the variables are not the same");
-  cuopt_expects(variable_upper_bounds.size() == (std::size_t)n_variables,
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the variables are not the same.");
-  cuopt_expects(variable_types.size() == (std::size_t)n_variables,
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the variables are not the same.");
+  cuopt_assert(variable_lower_bounds.size() == objective_coefficients.size(),
+               "Sizes for vectors related to the variables are not the same.");
+  cuopt_assert(variable_upper_bounds.size() == objective_coefficients.size(),
+               "Sizes for vectors related to the variables are not the same");
+  cuopt_assert(variable_upper_bounds.size() == (std::size_t)n_variables,
+               "Sizes for vectors related to the variables are not the same.");
+  cuopt_assert(variable_types.size() == (std::size_t)n_variables,
+               "Sizes for vectors related to the variables are not the same.");
   // Check constraints bounds sizes
   if (!empty) {
-    cuopt_expects(!constraint_lower_bounds.is_empty() && !constraint_upper_bounds.is_empty(),
-                  error_type_t::ValidationError,
-                  "Constraints lower bounds and constraints upper bounds must be set.");
+    cuopt_assert(!constraint_lower_bounds.is_empty() && !constraint_upper_bounds.is_empty(),
+                 "Constraints lower bounds and constraints upper bounds must be set.");
   }
-  cuopt_expects(constraint_lower_bounds.size() == constraint_upper_bounds.size(),
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the constraints are not the same.");
-  cuopt_expects(constraint_lower_bounds.size() == (size_t)n_constraints,
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the constraints are not the same.");
-  cuopt_expects((offsets.size() - 1) == constraint_lower_bounds.size(),
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the constraints are not the same.");
+  cuopt_assert(constraint_lower_bounds.size() == constraint_upper_bounds.size(),
+               "Sizes for vectors related to the constraints are not the same.");
+  cuopt_assert(constraint_lower_bounds.size() == (size_t)n_constraints,
+               "Sizes for vectors related to the constraints are not the same.");
+  cuopt_assert((offsets.size() - 1) == constraint_lower_bounds.size(),
+               "Sizes for vectors related to the constraints are not the same.");
 
   // Check combined bounds
-  cuopt_expects(combined_bounds.size() == (size_t)n_constraints,
-                error_type_t::ValidationError,
-                "Sizes for vectors related to the constraints are not the same.");
+  cuopt_assert(combined_bounds.size() == (size_t)n_constraints,
+               "Sizes for vectors related to the constraints are not the same.");
 
   // Check the validity of bounds
   cuopt_expects(
@@ -431,53 +410,42 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
     "Constraints bounds are invalid");
 
   if (check_mip_related_data) {
-    cuopt_expects(static_cast<size_t>(n_integer_vars) == integer_indices.size(),
-                  error_type_t::ValidationError,
-                  "incorrect integer indices structure");
-    cuopt_expects(is_binary_variable.size() == static_cast<size_t>(n_variables),
-                  error_type_t::ValidationError,
-                  "incorrect binary variable table size");
+    cuopt_assert(n_integer_vars == integer_indices.size(), "incorrect integer indices structure");
+    cuopt_assert(is_binary_variable.size() == n_variables, "incorrect binary variable table size");
 
-    cuopt_expects(thrust::is_sorted(
-                    handle_ptr->get_thrust_policy(), binary_indices.begin(), binary_indices.end()),
-                  error_type_t::ValidationError,
-                  "binary indices are not sorted");
-    cuopt_expects(
+    cuopt_assert(thrust::is_sorted(
+                   handle_ptr->get_thrust_policy(), binary_indices.begin(), binary_indices.end()),
+                 "binary indices are not sorted");
+    cuopt_assert(
       thrust::is_sorted(
         handle_ptr->get_thrust_policy(), nonbinary_indices.begin(), nonbinary_indices.end()),
-      error_type_t::ValidationError,
       "nonbinary indices are not sorted");
-    cuopt_expects(
-      thrust::is_sorted(
-        handle_ptr->get_thrust_policy(), integer_indices.begin(), integer_indices.end()),
-      error_type_t::ValidationError,
-      "integer indices are not sorted");
+    cuopt_assert(thrust::is_sorted(
+                   handle_ptr->get_thrust_policy(), integer_indices.begin(), integer_indices.end()),
+                 "integer indices are not sorted");
     // check precomputed helpers
-    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                 integer_indices.cbegin(),
-                                 integer_indices.cend(),
-                                 [types = variable_types.data()] __device__(i_t idx) {
-                                   return types[idx] == var_t::INTEGER;
-                                 }),
-                  error_type_t::ValidationError,
-                  "The integer indices table contains references to non-integer variables.");
-    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                 binary_indices.cbegin(),
-                                 binary_indices.cend(),
-                                 [bin_table = is_binary_variable.data()] __device__(i_t idx) {
-                                   return bin_table[idx];
-                                 }),
-                  error_type_t::ValidationError,
-                  "The binary indices table contains references to non-binary variables.");
-    cuopt_expects(thrust::all_of(handle_ptr->get_thrust_policy(),
-                                 nonbinary_indices.cbegin(),
-                                 nonbinary_indices.cend(),
-                                 [bin_table = is_binary_variable.data()] __device__(i_t idx) {
-                                   return !bin_table[idx];
-                                 }),
-                  error_type_t::ValidationError,
-                  "The non-binary indices table contains references to binary variables.");
-    cuopt_expects(
+    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                integer_indices.cbegin(),
+                                integer_indices.cend(),
+                                [types = variable_types.data()] __device__(i_t idx) {
+                                  return types[idx] == var_t::INTEGER;
+                                }),
+                 "The integer indices table contains references to non-integer variables.");
+    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                binary_indices.cbegin(),
+                                binary_indices.cend(),
+                                [bin_table = is_binary_variable.data()] __device__(i_t idx) {
+                                  return bin_table[idx];
+                                }),
+                 "The binary indices table contains references to non-binary variables.");
+    cuopt_assert(thrust::all_of(handle_ptr->get_thrust_policy(),
+                                nonbinary_indices.cbegin(),
+                                nonbinary_indices.cend(),
+                                [bin_table = is_binary_variable.data()] __device__(i_t idx) {
+                                  return !bin_table[idx];
+                                }),
+                 "The non-binary indices table contains references to binary variables.");
+    cuopt_assert(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -509,9 +477,8 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
-      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_expects(
+    cuopt_assert(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -543,9 +510,8 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
-      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_expects(
+    cuopt_assert(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_counting_iterator<i_t>(0),
@@ -577,9 +543,8 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           }
           return true;
         }),
-      error_type_t::ValidationError,
       "Some variables aren't referenced in the appropriate indice tables");
-    cuopt_expects(
+    cuopt_assert(
       thrust::all_of(
         handle_ptr->get_thrust_policy(),
         thrust::make_zip_iterator(thrust::make_counting_iterator<i_t>(0),
@@ -595,15 +560,13 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
           return pred == (types[idx] != var_t::CONTINUOUS && v.integer_equal(lb[idx], 0.) &&
                           v.integer_equal(ub[idx], 1.));
         }),
-      error_type_t::ValidationError,
       "The binary variable table is incorrect.");
     if (!empty) {
-      cuopt_expects(is_binary_pb == (n_variables == thrust::count(handle_ptr->get_thrust_policy(),
-                                                                  is_binary_variable.begin(),
-                                                                  is_binary_variable.end(),
-                                                                  1)),
-                    error_type_t::ValidationError,
-                    "is_binary_pb is incorrectly set");
+      cuopt_assert(is_binary_pb == (n_variables == thrust::count(handle_ptr->get_thrust_policy(),
+                                                                 is_binary_variable.begin(),
+                                                                 is_binary_variable.end(),
+                                                                 1)),
+                   "is_binary_pb is incorrectly set");
     }
   }
 }

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -163,7 +163,7 @@ TEST(ErrorTest, TestError)
   auto result = cuopt::linear_programming::solve_mip(&handle, problem, settings);
 
   EXPECT_EQ(result.get_termination_status(),
-            cuopt::linear_programming::mip_termination_status_t::Infeasible);
+            cuopt::linear_programming::mip_termination_status_t::NoTermination);
 }
 
 class MILPTestParams

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -163,7 +163,7 @@ TEST(ErrorTest, TestError)
   auto result = cuopt::linear_programming::solve_mip(&handle, problem, settings);
 
   EXPECT_EQ(result.get_termination_status(),
-            cuopt::linear_programming::mip_termination_status_t::NoTermination);
+            cuopt::linear_programming::mip_termination_status_t::Infeasible);
 }
 
 class MILPTestParams


### PR DESCRIPTION
Updating the constraint bounds based on minimal and maximal activity can sometimes cause the update constraint lower bounds to be greater than constraint upper bounds even if the constraint is feasible within tolerance.

This PR fixes the constraint bounds to the same value if this happens.