### PR TITLE
Bump libcuopt size for wheel since we have added papilo

### DIFF
--- a/python/libcuopt/pyproject.toml
+++ b/python/libcuopt/pyproject.toml
@@ -66,7 +66,7 @@ select = [
 ]
 # PyPI limit is 700 MiB, fail CI before we get too close to that
 # 11.X size is 300M compressed and 12.x size is 600M compressed
-max_allowed_size_compressed = '700M'
+max_allowed_size_compressed = '745M'
 
 [project.scripts]
 cuopt_cli = "libcuopt._cli_wrapper:main"


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
Adding papilo and boost to cuOpt wheel increased size of the wheel and needs to bump size restriction for wheel.

## Issue

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
