### PR TITLE
Unset NDEBUG in cmake in assert mode

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -134,6 +134,12 @@ elseif(CMAKE_CUDA_LINEINFO)
   set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
+# Undefine NDEBUG if assert mode is on
+if(DEFINE_ASSERT)
+  message(STATUS "Undefining NDEBUG with assert mode enabled")
+  add_definitions(-UNDEBUG)
+endif()
+
 
 # ##################################################################################################
 # - find CPM based dependencies  ------------------------------------------------------------------

--- a/cpp/src/mip/diversity/assignment_hash_map.cu
+++ b/cpp/src/mip/diversity/assignment_hash_map.cu
@@ -97,7 +97,7 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
   hash_solution_kernel<i_t, f_t, TPB>
     <<<(integer_assignment.size() + TPB - 1) / TPB, TPB, 0, solution.handle_ptr->get_stream()>>>(
       cuopt::make_span(integer_assignment), cuopt::make_span(reduction_buffer));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
   // Get the number of blocks used in the hash_solution_kernel
   int num_blocks = (integer_assignment.size() + TPB - 1) / TPB;
 

--- a/cpp/src/mip/solution/solution.cu
+++ b/cpp/src/mip/solution/solution.cu
@@ -541,6 +541,11 @@ f_t solution_t<i_t, f_t>::compute_max_int_violation()
 template <typename i_t, typename f_t>
 f_t solution_t<i_t, f_t>::compute_max_variable_violation()
 {
+  cuopt_assert(problem_ptr->n_variables == assignment.size(), "Size mismatch");
+  cuopt_assert(problem_ptr->n_variables == problem_ptr->variable_lower_bounds.size(),
+               "Size mismatch");
+  cuopt_assert(problem_ptr->n_variables == problem_ptr->variable_upper_bounds.size(),
+               "Size mismatch");
   return thrust::transform_reduce(
     handle_ptr->get_thrust_policy(),
     thrust::make_counting_iterator(0),

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -23,7 +23,6 @@
 // 2) medium
 // 3) heavy
 #ifdef ASSERT_MODE
-#undef NDEBUG
 #include <cassert>
 #define cuopt_assert(val, msg) assert(val&& msg)
 #define cuopt_func_call(func)  func;

--- a/cpp/tests/mip/bounds_standardization_test.cu
+++ b/cpp/tests/mip/bounds_standardization_test.cu
@@ -71,6 +71,7 @@ void test_bounds_standardization_test(std::string test_instance)
   init_handler(op_problem.get_handle_ptr());
   // run the problem constructor of MIP, so that we do bounds standardization
   detail::problem_t<int, double> standardized_problem(op_problem);
+  detail::problem_t<int, double> original_problem(op_problem);
   standardized_problem.preprocess_problem();
   detail::trivial_presolve(standardized_problem);
   detail::solution_t<int, double> solution_1(standardized_problem);
@@ -88,6 +89,7 @@ void test_bounds_standardization_test(std::string test_instance)
   // only consider the pdlp results
   EXPECT_TRUE(sol_1_feasible);
   standardized_problem.post_process_solution(solution_1);
+  solution_1.problem_ptr = &original_problem;
   auto optimization_prob_solution =
     solution_1.get_solution(sol_1_feasible, solver_stats_t<int, double>{});
   test_objective_sanity(problem,

--- a/cpp/tests/mip/elim_var_remap_test.cu
+++ b/cpp/tests/mip/elim_var_remap_test.cu
@@ -154,6 +154,7 @@ void test_elim_var_solution(std::string test_instance)
   init_handler(op_problem.get_handle_ptr());
   // run the problem constructor of MIP, so that we do bounds standardization
   detail::problem_t<int, double> standardized_problem(op_problem);
+  detail::problem_t<int, double> original_problem(op_problem);
   standardized_problem.preprocess_problem();
   trivial_presolve(standardized_problem);
   detail::problem_t<int, double> sub_problem(standardized_problem);
@@ -171,7 +172,8 @@ void test_elim_var_solution(std::string test_instance)
   bool sol_1_feasible = (int)result_1.get_termination_status() == CUOPT_TERIMINATION_STATUS_OPTIMAL;
   EXPECT_EQ((int)result_1.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
   standardized_problem.post_process_solution(solution_1);
-  auto opt_sol_1 = solution_1.get_solution(sol_1_feasible, solver_stats_t<int, double>{});
+  solution_1.problem_ptr = &original_problem;
+  auto opt_sol_1         = solution_1.get_solution(sol_1_feasible, solver_stats_t<int, double>{});
   test_objective_sanity(
     mps_problem, opt_sol_1.get_solution(), opt_sol_1.get_objective_value(), 1e-3);
   test_constraint_sanity_per_row(
@@ -198,7 +200,8 @@ void test_elim_var_solution(std::string test_instance)
   bool sol_2_feasible = (int)result_2.get_termination_status() == CUOPT_TERIMINATION_STATUS_OPTIMAL;
   EXPECT_EQ((int)result_2.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
   sub_problem.post_process_solution(solution_2);
-  auto opt_sol_2 = solution_2.get_solution(sol_2_feasible, solver_stats_t<int, double>{});
+  solution_2.problem_ptr = &original_problem;
+  auto opt_sol_2         = solution_2.get_solution(sol_2_feasible, solver_stats_t<int, double>{});
   test_objective_sanity(
     mps_problem, opt_sol_2.get_solution(), opt_sol_2.get_objective_value(), 1e-3);
   test_constraint_sanity_per_row(


### PR DESCRIPTION
Raft defines `RAFT_CHECK_CUDA` depending on if we run in release/Debug mode https://github.com/rapidsai/raft/blob/branch-25.06/cpp/include/raft/util/cuda_rt_essentials.hpp#L78-L82.
In cuopt we have a special mode "assert" that undefines `NDEBUG` to run with optimizations but still enable runtime checks. https://github.com/rapidsai/raft/blob/branch-25.06/cpp/include/raft/util/cuda_rt_essentials.hpp#L78-L82

The first version of `RAFT_CHECK_CUDA` uses the stream argument therefore in debug mode and assert mode we should catch that error. However unsetting `NDEBUG` in our header results in `NDEBUG` being undefined in cuopt but still defined for our dependencies. So we were calling the wrong implementation of `RAFT_CUDA_CHECK`. To undefine `NDEBUG` in both cuopt and our dependencies we have to do it through cmake.
This catches the compile error.

Closes: https://github.com/NVIDIA/cuopt/issues/247