### PR TITLE
Fix a bug in extract_best_per_route kernel

### DIFF
--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -116,7 +116,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
 
     if constexpr (squeeze_mode) {
-      i_t move_blocks = solution_ptr->get_num_requests();
+      size_t move_blocks = solution_ptr->get_num_requests();
       extract_best_per_route<i_t, f_t, REQUEST>
         <<<move_blocks, TPB, 0, stream>>>(solution_ptr->view(),
                                           cuopt::make_span(best_squeeze_per_cand),

--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -116,11 +116,11 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
 
     if constexpr (squeeze_mode) {
-      size_t move_blocks = solution_ptr->get_num_requests();
+      i_t move_blocks = solution_ptr->get_num_requests();
       extract_best_per_route<i_t, f_t, REQUEST>
-        <<<move_blocks, TPB, sh_size, stream>>>(solution_ptr->view(),
-                                                cuopt::make_span(best_squeeze_per_cand),
-                                                cuopt::make_span(best_squeeze_per_route));
+        <<<move_blocks, TPB, 0, stream>>>(solution_ptr->view(),
+                                          cuopt::make_span(best_squeeze_per_cand),
+                                          cuopt::make_span(best_squeeze_per_route));
       RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->
The mentioned kernel does not require any dynamic shared memory, however, we are passing `sh_size` that is relevant for the previous kernel in the code.  In most cases it is fine. However, if the sh_size is more than the shared memory available, the kernel fails to launch with `cudaInvalidValue` error.   The previous kernel has no issues because the dynamic shared memory is tuned for that kernel using `cudaFuncSetAttribute` call.  

This PR passes zero as the dynamic shared size to resolve the issue. 

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

This is a bug reported by a customer. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing 
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation 
   - [x] NA
