### PR TITLE
Feat: rework cmakelists.txt to facilitate deb file creation.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -252,16 +252,49 @@ endif(BUILD_TESTS)
 
 # ##################################################################################################
 # - install targets -------------------------------------------------------------------------------
+
+# allows for CPack component builds and install location
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+set(CPACK_COMPONENTS_ALL runtime dev)
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+
+#If using cpack to create a deb package
+if(CPACK_GENERATOR STREQUAL "DEB")
+  set(_BIN_DEST "bin")
+  set(_LIB_DEST "lib")
+  set(_INCLUDE_DEST "lib/cuopt")
+
+#If building locally use the Default install paths(e.g. for local development or other package types)
+else()
+  set(_BIN_DEST "${CMAKE_INSTALL_BINDIR}")
+  set(_LIB_DEST "${lib_dir}")
+  set(_INCLUDE_DEST  include/cuopt/)
+endif()
+
+# adds the .so files to the runtime deb package
 install(TARGETS cuopt mps_parser
-  DESTINATION ${lib_dir}
-  EXPORT cuopt-exports)
+  DESTINATION ${_LIB_DEST}z
+  COMPONENT runtime
+  EXPORT cuopt-exports
+)
 
+# adds the .so files to the development deb package
+install(TARGETS cuopt mps_parser
+  DESTINATION ${_LIB_DEST}
+  COMPONENT dev
+)
+
+# adds the header files to the development deb package
 install(DIRECTORY include/cuopt/
-  DESTINATION include/cuopt)
+  DESTINATION ${_INCLUDE_DEST}
+  COMPONENT dev
+)
 
+# adds the version header file to the development deb package
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/cuopt/version_config.hpp
-  DESTINATION include/cuopt)
-
+  DESTINATION ${_INCLUDE_DEST}
+  COMPONENT dev
+)
 # ###############################################################################################
 # - install export -------------------------------------------------------------------------------
 set(doc_string
@@ -306,8 +339,6 @@ if(Doxygen_FOUND)
 endif()
 
 
-
-list(APPEND CUOPT_CXX_FLAGS -g -O0)
 add_executable(cuopt_cli cuopt_cli.cpp)
 target_compile_options(cuopt_cli
   PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUOPT_CXX_FLAGS}>"
@@ -330,10 +361,12 @@ target_link_libraries(cuopt_cli
 )
 set_property(TARGET cuopt_cli PROPERTY INSTALL_RPATH "$ORIGIN/../${lib_dir}")
 
-# FIXME:: Is this the right way? 
-install(TARGETS cuopt_cli
-  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# adds the cuopt_cli executable to the runtime deb package
+install(TARGETS cuopt_cli
+  COMPONENT runtime
+  RUNTIME DESTINATION ${_BIN_DEST}
+)
 
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 if(BUILD_BENCHMARKS)
@@ -348,3 +381,38 @@ if(BUILD_BENCHMARKS)
     OpenMP::OpenMP_CXX
   )
 endif()
+
+
+# ##################################################################################################
+# - CPack has to be the last item in the cmake file-------------------------------------------------
+# Used to create an installable deb package for cuOpt
+
+set(CPACK_GENERATOR "DEB")
+
+# Runtime package metadata
+execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE DEB_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# general package metadata
+set(CPACK_DEBIAN_PACKAGE_NAME "cuOpt")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Nvidia")
+set(CPACK_PACKAGE_FILE_NAME "cuOpt_${CPACK_PACKAGE_VERSION}_${DEB_ARCH}")
+
+# runtime package metadata
+set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "cuOpt runtime components (binaries and shared libraries)")
+set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "cuOpt Runtime")
+set(CPACK_COMPONENT_RUNTIME_GROUP "Runtime")
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_MAINTAINER "NVIDIA")
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "cuopt")
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_FILE_NAME "cuopt_${PROJECT_VERSION}_${DEB_ARCH}")
+
+# Dev package metadata
+set(CPACK_COMPONENT_DEV_DESCRIPTION "cuOpt development files (headers, symlinks, etc.)")
+set(CPACK_COMPONENT_DEV_DISPLAY_NAME "cuOpt Development")
+set(CPACK_COMPONENT_DEV_GROUP "Development")
+set(CPACK_DEBIAN_DEV_PACKAGE_MAINTAINER "NVIDIA")
+set(CPACK_DEBIAN_DEV_PACKAGE_NAME "cuopt-dev")
+set(CPACK_DEBIAN_DEV_PACKAGE_FILE_NAME "cuopt-dev_${PROJECT_VERSION}_${DEB_ARCH}")
+
+# MUST BE THE LAST ITEM IN THE CMAKE FILE!!!
+include(CPack)


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
Adds changes to the top level cmake_lists.txt to enable cpack creation of .deb files. In order to create the runtime and develop .deb files you will need to:
1) Build cuOpt
2) Navigate to cpp/build
3) run  cpack -G DEB

This creates two .deb files for the architecture of the machine that cuOpt is built on. 
For example: `cuOpt_25.08.0_amd64-Development.deb` and `cuOpt_25.08.0_amd64-Runtime.deb`

The runtime deb package contains the cuopt CLI, the mps reader.so and the cuopt.so.
The cuopt_CLI is installed in the `/usr/local/bin` directory
The .so files are installed in the `/usr/local/lib` directory

The development deb package contains the mps reader.so, the cuopt.so and the header files for the project all of which are installed in `/usr/local/lib` in a standard fashion. 

The headers are in `/usr/local/lib/cuopt`

Note: There are items in the deb package creation that I took the liberty to fill, some of them may need changes. 
Specifically these two lines:
`set(CPACK_DEBIAN_DEV_PACKAGE_MAINTAINER "NVIDIA")`
`set(CPACK_DEBIAN_RUNTIME_PACKAGE_MAINTAINER "NVIDIA")`
I assumed that is how you'd like the maintainer referenced.

Additionally the deb packages do not correctly reference their dependencies yet, i'm happy to follow up with that work if this looks likely to be merged.

## Issue
#189 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing 
   - [ ] New or existing tests cover these changes (Not added for the cmake changes)
   - [ ] Added tests (Compiling and deb installation works, unsure how you'd like a test for this)
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation ( Happy to add the documentation just need to pointed to where you'd like the cpack instructions)
   - [ ] NA
