### PR TITLE
Fix logging levels

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -96,12 +96,9 @@ set(LIBCUOPT_LOGGING_LEVEL
   CACHE STRING "Choose the logging level."
 )
 set_property(
-  CACHE LIBCUOPT_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL"
-                                       "OFF"
+  CACHE LIBCUOPT_LOGGING_LEVEL PROPERTY STRINGS "OFF" "CRITICAL" "ERROR"  "WARN" "INFO" "DEBUG" "TRACE"                      
 )
 message(VERBOSE "CUOPT: LIBCUOPT_LOGGING_LEVEL = '${LIBCUOPT_LOGGING_LEVEL}'.")
-
-#add_compile_definitions(CUOPT_LOG_ACTIVE_LEVEL=CUOPT_LOG_LEVEL_${LIBCUOPT_LOGGING_LEVEL})
 
 message("-- Building with logging level = ${LIBCUOPT_LOGGING_LEVEL}")
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -96,8 +96,8 @@ set(LIBCUOPT_LOGGING_LEVEL
   CACHE STRING "Choose the logging level."
 )
 set_property(
-  CACHE LIBCUOPT_LOGGING_LEVEL PROPERTY STRINGS "OFF" "CRITICAL" "ERROR"  "WARN" "INFO" "DEBUG" "TRACE"                      
-)
+  CACHE LIBCUOPT_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL"
+                                       "OFF")
 message(VERBOSE "CUOPT: LIBCUOPT_LOGGING_LEVEL = '${LIBCUOPT_LOGGING_LEVEL}'.")
 
 message("-- Building with logging level = ${LIBCUOPT_LOGGING_LEVEL}")

--- a/cpp/src/linear_programming/utilities/logger_init.hpp
+++ b/cpp/src/linear_programming/utilities/logger_init.hpp
@@ -37,7 +37,11 @@ class init_logger_t {
       // TODO save the defaul sink and restore it
       cuopt::default_logger().sinks().push_back(
         std::make_shared<rapids_logger::basic_file_sink_mt>(log_file, true));
+#if CUOPT_LOG_ACTIVE_LEVEL >= RAPIDS_LOGGER_LOG_LEVEL_INFO
       cuopt::default_logger().set_pattern("%v");
+#else
+      cuopt::default_logger().set_pattern(cuopt::default_pattern());
+#endif
       cuopt::default_logger().flush_on(rapids_logger::level_enum::info);
     }
   }


### PR DESCRIPTION
## Description

This fixes an issue of formatting when writing to a log file, it was always writing with the default format regardless of the log level. Whereas, for builds on debug and higher levels we want timestamps.