### PR TITLE
Mention GAMS and GAMSPy in third-party modeling languages page in documentation

### DIFF
--- a/docs/cuopt/source/introduction.rst
+++ b/docs/cuopt/source/introduction.rst
@@ -120,6 +120,7 @@ cuOpt supports the following APIs:
    - `Routing (TSP, VRP, and PDP) - Server <cuopt-server/quick-start.html>`_
 - Third-party modeling languages
    - `AMPL <https://www.ampl.com/>`_
+   - `GAMS <https://www.gams.com/>`_
    - `PuLP <https://pypi.org/project/PuLP/>`_
 
 

--- a/docs/cuopt/source/lp-features.rst
+++ b/docs/cuopt/source/lp-features.rst
@@ -11,6 +11,7 @@ The LP solver can be accessed in the following ways:
 
   Supported modeling languages:
    -  AMPL
+   -  GAMS
    -  PuLP 
 
 - **C API**: A native C API that provides direct low-level access to cuOpt's LP capabilities, enabling integration into any application or system that can interface with C.

--- a/docs/cuopt/source/milp-features.rst
+++ b/docs/cuopt/source/milp-features.rst
@@ -11,7 +11,8 @@ The MILP solver can be accessed in the following ways:
 
   Currently supported solvers:
    - AMPL
-   - PuLP 
+   - GAMS
+   - PuLP
 
 - **C API**: A native C API that provides direct low-level access to cuOpt's MILP solver, enabling integration into any application or system that can interface with C.
 

--- a/docs/cuopt/source/thirdparty_modeling_languages/index.rst
+++ b/docs/cuopt/source/thirdparty_modeling_languages/index.rst
@@ -10,6 +10,12 @@ AMPL Support
 AMPL can be used with near zero code changes: simply switch to cuOpt as a solver to solve linear and mixed-integer programming problems. Please refer to the `AMPL documentation <https://www.ampl.com/>`_ for more information. Also, see the example notebook in the `colab <https://colab.research.google.com/drive/1eEQik_pae4g_tJQ61QJFlO1fFBXazpBr?usp=sharing>`_.
 
 --------------------------
+GAMS and GAMSPy Support
+--------------------------
+
+GAMS and GAMSPy models can be used with near zero code changes: simply switch to cuOpt as a solver to solve linear and mixed-integer programming problems. Please refer to the `GAMS cuOpt link repository <https://github.com/GAMS-dev/cuoptlink-builder>`_ for more information. Also, see the example notebook in the `cuopt-examples <https://github.com/NVIDIA/cuopt-examples>`_ repository.
+
+--------------------------
 PuLP Support
 --------------------------
 

--- a/docs/cuopt/source/thirdparty_modeling_languages/index.rst
+++ b/docs/cuopt/source/thirdparty_modeling_languages/index.rst
@@ -13,7 +13,7 @@ AMPL can be used with near zero code changes: simply switch to cuOpt as a solver
 GAMS and GAMSPy Support
 --------------------------
 
-GAMS and GAMSPy models can be used with near zero code changes: simply switch to cuOpt as a solver to solve linear and mixed-integer programming problems. Please refer to the `GAMS cuOpt link repository <https://github.com/GAMS-dev/cuoptlink-builder>`_ for more information. Also, see the example notebook in the `cuopt-examples <https://github.com/NVIDIA/cuopt-examples>`_ repository.
+GAMS and GAMSPy models can be used with near zero code changes after setting up the solver link: simply switch to cuOpt as a solver to solve linear and mixed-integer programming problems (e.g. ``gams trnsport lp=cuopt``). Please refer to the `GAMS cuOpt link repository <https://github.com/GAMS-dev/cuoptlink-builder>`_ for more information on how to setup GAMS and GAMSPy for cuOpt. Also, see the example notebook in the `cuopt-examples <https://github.com/NVIDIA/cuopt-examples>`_ repository.
 
 --------------------------
 PuLP Support


### PR DESCRIPTION
## Description

This PR adds a mention of the GAMS and GAMSPy solver link for cuOpt.

I created this as a draft, as the PR has some prerequisites:
- The repository for the solver link [cuoptlink-builder](https://github.com/GAMS-dev/cuoptlink-builder) must be set to public beforehand and this will be timed with the publication of a GAMS blog article on the link.
- A [counterpart PR](https://github.com/NVIDIA/cuopt-examples/pull/71) for the [cuopt-examples](https://github.com/NVIDIA/cuopt-examples) repository should ideally be merged shortly before as it is mentioned here.

## Issue

Part of resolving #188