### PR TITLE
Fix incorrect reported solving time

### DIFF
--- a/cpp/src/utilities/scope_guard.hpp
+++ b/cpp/src/utilities/scope_guard.hpp
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <utility>
+
+namespace cuopt {
+
+template <typename Func>
+class scope_guard {
+ public:
+  explicit scope_guard(Func cleanup) : cleanup_(std::move(cleanup)) {}
+
+  ~scope_guard() { cleanup_(); }
+
+  scope_guard(const scope_guard&)            = delete;
+  scope_guard& operator=(const scope_guard&) = delete;
+  scope_guard(scope_guard&&)                 = delete;
+  scope_guard& operator=(scope_guard&&)      = delete;
+
+ private:
+  Func cleanup_;
+};
+
+}  // namespace cuopt

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -79,6 +79,19 @@ TEST(c_api, iteration_limit)
   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
 }
 
+TEST(c_api, solve_time_bb_preemption)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string filename                    = rapidsDatasetRootDir + "/mip/" + "bb_optimality.mps";
+  int termination_status;
+  double solve_time = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(solve_mps_file(filename.c_str(), 5, CUOPT_INFINITY, &termination_status, &solve_time),
+            CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_GT(solve_time, 0);  // solve time should not be equal to 0, even on very simple instances
+                             // solved by B&B before the diversity solver has time to run
+}
+
 TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
 
 TEST(c_api, burglar) { EXPECT_EQ(burglar_problem(), CUOPT_SUCCESS); }


### PR DESCRIPTION
This PR fixes a bug causing solving time to be incorrectly reported on problems that are solved by B&B pre-emption before the main GPU solver loop runs.