### PR TITLE
Add maximization support for root node presolve

### DIFF
--- a/cpp/src/linear_programming/solve.cu
+++ b/cpp/src/linear_programming/solve.cu
@@ -591,7 +591,6 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(optimization_problem_t<i_t, f
     double presolve_time = 0.0;
     std::unique_ptr<detail::third_party_presolve_t<i_t, f_t>> presolver;
     auto run_presolve = settings.presolve;
-    run_presolve      = run_presolve && op_problem.get_sense() == false;
     run_presolve = run_presolve && settings.get_pdlp_warm_start_data().total_pdlp_iterations_ == -1;
     if (!run_presolve) { CUOPT_LOG_INFO("Presolve is disabled, skipping"); }
 

--- a/cpp/src/mip/problem/problem_helpers.cuh
+++ b/cpp/src/mip/problem/problem_helpers.cuh
@@ -129,12 +129,14 @@ static void convert_to_maximization_problem(detail::problem_t<i_t, f_t>& op_prob
 {
   raft::common::nvtx::range scope("convert_to_maximization_problem");
 
-  // Negate objective coefficient
-  raft::linalg::unaryOp(op_problem.objective_coefficients.data(),
-                        op_problem.objective_coefficients.data(),
-                        op_problem.objective_coefficients.size(),
-                        detail::negate<f_t>(),
-                        op_problem.handle_ptr->get_stream());
+  if (op_problem.objective_coefficients.size()) {
+    // Negate objective coefficient
+    raft::linalg::unaryOp(op_problem.objective_coefficients.data(),
+                          op_problem.objective_coefficients.data(),
+                          op_problem.objective_coefficients.size(),
+                          detail::negate<f_t>(),
+                          op_problem.handle_ptr->get_stream());
+  }
   // Negate objective scaling factor and objective offset so that primal / dual stay same sign after
   // negating objective coeffs
   op_problem.presolve_data.objective_scaling_factor =

--- a/cpp/src/mip/solve.cu
+++ b/cpp/src/mip/solve.cu
@@ -183,7 +183,6 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
     detail::problem_t<i_t, f_t> problem(op_problem, settings.get_tolerances());
 
     auto run_presolve = settings.presolve;
-    run_presolve      = run_presolve && op_problem.get_sense() == false;
     run_presolve      = run_presolve && settings.get_mip_callbacks().empty();
 
     if (!run_presolve) { CUOPT_LOG_INFO("Presolve is disabled, skipping"); }


### PR DESCRIPTION
Currently maximization problem aren't presolved by Papilo.
This PR updates obj coefficients and resets the sense when building op_problem from papilo problem.
Conversions of obj coefficients are needed to validate post solve checks.
The conversion in problem_t constructor is kept for the case presolve is disabled.