### PR TITLE
Bump actions/checkout in nightly.yaml to v4

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
         include:
           - cuopt_version: "25.08"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Trigger Pipeline
         env:
           GH_TOKEN: ${{ github.token }}
@@ -61,7 +61,7 @@ jobs:
         include:
           - cuopt_version: "25.08"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Trigger Test
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description
Bumps the version of actions/checkout in nightly.yaml to the latest, v4 - https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
