### PR TITLE
Concurrent LP in get_relaxed_lp (used in FP) and lay foundations for future PDLP warm start

### DIFF
--- a/cpp/include/cuopt/linear_programming/pdlp/pdlp_warm_start_data.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/pdlp_warm_start_data.hpp
@@ -49,6 +49,7 @@ struct pdlp_warm_start_data_t {
   f_t last_restart_kkt_score_{-1};
   f_t sum_solution_weight_{-1};
   i_t iterations_since_last_restart_{-1};
+  bool solved_by_pdlp_{false};
 
   // Constructor when building it in the solution object
   pdlp_warm_start_data_t(rmm::device_uvector<f_t>& current_primal_solution,
@@ -67,7 +68,8 @@ struct pdlp_warm_start_data_t {
                          f_t last_candidate_kkt_score,
                          f_t last_restart_kkt_score,
                          f_t sum_solution_weight,
-                         i_t iterations_since_last_restart);
+                         i_t iterations_since_last_restart,
+                         bool solved_by_pdlp);
 
   // Empty constructor
   pdlp_warm_start_data_t();
@@ -104,6 +106,7 @@ struct pdlp_warm_start_data_view_t {
   f_t last_restart_kkt_score_{-1};
   f_t sum_solution_weight_{-1};
   i_t iterations_since_last_restart_{-1};
+  bool solved_by_pdlp_{false};
 };
 
 }  // namespace cuopt::linear_programming

--- a/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
@@ -110,9 +110,6 @@ class pdlp_solver_settings_t {
                                    i_t size,
                                    rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
-  // TODO comment
-  void set_initial_primal_solution(const rmm::device_uvector<f_t>& initial_primal_solution);
-
   /**
    * @brief Set an initial dual solution.
    *
@@ -126,9 +123,6 @@ class pdlp_solver_settings_t {
   void set_initial_dual_solution(const f_t* initial_dual_solution,
                                  i_t size,
                                  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
-
-  // TODO comment
-  void set_initial_dual_solution(const rmm::device_uvector<f_t>& initial_dual_solution);
 
   /**
    * @brief Set the pdlp warm start data. This allows to restart PDLP with a previous solution
@@ -168,12 +162,23 @@ class pdlp_solver_settings_t {
                                 f_t sum_solution_weight_,
                                 i_t iterations_since_last_restart_,
                                 bool solved_by_pdlp_);
+
+  /**
+   * @brief Check if the pdlp warm start data is set
+   *
+   * @return true if the pdlp warm start data is set, false otherwise
+   */
+  bool has_pdlp_warm_start_data() const;
+
   /**
    * @brief Get the pdlp warm start data
    *
+   * @note PDLP warm start data is an optional field, it is not set by default.
+   * You need to make sure that the warm start data is set before calling this function.
+   * You can check if the warm start data is set by calling has_pdlp_warm_start_data().
+   *
    * @return pdlp warm start data
    */
-  bool has_pdlp_warm_start_data() const;
   const pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data() const noexcept;
   pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data();
   const pdlp_warm_start_data_view_t<i_t, f_t>& get_pdlp_warm_start_data_view() const noexcept;

--- a/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
@@ -173,8 +173,9 @@ class pdlp_solver_settings_t {
    *
    * @return pdlp warm start data
    */
-  const std::optional<pdlp_warm_start_data_t<i_t, f_t>>& get_pdlp_warm_start_data() const noexcept;
-  std::optional<pdlp_warm_start_data_t<i_t, f_t>>& get_pdlp_warm_start_data();
+  bool has_pdlp_warm_start_data() const;
+  const pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data() const noexcept;
+  pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data();
   const pdlp_warm_start_data_view_t<i_t, f_t>& get_pdlp_warm_start_data_view() const noexcept;
 
   const rmm::device_uvector<f_t>& get_initial_primal_solution() const;

--- a/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/solver_settings.hpp
@@ -110,6 +110,9 @@ class pdlp_solver_settings_t {
                                    i_t size,
                                    rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
+  // TODO comment
+  void set_initial_primal_solution(const rmm::device_uvector<f_t>& initial_primal_solution);
+
   /**
    * @brief Set an initial dual solution.
    *
@@ -123,6 +126,9 @@ class pdlp_solver_settings_t {
   void set_initial_dual_solution(const f_t* initial_dual_solution,
                                  i_t size,
                                  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+  // TODO comment
+  void set_initial_dual_solution(const rmm::device_uvector<f_t>& initial_dual_solution);
 
   /**
    * @brief Set the pdlp warm start data. This allows to restart PDLP with a previous solution
@@ -160,14 +166,15 @@ class pdlp_solver_settings_t {
                                 f_t last_candidate_kkt_score_,
                                 f_t last_restart_kkt_score_,
                                 f_t sum_solution_weight_,
-                                i_t iterations_since_last_restart_);
+                                i_t iterations_since_last_restart_,
+                                bool solved_by_pdlp_);
   /**
    * @brief Get the pdlp warm start data
    *
    * @return pdlp warm start data
    */
-  const pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data() const noexcept;
-  pdlp_warm_start_data_t<i_t, f_t>& get_pdlp_warm_start_data();
+  const std::optional<pdlp_warm_start_data_t<i_t, f_t>>& get_pdlp_warm_start_data() const noexcept;
+  std::optional<pdlp_warm_start_data_t<i_t, f_t>>& get_pdlp_warm_start_data();
   const pdlp_warm_start_data_view_t<i_t, f_t>& get_pdlp_warm_start_data_view() const noexcept;
 
   const rmm::device_uvector<f_t>& get_initial_primal_solution() const;
@@ -216,7 +223,7 @@ class pdlp_solver_settings_t {
   /** Initial dual solution */
   std::shared_ptr<rmm::device_uvector<f_t>> initial_dual_solution_;
   // For the C++ interface
-  pdlp_warm_start_data_t<i_t, f_t> pdlp_warm_start_data_;
+  std::optional<pdlp_warm_start_data_t<i_t, f_t>> pdlp_warm_start_data_;
   // For the Cython interface
   pdlp_warm_start_data_view_t<i_t, f_t> pdlp_warm_start_data_view_;
 

--- a/cpp/include/cuopt/linear_programming/solve.hpp
+++ b/cpp/include/cuopt/linear_programming/solve.hpp
@@ -29,6 +29,11 @@
 
 namespace cuopt::linear_programming {
 
+namespace detail {
+template <typename i_t, typename f_t>
+class problem_t;
+}
+
 /**
  * @brief Linear programming solve function.
  * @note Both primal and dual solutions are zero-initialized. For custom initialization, see
@@ -52,6 +57,31 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
   pdlp_solver_settings_t<i_t, f_t> const& settings = pdlp_solver_settings_t<i_t, f_t>{},
   bool problem_checking                            = true,
   bool use_pdlp_solver_mode                        = true);
+
+/**
+ * @brief Linear programming solve function.
+ * @note Both primal and dual solutions are zero-initialized. For custom initialization, see
+ * op_problem.initial_primal/dual_solution
+ *
+ * @tparam i_t Data type of indexes
+ * @tparam f_t Data type of the variables and their weights in the equations
+ *
+ * @param[in] op_problem  An optimization_problem_t<i_t, f_t> object with a
+ * representation of a linear program
+ * @param[in] settings  A pdlp_solver_settings_t<i_t, f_t> object with the settings for the PDLP
+ * solver.
+ * @param[in] problem_checking  If true, the problem is checked for consistency.
+ * @param[in] use_pdlp_solver_modes  If true, the PDLP hyperparameters coming from the
+ * pdlp_solver_mode are used (instead of the ones comming from a potential hyper-params file).
+ * @return optimization_problem_solution_t<i_t, f_t> owning container for the solver solution
+ */
+template <typename i_t, typename f_t>
+optimization_problem_solution_t<i_t, f_t> solve_lp(
+  detail::problem_t<i_t, f_t>& problem,
+  pdlp_solver_settings_t<i_t, f_t> const& settings = pdlp_solver_settings_t<i_t, f_t>{},
+  bool problem_checking                            = true,
+  bool use_pdlp_solver_mode                        = true,
+  bool inside_mip                                = false);
 
 /**
  * @brief Linear programming solve function.

--- a/cpp/include/cuopt/linear_programming/solve.hpp
+++ b/cpp/include/cuopt/linear_programming/solve.hpp
@@ -81,7 +81,7 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
   pdlp_solver_settings_t<i_t, f_t> const& settings = pdlp_solver_settings_t<i_t, f_t>{},
   bool problem_checking                            = true,
   bool use_pdlp_solver_mode                        = true,
-  bool inside_mip                                = false);
+  bool inside_mip                                  = false);
 
 /**
  * @brief Linear programming solve function.

--- a/cpp/include/cuopt/linear_programming/solve.hpp
+++ b/cpp/include/cuopt/linear_programming/solve.hpp
@@ -59,7 +59,8 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
   bool use_pdlp_solver_mode                        = true);
 
 /**
- * @brief Linear programming solve function.
+ * @brief Linear programming solve function. Used in the context of a MIP when the input is a
+ * detail::problem_t.
  * @note Both primal and dual solutions are zero-initialized. For custom initialization, see
  * op_problem.initial_primal/dual_solution
  *
@@ -73,6 +74,7 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
  * @param[in] problem_checking  If true, the problem is checked for consistency.
  * @param[in] use_pdlp_solver_modes  If true, the PDLP hyperparameters coming from the
  * pdlp_solver_mode are used (instead of the ones comming from a potential hyper-params file).
+ * @param[in] inside_mip  If true, the problem is being solved in the context of a MIP.
  * @return optimization_problem_solution_t<i_t, f_t> owning container for the solver solution
  */
 template <typename i_t, typename f_t>
@@ -84,7 +86,8 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
   bool inside_mip                                  = false);
 
 /**
- * @brief Linear programming solve function.
+ * @brief Linear programming solve function. This is a wrapper around the solve_lp function taking a
+ * detail::problem_t as input.
  * @note Both primal and dual solutions are zero-initialized. For custom initialization, see
  * op_problem.initial_primal/dual_solution
  *

--- a/cpp/include/cuopt/linear_programming/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/solver_settings.hpp
@@ -82,7 +82,8 @@ class solver_settings_t {
                                 f_t last_candidate_kkt_score_,
                                 f_t last_restart_kkt_score_,
                                 f_t sum_solution_weight_,
-                                i_t iterations_since_last_restart_);
+                                i_t iterations_since_last_restart_,
+                                bool solved_by_pdlp_);
 
   const rmm::device_uvector<f_t>& get_initial_pdlp_primal_solution() const;
   const rmm::device_uvector<f_t>& get_initial_pdlp_dual_solution() const;

--- a/cpp/include/cuopt/linear_programming/utilities/cython_solve.hpp
+++ b/cpp/include/cuopt/linear_programming/utilities/cython_solve.hpp
@@ -70,6 +70,12 @@ struct linear_programming_ret_t {
   double gap_;
   int nb_iterations_;
   double solve_time_;
+  // This parameter is stored twice in both the C++ and the Python layer: inside the solution object
+  // and in the warm start data It is required in the solution object to know if the problem was
+  // solved by PDLP or Dual Simplex, whether or not the warm start data was populated It is required
+  // in the warm start data as only this object and not the solution object is passed to the solver
+  // settings In this adapter between the C++ and the Python layer, we can carry the information
+  // through a single field
   bool solved_by_pdlp_;
 };
 

--- a/cpp/src/linear_programming/pdlp.cu
+++ b/cpp/src/linear_programming/pdlp.cu
@@ -292,7 +292,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
       pdhg_solver_,
       pdhg_solver_.get_primal_solution(),
       pdhg_solver_.get_dual_solution(),
-      get_filled_warmed_start_data(true),
+      get_filled_warmed_start_data(),
       pdlp_termination_status_t::TimeLimit);
   }
 
@@ -316,7 +316,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
       pdhg_solver_,
       pdhg_solver_.get_primal_solution(),
       pdhg_solver_.get_dual_solution(),
-      get_filled_warmed_start_data(true),
+      get_filled_warmed_start_data(),
       pdlp_termination_status_t::IterationLimit);
   }
 
@@ -616,7 +616,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
           pdhg_solver_,
           pdhg_solver_.get_primal_solution(),
           pdhg_solver_.get_dual_solution(),
-          get_filled_warmed_start_data(true),
+          get_filled_warmed_start_data(),
           termination_current);
       } else  // Average has better overall residual
       {
@@ -625,7 +625,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
           pdhg_solver_,
           unscaled_primal_avg_solution_,
           unscaled_dual_avg_solution_,
-          get_filled_warmed_start_data(true),
+          get_filled_warmed_start_data(),
           termination_average);
       }
     } else if (termination_current == pdlp_termination_status_t::PrimalFeasible) {
@@ -634,7 +634,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
         pdhg_solver_,
         pdhg_solver_.get_primal_solution(),
         pdhg_solver_.get_dual_solution(),
-        get_filled_warmed_start_data(true),
+        get_filled_warmed_start_data(),
         termination_current);
     } else if (termination_average == pdlp_termination_status_t::PrimalFeasible) {
       return average_termination_strategy_.fill_return_problem_solution(
@@ -642,7 +642,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
         pdhg_solver_,
         unscaled_primal_avg_solution_,
         unscaled_dual_avg_solution_,
-        get_filled_warmed_start_data(true),
+        get_filled_warmed_start_data(),
         termination_average);
     }
     // else neither of the two is primal feasible
@@ -676,7 +676,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
         pdhg_solver_,
         pdhg_solver_.get_primal_solution(),
         pdhg_solver_.get_dual_solution(),
-        get_filled_warmed_start_data(true),
+        get_filled_warmed_start_data(),
         termination_current);
     } else {
 #ifdef PDLP_VERBOSE_MODE
@@ -692,7 +692,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
         pdhg_solver_,
         unscaled_primal_avg_solution_,
         unscaled_dual_avg_solution_,
-        get_filled_warmed_start_data(true),
+        get_filled_warmed_start_data(),
         termination_average);
     }
   }
@@ -712,7 +712,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
       pdhg_solver_,
       unscaled_primal_avg_solution_,
       unscaled_dual_avg_solution_,
-      get_filled_warmed_start_data(true),
+      get_filled_warmed_start_data(),
       termination_average);
   }
   if (termination_current == pdlp_termination_status_t::Optimal) {
@@ -727,7 +727,7 @@ std::optional<optimization_problem_solution_t<i_t, f_t>> pdlp_solver_t<i_t, f_t>
       pdhg_solver_,
       pdhg_solver_.get_primal_solution(),
       pdhg_solver_.get_dual_solution(),
-      get_filled_warmed_start_data(true),
+      get_filled_warmed_start_data(),
       termination_current);
   }
 

--- a/cpp/src/linear_programming/pdlp.cuh
+++ b/cpp/src/linear_programming/pdlp.cuh
@@ -171,7 +171,7 @@ class pdlp_solver_t {
   // Intentionnaly take a copy to avoid an unintentional modification in the calling context
   const pdlp_solver_settings_t<i_t, f_t> settings_;
 
-  pdlp_warm_start_data_t<i_t, f_t> get_filled_warmed_start_data();
+  pdlp_warm_start_data_t<i_t, f_t> get_filled_warmed_start_data(bool solved_by_pdlp);
 
   // Initial scaling strategy
   detail::pdlp_initial_scaling_strategy_t<i_t, f_t> initial_scaling_strategy_;

--- a/cpp/src/linear_programming/pdlp.cuh
+++ b/cpp/src/linear_programming/pdlp.cuh
@@ -171,7 +171,7 @@ class pdlp_solver_t {
   // Intentionnaly take a copy to avoid an unintentional modification in the calling context
   const pdlp_solver_settings_t<i_t, f_t> settings_;
 
-  pdlp_warm_start_data_t<i_t, f_t> get_filled_warmed_start_data(bool solved_by_pdlp);
+  pdlp_warm_start_data_t<i_t, f_t> get_filled_warmed_start_data(bool solved_by_pdlp = true);
 
   // Initial scaling strategy
   detail::pdlp_initial_scaling_strategy_t<i_t, f_t> initial_scaling_strategy_;

--- a/cpp/src/linear_programming/pdlp_warm_start_data.cu
+++ b/cpp/src/linear_programming/pdlp_warm_start_data.cu
@@ -46,7 +46,8 @@ pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t(
   f_t last_candidate_kkt_score,
   f_t last_restart_kkt_score,
   f_t sum_solution_weight,
-  i_t iterations_since_last_restart)
+  i_t iterations_since_last_restart,
+  bool solved_by_pdlp)
   :  // When initially creating this object, we can't move neither the primal/dual solution nor
      // the average since they might be used as a solution by the solution object, they have to be
      // copied
@@ -66,7 +67,8 @@ pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t(
     last_candidate_kkt_score_(last_candidate_kkt_score),
     last_restart_kkt_score_(last_restart_kkt_score),
     sum_solution_weight_(sum_solution_weight),
-    iterations_since_last_restart_(iterations_since_last_restart)
+    iterations_since_last_restart_(iterations_since_last_restart),
+    solved_by_pdlp_(solved_by_pdlp)
 {
   check_sizes();
 }
@@ -107,7 +109,8 @@ pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t(
     last_candidate_kkt_score_(other.last_candidate_kkt_score_),
     last_restart_kkt_score_(other.last_restart_kkt_score_),
     sum_solution_weight_(other.sum_solution_weight_),
-    iterations_since_last_restart_(other.iterations_since_last_restart_)
+    iterations_since_last_restart_(other.iterations_since_last_restart_),
+    solved_by_pdlp_(other.solved_by_pdlp_)
 {
   raft::copy(current_primal_solution_.data(),
              other.current_primal_solution_.data(),
@@ -168,7 +171,8 @@ pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t(const pdlp_warm_start_d
     last_candidate_kkt_score_(other.last_candidate_kkt_score_),
     last_restart_kkt_score_(other.last_restart_kkt_score_),
     sum_solution_weight_(other.sum_solution_weight_),
-    iterations_since_last_restart_(other.iterations_since_last_restart_)
+    iterations_since_last_restart_(other.iterations_since_last_restart_),
+    solved_by_pdlp_(other.solved_by_pdlp_)
 {
   check_sizes();
 }

--- a/cpp/src/linear_programming/solve.cu
+++ b/cpp/src/linear_programming/solve.cu
@@ -572,7 +572,8 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(detail::problem_t<i_t, f_t>& 
       raft::common::nvtx::range fun_scope("Check problem representation");
       // This is required as user might forget to set some fields
       problem_checking_t<i_t, f_t>::check_problem_representation(*problem.original_problem_ptr);
-      problem_checking_t<i_t, f_t>::check_initial_solution_representation(*problem.original_problem_ptr, settings);
+      problem_checking_t<i_t, f_t>::check_initial_solution_representation(
+        *problem.original_problem_ptr, settings);
     }
     CUOPT_LOG_INFO(
       "Solving a problem with %d constraints %d variables (%d integers) and %d nonzeros",
@@ -594,7 +595,7 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(detail::problem_t<i_t, f_t>& 
 
     setup_device_symbols(problem.handle_ptr->get_stream());
 
-    auto sol = solve_lp_with_method( problem, settings, inside_mip);
+    auto sol = solve_lp_with_method(problem, settings, inside_mip);
 
     if (settings.sol_file != "") {
       CUOPT_LOG_INFO("Writing solution to file %s", settings.sol_file.c_str());
@@ -711,7 +712,12 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
     pdlp_solver_settings_t<int, F_TYPE> const& settings,                               \
     bool problem_checking,                                                             \
     bool use_pdlp_solver_mode);                                                        \
-                                                                                       \
+  template optimization_problem_solution_t<int, F_TYPE> solve_lp(                      \
+    detail::problem_t<int, F_TYPE>& problem,                                           \
+    pdlp_solver_settings_t<int, F_TYPE> const& settings,                               \
+    bool problem_checking,                                                             \
+    bool use_pdlp_solver_mode,                                                         \
+    bool inside_mip);                                                                  \
   template optimization_problem_solution_t<int, F_TYPE> solve_lp(                      \
     raft::handle_t const* handle_ptr,                                                  \
     const cuopt::mps_parser::mps_data_model_t<int, F_TYPE>& mps_data_model,            \

--- a/cpp/src/linear_programming/solver_settings.cu
+++ b/cpp/src/linear_programming/solver_settings.cu
@@ -80,18 +80,6 @@ void pdlp_solver_settings_t<i_t, f_t>::set_initial_primal_solution(
 }
 
 template <typename i_t, typename f_t>
-void pdlp_solver_settings_t<i_t, f_t>::set_initial_primal_solution(
-  const rmm::device_uvector<f_t>& initial_primal_solution)
-{
-  initial_primal_solution_ = std::make_shared<rmm::device_uvector<f_t>>(
-    initial_primal_solution.size(), initial_primal_solution.stream());
-  raft::copy(initial_primal_solution_.get()->data(),
-             initial_primal_solution.data(),
-             initial_primal_solution.size(),
-             initial_primal_solution.stream());
-}
-
-template <typename i_t, typename f_t>
 void pdlp_solver_settings_t<i_t, f_t>::set_initial_dual_solution(const f_t* initial_dual_solution,
                                                                  i_t size,
                                                                  rmm::cuda_stream_view stream)
@@ -102,19 +90,6 @@ void pdlp_solver_settings_t<i_t, f_t>::set_initial_dual_solution(const f_t* init
 
   initial_dual_solution_ = std::make_shared<rmm::device_uvector<f_t>>(size, stream);
   raft::copy(initial_dual_solution_.get()->data(), initial_dual_solution, size, stream);
-}
-
-// TODO could use a move constructor here
-template <typename i_t, typename f_t>
-void pdlp_solver_settings_t<i_t, f_t>::set_initial_dual_solution(
-  const rmm::device_uvector<f_t>& initial_dual_solution)
-{
-  initial_dual_solution_ = std::make_shared<rmm::device_uvector<f_t>>(
-    initial_dual_solution.size(), initial_dual_solution.stream());
-  raft::copy(initial_dual_solution_.get()->data(),
-             initial_dual_solution.data(),
-             initial_dual_solution.size(),
-             initial_dual_solution.stream());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/linear_programming/solver_settings.cu
+++ b/cpp/src/linear_programming/solver_settings.cu
@@ -22,6 +22,7 @@
 #include <math_optimization/solution_writer.hpp>
 #include <mip/mip_constants.hpp>
 #include <mps_parser/utilities/span.hpp>
+#include <utilities/macros.cuh>
 
 #include <raft/util/cudart_utils.hpp>
 
@@ -82,7 +83,8 @@ template <typename i_t, typename f_t>
 void pdlp_solver_settings_t<i_t, f_t>::set_initial_primal_solution(
   const rmm::device_uvector<f_t>& initial_primal_solution)
 {
-  initial_primal_solution_ = std::make_shared<rmm::device_uvector<f_t>>(initial_primal_solution.size(), initial_primal_solution.stream());
+  initial_primal_solution_ = std::make_shared<rmm::device_uvector<f_t>>(
+    initial_primal_solution.size(), initial_primal_solution.stream());
   raft::copy(initial_primal_solution_.get()->data(),
              initial_primal_solution.data(),
              initial_primal_solution.size(),
@@ -107,7 +109,8 @@ template <typename i_t, typename f_t>
 void pdlp_solver_settings_t<i_t, f_t>::set_initial_dual_solution(
   const rmm::device_uvector<f_t>& initial_dual_solution)
 {
-  initial_dual_solution_ = std::make_shared<rmm::device_uvector<f_t>>(initial_dual_solution.size(), initial_dual_solution.stream());
+  initial_dual_solution_ = std::make_shared<rmm::device_uvector<f_t>>(
+    initial_dual_solution.size(), initial_dual_solution.stream());
   raft::copy(initial_dual_solution_.get()->data(),
              initial_dual_solution.data(),
              initial_dual_solution.size(),
@@ -157,13 +160,12 @@ void pdlp_solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
                       pdlp_warm_start_data.last_restart_duality_gap_primal_solution_.begin());
 
       pdlp_warm_start_data.current_primal_solution_.resize(var_mapping.size(),
-                                                            var_mapping.stream());
-      pdlp_warm_start_data.initial_primal_average_.resize(var_mapping.size(),
                                                            var_mapping.stream());
+      pdlp_warm_start_data.initial_primal_average_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.current_ATY_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.sum_primal_solutions_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.last_restart_duality_gap_primal_solution_.resize(var_mapping.size(),
-                                                                             var_mapping.stream());
+                                                                            var_mapping.stream());
     } else if (var_mapping.size() >
                pdlp_warm_start_data.last_restart_duality_gap_primal_solution_.size()) {
       const auto previous_size =
@@ -171,13 +173,12 @@ void pdlp_solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
 
       // If more variables just pad with 0s
       pdlp_warm_start_data.current_primal_solution_.resize(var_mapping.size(),
-                                                            var_mapping.stream());
-      pdlp_warm_start_data.initial_primal_average_.resize(var_mapping.size(),
                                                            var_mapping.stream());
+      pdlp_warm_start_data.initial_primal_average_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.current_ATY_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.sum_primal_solutions_.resize(var_mapping.size(), var_mapping.stream());
       pdlp_warm_start_data.last_restart_duality_gap_primal_solution_.resize(var_mapping.size(),
-                                                                             var_mapping.stream());
+                                                                            var_mapping.stream());
 
       thrust::fill(rmm::exec_policy(var_mapping.stream()),
                    pdlp_warm_start_data.current_primal_solution_.begin() + previous_size,
@@ -231,11 +232,11 @@ void pdlp_solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
                       pdlp_warm_start_data.last_restart_duality_gap_dual_solution_.begin());
 
       pdlp_warm_start_data.current_dual_solution_.resize(constraint_mapping.size(),
-                                                          constraint_mapping.stream());
-      pdlp_warm_start_data.initial_dual_average_.resize(constraint_mapping.size(),
                                                          constraint_mapping.stream());
+      pdlp_warm_start_data.initial_dual_average_.resize(constraint_mapping.size(),
+                                                        constraint_mapping.stream());
       pdlp_warm_start_data.sum_dual_solutions_.resize(constraint_mapping.size(),
-                                                       constraint_mapping.stream());
+                                                      constraint_mapping.stream());
       pdlp_warm_start_data.last_restart_duality_gap_dual_solution_.resize(
         constraint_mapping.size(), constraint_mapping.stream());
     } else if (constraint_mapping.size() >
@@ -245,11 +246,11 @@ void pdlp_solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
 
       // If more variables just pad with 0s
       pdlp_warm_start_data.current_dual_solution_.resize(constraint_mapping.size(),
-                                                          constraint_mapping.stream());
-      pdlp_warm_start_data.initial_dual_average_.resize(constraint_mapping.size(),
                                                          constraint_mapping.stream());
+      pdlp_warm_start_data.initial_dual_average_.resize(constraint_mapping.size(),
+                                                        constraint_mapping.stream());
       pdlp_warm_start_data.sum_dual_solutions_.resize(constraint_mapping.size(),
-                                                       constraint_mapping.stream());
+                                                      constraint_mapping.stream());
       pdlp_warm_start_data.last_restart_duality_gap_dual_solution_.resize(
         constraint_mapping.size(), constraint_mapping.stream());
 
@@ -350,7 +351,7 @@ void pdlp_solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
   pdlp_warm_start_data_view_.last_restart_kkt_score_        = last_restart_kkt_score;
   pdlp_warm_start_data_view_.sum_solution_weight_           = sum_solution_weight;
   pdlp_warm_start_data_view_.iterations_since_last_restart_ = iterations_since_last_restart;
-  pdlp_warm_start_data_view_.solved_by_pdlp_               = solved_by_pdlp;
+  pdlp_warm_start_data_view_.solved_by_pdlp_                = solved_by_pdlp;
 }
 
 template <typename i_t, typename f_t>
@@ -385,16 +386,26 @@ bool pdlp_solver_settings_t<i_t, f_t>::has_initial_dual_solution() const
 }
 
 template <typename i_t, typename f_t>
-const std::optional<pdlp_warm_start_data_t<i_t, f_t>>&
-pdlp_solver_settings_t<i_t, f_t>::get_pdlp_warm_start_data() const noexcept
+bool pdlp_solver_settings_t<i_t, f_t>::has_pdlp_warm_start_data() const
 {
-  return pdlp_warm_start_data_;
+  return pdlp_warm_start_data_.has_value();
 }
 
 template <typename i_t, typename f_t>
-std::optional<pdlp_warm_start_data_t<i_t, f_t>>& pdlp_solver_settings_t<i_t, f_t>::get_pdlp_warm_start_data()
+const pdlp_warm_start_data_t<i_t, f_t>& pdlp_solver_settings_t<i_t, f_t>::get_pdlp_warm_start_data()
+  const noexcept
 {
-  return pdlp_warm_start_data_;
+  cuopt_assert(pdlp_warm_start_data_.has_value(),
+               "PDLP warm start data was not set, but accessed!");
+  return pdlp_warm_start_data_.value();
+}
+
+template <typename i_t, typename f_t>
+pdlp_warm_start_data_t<i_t, f_t>& pdlp_solver_settings_t<i_t, f_t>::get_pdlp_warm_start_data()
+{
+  cuopt_assert(pdlp_warm_start_data_.has_value(),
+               "PDLP warm start data was not set, but accessed!");
+  return pdlp_warm_start_data_.value();
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -334,7 +334,8 @@ void solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
   f_t last_candidate_kkt_score,
   f_t last_restart_kkt_score,
   f_t sum_solution_weight,
-  i_t iterations_since_last_restart)
+  i_t iterations_since_last_restart,
+  bool solved_by_pdlp)
 {
   pdlp_settings.set_pdlp_warm_start_data(current_primal_solution,
                                          current_dual_solution,
@@ -354,7 +355,8 @@ void solver_settings_t<i_t, f_t>::set_pdlp_warm_start_data(
                                          last_candidate_kkt_score,
                                          last_restart_kkt_score,
                                          sum_solution_weight,
-                                         iterations_since_last_restart);
+                                         iterations_since_last_restart,
+                                         solved_by_pdlp);
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip/diversity/diversity_manager.cu
+++ b/cpp/src/mip/diversity/diversity_manager.cu
@@ -22,6 +22,8 @@
 #include <mip/presolve/probing_cache.cuh>
 #include <mip/presolve/trivial_presolve.cuh>
 
+#include <raft/common/nvtx.hpp>
+
 #include "cuda_profiler_api.h"
 
 namespace cuopt::linear_programming::detail {
@@ -263,6 +265,8 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit)
 template <typename i_t, typename f_t>
 void diversity_manager_t<i_t, f_t>::generate_quick_feasible_solution()
 {
+  raft::common::nvtx::range fun_scope("Generate Quick Feasible Solution");
+
   solution_t<i_t, f_t> solution(*problem_ptr);
   // min 1 second, max 10 seconds
   const f_t generate_fast_solution_time = min(10., max(1., timer.remaining_time() / 20.));

--- a/cpp/src/mip/local_search/feasibility_pump/feasibility_pump.cu
+++ b/cpp/src/mip/local_search/feasibility_pump/feasibility_pump.cu
@@ -146,6 +146,8 @@ bool feasibility_pump_t<i_t, f_t>::linear_project_onto_polytope(solution_t<i_t, 
                                                                 f_t ratio_of_set_integers,
                                                                 bool longer_lp_run)
 {
+  raft::common::nvtx::range fun_scope("linear_project_onto_polytope");
+
   CUOPT_LOG_DEBUG("linear projection of fp");
   auto h_assignment            = solution.get_host_assignment();
   auto h_variable_upper_bounds = cuopt::host_copy(solution.problem_ptr->variable_upper_bounds,

--- a/cpp/src/mip/relaxed_lp/relaxed_lp.cu
+++ b/cpp/src/mip/relaxed_lp/relaxed_lp.cu
@@ -95,8 +95,11 @@ optimization_problem_solution_t<i_t, f_t> get_relaxed_lp_solution(
                        if (!isfinite(x) || i >= prev_size) { return 0.0; }
                        return x;
                      });
-    settings.set_initial_primal_solution(lp_state.prev_primal);
-    settings.set_initial_dual_solution(lp_state.prev_dual);
+    settings.set_initial_primal_solution(lp_state.prev_primal.data(),
+                                         lp_state.prev_primal.size(),
+                                         op_problem.handle_ptr->get_stream());
+    settings.set_initial_dual_solution(
+      lp_state.prev_dual.data(), lp_state.prev_dual.size(), op_problem.handle_ptr->get_stream());
   }
   CUOPT_LOG_DEBUG(
     "running LP with n_vars %d n_cstr %d", op_problem.n_variables, op_problem.n_constraints);

--- a/cpp/src/mip/relaxed_lp/relaxed_lp.cu
+++ b/cpp/src/mip/relaxed_lp/relaxed_lp.cu
@@ -102,7 +102,6 @@ optimization_problem_solution_t<i_t, f_t> get_relaxed_lp_solution(
     "running LP with n_vars %d n_cstr %d", op_problem.n_variables, op_problem.n_constraints);
   // before LP flush the logs as it takes quite some time
   cuopt::default_logger().flush();
-  // temporarily add timer
   // TODO check that we do want to do problem checking here
   auto solver_response = solve_lp(op_problem, settings, true, true, true);
 

--- a/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
+++ b/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
@@ -134,19 +134,21 @@ TEST(SolverSettingsTest, warm_start_smaller_vector)
                                         -1,
                                         -1,
                                         -1,
-                                        -1);
+                                        -1,
+                                        true);
   solver_settings.set_pdlp_warm_start_data(warm_start_data, d_primal_mapping, d_dual_mapping);
 
+  const auto& _warm_start_data = solver_settings.get_pdlp_warm_start_data();
+
   std::vector<double> h_current_primal_solution =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_primal_solution_);
+    cuopt::host_copy(_warm_start_data.current_primal_solution_);
   std::vector<double> h_initial_primal_average =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().initial_primal_average_);
-  std::vector<double> h_current_ATY =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_ATY_);
+    cuopt::host_copy(_warm_start_data.initial_primal_average_);
+  std::vector<double> h_current_ATY = cuopt::host_copy(_warm_start_data.current_ATY_);
   std::vector<double> h_sum_primal_solutions =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().sum_primal_solutions_);
-  std::vector<double> h_last_restart_duality_gap_primal_solution = cuopt::host_copy(
-    solver_settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution_);
+    cuopt::host_copy(_warm_start_data.sum_primal_solutions_);
+  std::vector<double> h_last_restart_duality_gap_primal_solution =
+    cuopt::host_copy(_warm_start_data.last_restart_duality_gap_primal_solution_);
 
   EXPECT_EQ(h_current_primal_solution.size(), primal_expected.size());
   EXPECT_EQ(h_initial_primal_average.size(), primal_expected.size());
@@ -159,15 +161,15 @@ TEST(SolverSettingsTest, warm_start_smaller_vector)
   EXPECT_EQ(h_current_ATY, primal_expected);
   EXPECT_EQ(h_sum_primal_solutions, primal_expected);
   EXPECT_EQ(h_last_restart_duality_gap_primal_solution, primal_expected);
+  EXPECT_EQ(_warm_start_data.solved_by_pdlp_, true);
 
   std::vector<double> h_current_dual_solution =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_dual_solution_);
+    cuopt::host_copy(_warm_start_data.current_dual_solution_);
   std::vector<double> h_initial_dual_average =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().initial_dual_average_);
-  std::vector<double> h_sum_dual_solutions =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().sum_dual_solutions_);
-  std::vector<double> h_last_restart_duality_gap_dual_solution = cuopt::host_copy(
-    solver_settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution_);
+    cuopt::host_copy(_warm_start_data.initial_dual_average_);
+  std::vector<double> h_sum_dual_solutions = cuopt::host_copy(_warm_start_data.sum_dual_solutions_);
+  std::vector<double> h_last_restart_duality_gap_dual_solution =
+    cuopt::host_copy(_warm_start_data.last_restart_duality_gap_dual_solution_);
 
   EXPECT_EQ(h_current_dual_solution.size(), dual_expected.size());
   EXPECT_EQ(h_initial_dual_average.size(), dual_expected.size());
@@ -189,9 +191,8 @@ TEST(SolverSettingsTest, warm_start_bigger_vector)
 
   std::vector<double> primal      = {0.0, 1.0, 2.0, 3.0};
   std::vector<double> dual        = {0.0, 1.0, 2.0};
-  std::vector<int> primal_mapping = {0, 1, 2, 3, 4, 5};  // Only two variables and 0 - 1 swapped
-  std::vector<int> dual_mapping   = {
-    0, 1, 2, 3, 4, 5, 6};  // Only three constraints and  1 - 2 swapped
+  std::vector<int> primal_mapping = {0, 1, 2, 3, 4, 5};
+  std::vector<int> dual_mapping   = {0, 1, 2, 3, 4, 5, 6};
 
   std::vector<double> primal_expected = {0.0, 1.0, 2.0, 3.0, 0.0, 0.0};
   std::vector<double> dual_expected   = {0.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0};
@@ -234,19 +235,22 @@ TEST(SolverSettingsTest, warm_start_bigger_vector)
                                         -1,
                                         -1,
                                         -1,
-                                        -1);
+                                        -1,
+                                        true);
   solver_settings.set_pdlp_warm_start_data(warm_start_data, d_primal_mapping, d_dual_mapping);
 
+  const pdlp_warm_start_data_t<int, double>& _warm_start_data =
+    solver_settings.get_pdlp_warm_start_data();
+
   std::vector<double> h_current_primal_solution =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_primal_solution_);
+    cuopt::host_copy(_warm_start_data.current_primal_solution_);
   std::vector<double> h_initial_primal_average =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().initial_primal_average_);
-  std::vector<double> h_current_ATY =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_ATY_);
+    cuopt::host_copy(_warm_start_data.initial_primal_average_);
+  std::vector<double> h_current_ATY = cuopt::host_copy(_warm_start_data.current_ATY_);
   std::vector<double> h_sum_primal_solutions =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().sum_primal_solutions_);
-  std::vector<double> h_last_restart_duality_gap_primal_solution = cuopt::host_copy(
-    solver_settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution_);
+    cuopt::host_copy(_warm_start_data.sum_primal_solutions_);
+  std::vector<double> h_last_restart_duality_gap_primal_solution =
+    cuopt::host_copy(_warm_start_data.last_restart_duality_gap_primal_solution_);
 
   EXPECT_EQ(h_current_primal_solution.size(), primal_expected.size());
   EXPECT_EQ(h_initial_primal_average.size(), primal_expected.size());
@@ -261,13 +265,12 @@ TEST(SolverSettingsTest, warm_start_bigger_vector)
   EXPECT_EQ(h_last_restart_duality_gap_primal_solution, primal_expected);
 
   std::vector<double> h_current_dual_solution =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().current_dual_solution_);
+    cuopt::host_copy(_warm_start_data.current_dual_solution_);
   std::vector<double> h_initial_dual_average =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().initial_dual_average_);
-  std::vector<double> h_sum_dual_solutions =
-    cuopt::host_copy(solver_settings.get_pdlp_warm_start_data().sum_dual_solutions_);
-  std::vector<double> h_last_restart_duality_gap_dual_solution = cuopt::host_copy(
-    solver_settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution_);
+    cuopt::host_copy(_warm_start_data.initial_dual_average_);
+  std::vector<double> h_sum_dual_solutions = cuopt::host_copy(_warm_start_data.sum_dual_solutions_);
+  std::vector<double> h_last_restart_duality_gap_dual_solution =
+    cuopt::host_copy(_warm_start_data.last_restart_duality_gap_dual_solution_);
 
   EXPECT_EQ(h_current_dual_solution.size(), dual_expected.size());
   EXPECT_EQ(h_initial_dual_average.size(), dual_expected.size());

--- a/python/cuopt/cuopt/linear_programming/solution/solution.py
+++ b/python/cuopt/cuopt/linear_programming/solution/solution.py
@@ -40,6 +40,7 @@ class PDLPWarmStartData:
         last_restart_kkt_score,
         sum_solution_weight,
         iterations_since_last_restart,
+        solved_by_pdlp,
     ):
         self.current_primal_solution = current_primal_solution
         self.current_dual_solution = current_dual_solution
@@ -62,6 +63,7 @@ class PDLPWarmStartData:
         self.last_restart_kkt_score = last_restart_kkt_score
         self.sum_solution_weight = sum_solution_weight
         self.iterations_since_last_restart = iterations_since_last_restart
+        self.solved_by_pdlp = solved_by_pdlp
 
 
 class Solution:
@@ -197,6 +199,7 @@ class Solution:
             last_restart_kkt_score,
             sum_solution_weight,
             iterations_since_last_restart,
+            solved_by_pdlp,
         )
         self._set_termination_status(termination_status)
         self.error_status = error_status

--- a/python/cuopt/cuopt/linear_programming/solver/solver.pxd
+++ b/python/cuopt/cuopt/linear_programming/solver/solver.pxd
@@ -64,7 +64,8 @@ cdef extern from "cuopt/linear_programming/solver_settings.hpp" namespace "cuopt
             f_t last_candidate_kkt_score_,
             f_t last_restart_kkt_score_,
             f_t sum_solution_weight_,
-            i_t iterations_since_last_restart_) except +
+            i_t iterations_since_last_restart_,
+            bool solved_by_pdlp_) except +
 
         void set_parameter_from_string(
             const string& name,

--- a/python/cuopt/cuopt/linear_programming/solver/solver_wrapper.pyx
+++ b/python/cuopt/cuopt/linear_programming/solver/solver_wrapper.pyx
@@ -344,86 +344,90 @@ cdef set_solver_setting(
 
 
     if settings.get_pdlp_warm_start_data() is not None:  # noqa
-        if len(data_model_obj.get_objective_coefficients()) != len(
-            settings.get_pdlp_warm_start_data().current_primal_solution
-        ):
-            raise Exception(
-                "Invalid PDLPWarmStart data. Passed problem and PDLPWarmStart " # noqa
-                "data should have the same amount of variables."
-            )
-        if len(data_model_obj.get_constraint_matrix_offsets()) - 1 != len( # noqa
-            settings.get_pdlp_warm_start_data().current_dual_solution
-        ):
-            raise Exception(
-                "Invalid PDLPWarmStart data. Passed problem and PDLPWarmStart " # noqa
-                "data should have the same amount of constraints."
-            )
-        c_current_primal_solution = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().current_primal_solution # noqa
-            )
-        )
-        c_current_dual_solution = (
-            get_data_ptr(
+        if not settings.get_pdlp_warm_start_data().solved_by_pdlp:
+            warnings.warn("PDLPWarmStart data was passed to the solver, but the problem was solved by Dual Simplex. This data will be ignored.") # noqa
+        else:
+            if len(data_model_obj.get_objective_coefficients()) != len(
+                settings.get_pdlp_warm_start_data().current_primal_solution
+            ):
+                raise Exception(
+                    "Invalid PDLPWarmStart data. Passed problem and PDLPWarmStart " # noqa
+                    "data should have the same amount of variables."
+                )
+            if len(data_model_obj.get_constraint_matrix_offsets()) - 1 != len( # noqa
                 settings.get_pdlp_warm_start_data().current_dual_solution
+            ):
+                raise Exception(
+                    "Invalid PDLPWarmStart data. Passed problem and PDLPWarmStart " # noqa
+                    "data should have the same amount of constraints."
+                )
+            c_current_primal_solution = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().current_primal_solution # noqa
+                )
             )
-        )
-        c_initial_primal_average = (
-            get_data_ptr(
-               settings.get_pdlp_warm_start_data().initial_primal_average # noqa
+            c_current_dual_solution = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().current_dual_solution
+                )
             )
-        )
-        c_initial_dual_average = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().initial_dual_average
+            c_initial_primal_average = (
+                get_data_ptr(
+                settings.get_pdlp_warm_start_data().initial_primal_average # noqa
+                )
             )
-        )
-        c_current_ATY = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().current_ATY
+            c_initial_dual_average = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().initial_dual_average
+                )
             )
-        )
-        c_sum_primal_solutions = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().sum_primal_solutions
+            c_current_ATY = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().current_ATY
+                )
             )
-        )
-        c_sum_dual_solutions = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().sum_dual_solutions
+            c_sum_primal_solutions = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().sum_primal_solutions
+                )
             )
-        )
-        c_last_restart_duality_gap_primal_solution = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution # noqa
+            c_sum_dual_solutions = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().sum_dual_solutions
+                )
             )
-        )
-        c_last_restart_duality_gap_dual_solution = (
-            get_data_ptr(
-                settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution # noqa
+            c_last_restart_duality_gap_primal_solution = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution # noqa
+                )
             )
-        )
-        c_solver_settings.set_pdlp_warm_start_data(
-            <const double *> c_current_primal_solution,
-            <const double *> c_current_dual_solution,
-            <const double *> c_initial_primal_average,
-            <const double *> c_initial_dual_average,
-            <const double *> c_current_ATY,
-            <const double *> c_sum_primal_solutions,
-            <const double *> c_sum_dual_solutions,
-            <const double *> c_last_restart_duality_gap_primal_solution,
-            <const double *> c_last_restart_duality_gap_dual_solution,
-            settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution.shape[0], # Primal size # noqa
-            settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution.shape[0], # Dual size # noqa
-            settings.get_pdlp_warm_start_data().initial_primal_weight,
-            settings.get_pdlp_warm_start_data().initial_step_size,
-            settings.get_pdlp_warm_start_data().total_pdlp_iterations,
-            settings.get_pdlp_warm_start_data().total_pdhg_iterations,
-            settings.get_pdlp_warm_start_data().last_candidate_kkt_score,
-            settings.get_pdlp_warm_start_data().last_restart_kkt_score,
-            settings.get_pdlp_warm_start_data().sum_solution_weight,
-            settings.get_pdlp_warm_start_data().iterations_since_last_restart # noqa
-        )
+            c_last_restart_duality_gap_dual_solution = (
+                get_data_ptr(
+                    settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution # noqa
+                )
+            )
+            c_solver_settings.set_pdlp_warm_start_data(
+                <const double *> c_current_primal_solution,
+                <const double *> c_current_dual_solution,
+                <const double *> c_initial_primal_average,
+                <const double *> c_initial_dual_average,
+                <const double *> c_current_ATY,
+                <const double *> c_sum_primal_solutions,
+                <const double *> c_sum_dual_solutions,
+                <const double *> c_last_restart_duality_gap_primal_solution,
+                <const double *> c_last_restart_duality_gap_dual_solution,
+                settings.get_pdlp_warm_start_data().last_restart_duality_gap_primal_solution.shape[0], # Primal size # noqa
+                settings.get_pdlp_warm_start_data().last_restart_duality_gap_dual_solution.shape[0], # Dual size # noqa
+                settings.get_pdlp_warm_start_data().initial_primal_weight,
+                settings.get_pdlp_warm_start_data().initial_step_size,
+                settings.get_pdlp_warm_start_data().total_pdlp_iterations,
+                settings.get_pdlp_warm_start_data().total_pdhg_iterations,
+                settings.get_pdlp_warm_start_data().last_candidate_kkt_score,
+                settings.get_pdlp_warm_start_data().last_restart_kkt_score,
+                settings.get_pdlp_warm_start_data().sum_solution_weight,
+                settings.get_pdlp_warm_start_data().iterations_since_last_restart, # noqa
+                settings.get_pdlp_warm_start_data().solved_by_pdlp
+            )
 
     # Common to LP and MIP
 
@@ -648,7 +652,7 @@ cdef create_solution(unique_ptr[solver_ret_t] sol_ret_ptr,
                 dual_objective,
                 gap,
                 nb_iterations,
-                solved_by_pdlp,
+                solved_by_pdlp=solved_by_pdlp,
             )
         return Solution(
             problem_category=ProblemCategory(sol_ret.problem_type),

--- a/python/cuopt/cuopt/linear_programming/solver_settings/solver_settings.py
+++ b/python/cuopt/cuopt/linear_programming/solver_settings/solver_settings.py
@@ -226,10 +226,14 @@ class SolverSettings:
         For now, the problem must have the same number of variables and
         constraints as the one found in the previous solution.
 
-        Only supported solver modes are Stable2 and Fast1.
+        Only supported PDLP solver modes are Stable2 and Fast1.
+        Only supported if both the previous and new problem are solved by PDLP.
 
         Examples
         --------
+        >>> # Set PDLP as the solver method to make sure Dual Simplex will not
+        >>> # be used
+        >>> settings.set_parameter(CUOPT_METHOD, SolverMethod.PDLP)
         >>> solution = solver.Solve(first_problem, settings)
         >>> settings.set_pdlp_warm_start_data(
         >>>     solution.get_pdlp_warm_start_data()

--- a/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
@@ -510,6 +510,22 @@ def test_parser_and_batch_solver():
         )
 
 
+def test_solved_by_pdlp():
+
+    file_path = (
+        RAPIDS_DATASET_ROOT_DIR + "/linear_programming/afiro_original.mps"
+    )
+    data_model_obj = cuopt_mps_parser.ParseMps(file_path)
+
+    settings = solver_settings.SolverSettings()
+    settings.set_parameter(CUOPT_METHOD, SolverMethod.PDLP)
+
+    solution = solver.Solve(data_model_obj, settings)
+
+    assert solution.get_solved_by_pdlp()
+    assert solution.get_pdlp_warm_start_data().solved_by_pdlp
+
+
 def test_warm_start():
 
     file_path = RAPIDS_DATASET_ROOT_DIR + "/linear_programming/a2864/a2864.mps"

--- a/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
+++ b/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
@@ -574,6 +574,7 @@ class WarmStartData(StrictModel):
     last_restart_kkt_score: float
     sum_solution_weight: float
     iterations_since_last_restart: int
+    solved_by_pdlp: bool = False
 
 
 class SolutionData(StrictModel):


### PR DESCRIPTION
This PR aims at multiple improvements in MIP:

- Allow for concurrent solve (PDLP and Dual Simplex) in get_relaxed_lp which should improve FP
	- This is done by adding a solve LP interface that takes as input the MIP problem representation (instead of the LP one)
	- This interface is now used everywhere. If we need to solve an LP with the LP problem representation, the problem will be converted (which was already done eventually in any case)
	- Added handling of the "inside_mip" flag for both PDLP and Dual Simplex
- Proper handling of PDLP with warm start data through an additional field. This is in case previous problem was solved by Dual Simplex because of a concurent solve
	- Test added and also comments
- Added a few missing NVTX ranges

Eventually we want to add plug warm start in FP for both PDLP and Dual Simplex.