### PR TITLE
Fix compile error when building with clang.

### DIFF
--- a/cpp/src/mip/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip/feasibility_jump/feasibility_jump_kernels.cu
@@ -1153,7 +1153,9 @@ __global__ void select_variable_kernel(typename fj_t<i_t, f_t>::climber_data_t::
   raft::random::PCGenerator rng(
     fj.settings->seed, *fj.iterations * fj.settings->parameters.max_sampled_moves, 0);
 
-  __shared__ typename fj_t<i_t, f_t>::move_score_t shmem[2 * raft::WarpSize];
+  using move_score_t = typename fj_t<i_t, f_t>::move_score_t;
+  __shared__ alignas(move_score_t) char shmem_storage[2 * raft::WarpSize * sizeof(move_score_t)];
+  auto* const shmem = (move_score_t*)shmem_storage;
 
   auto th_best_score  = fj_t<i_t, f_t>::move_score_t::invalid();
   i_t th_selected_var = std::numeric_limits<i_t>::max();
@@ -1300,7 +1302,9 @@ DI thrust::tuple<i_t, f_t, typename fj_t<i_t, f_t>::move_score_t> gridwide_reduc
   cg::this_grid().sync();
 
   if (blockIdx.x == 0) {
-    __shared__ typename fj_t<i_t, f_t>::move_score_t shmem[2 * raft::WarpSize];
+    using move_score_t = typename fj_t<i_t, f_t>::move_score_t;
+    __shared__ alignas(move_score_t) char shmem_storage[2 * raft::WarpSize * sizeof(move_score_t)];
+    auto* const shmem = (move_score_t*)shmem_storage;
 
     auto th_best_score = fj_t<i_t, f_t>::move_score_t::invalid();
     i_t th_best_block  = 0;


### PR DESCRIPTION
`move_score_t` is not trivially default-constructible, clang is unhappy with a shared array of `move_score_t`:

`error: initialization is not supported for __shared__ variables`

Use an aligned char array instead.
