### PR TITLE
Fix to decouple thin client requirements from cuopt main module

### DIFF
--- a/python/cuopt/cuopt/linear_programming/solution/solution.py
+++ b/python/cuopt/cuopt/linear_programming/solution/solution.py
@@ -13,11 +13,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cuopt.linear_programming.solver.solver_wrapper import (
-    LPTerminationStatus,
-    MILPTerminationStatus,
-    ProblemCategory,
-)
+from enum import IntEnum
+
+
+# TODO: Remove this once we have a way to not include main cuOpt
+# libs in in thin client
+class ProblemCategory(IntEnum):
+    """
+    Problem category enum
+    """
+
+    LP = 0
+    MIP = 1
+    IP = 2
+
+
+# TODO: Remove this once we have a way to not include main cuOpt
+# libs in in thin client
+class LPTerminationStatus(IntEnum):
+    """
+    LP termination status enum
+    """
+
+    NoTermination = 0
+    NumericalError = 6
+    Optimal = 1
+    PrimalInfeasible = 2
+    DualInfeasible = 3
+    IterationLimit = 4
+    TimeLimit = 5
+    PrimalFeasible = 7
+
+
+# TODO: Remove this once we have a way to not include main cuOpt
+# libs in in thin client
+class MILPTerminationStatus(IntEnum):
+    """
+    MILP termination status enum
+    """
+
+    NoTermination = 0
+    Optimal = 1
+    FeasibleFound = 8
+    Infeasible = 2
+    Unbounded = 3
+    TimeLimit = 5
 
 
 class PDLPWarmStartData:


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Termination status is being pulled from cuOpt which makes cuopt main library a dependency for cuopt thin client. Just for temporary, a copy of these termination status is being added to solution to detach thin client.

We will circle back and fix this in 25.08. I will create an issue to follow-up for this.