### PR TITLE
Fix: Prevent Github language statistics from mistaking MPS files as JetBrains related

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mps linguist-detectable=false


### PR DESCRIPTION
Github relies on github-linguist internally for its language statistics, which incorrectly pick up our .mps datasets as JetBrains MPS related files. 
This PR adds a `.gitattributes` file to tell github-linguist to ignore *.mps files.