### PR TITLE
Fix test commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,8 +164,8 @@ To run the C++ tests, run
 
 ```bash
 cd $CUOPT_HOME/datasets && get_test_data.sh
-cd $CUOPT_HOME/datasets/linear_programming && download_pdlp_test_dataset.sh
-cd $CUOPT_HOME/datasets/mip && download_miplib_test_dataset.sh
+cd $CUOPT_HOME && datasets/linear_programming/download_pdlp_test_dataset.sh
+datasets/mip/download_miplib_test_dataset.sh
 export RAPIDS_DATASET_ROOT_DIR=$CUOPT_HOME/datasets/
 ctest --test-dir ${CUOPT_HOME}/cpp/build  # libcuopt
 ```
@@ -176,8 +176,8 @@ To run python tests, run
 ```bash
 
 cd $CUOPT_HOME/datasets && get_test_data.sh
-cd $CUOPT_HOME/datasets/linear_programming && download_pdlp_test_dataset.sh
-cd $CUOPT_HOME/datasets/mip && download_miplib_test_dataset.sh
+cd $CUOPT_HOME && datasets/linear_programming/download_pdlp_test_dataset.sh
+datasets/mip/download_miplib_test_dataset.sh
 export RAPIDS_DATASET_ROOT_DIR=$CUOPT_HOME/datasets/
 cd $CUOPT_HOME/python
 pytest -v ${CUOPT_HOME}/python/cuopt/cuopt/tests


### PR DESCRIPTION
Minor doc fix to ensure commands to fetch test datasets are instructed to be run the right working directory.
