### PR TITLE
Fix bug in optimization_problem_solution_t::copy_from

### DIFF
--- a/cpp/src/linear_programming/solver_solution.cu
+++ b/cpp/src/linear_programming/solver_solution.cu
@@ -124,6 +124,12 @@ template <typename i_t, typename f_t>
 void optimization_problem_solution_t<i_t, f_t>::copy_from(
   const raft::handle_t* handle_ptr, const optimization_problem_solution_t<i_t, f_t>& other)
 {
+  // Resize to make sure they are of same size
+  primal_solution_.resize(other.primal_solution_.size(), handle_ptr->get_stream());
+  dual_solution_.resize(other.dual_solution_.size(), handle_ptr->get_stream());
+  reduced_cost_.resize(other.reduced_cost_.size(), handle_ptr->get_stream());
+
+  // Copy the data
   raft::copy(primal_solution_.data(),
              other.primal_solution_.data(),
              primal_solution_.size(),


### PR DESCRIPTION

This PR closes #108 

When PDLP fails, the vectors are not resized appropriately.  This is causing wrong values sent to julia interface.  This could result in crashes for large cases. 