### PR TITLE
Make infeasibility checks consistent between the main solver and presolver

### DIFF
--- a/cpp/src/linear_programming/solve.cu
+++ b/cpp/src/linear_programming/solve.cu
@@ -604,6 +604,7 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(optimization_problem_t<i_t, f
         presolver->apply(op_problem,
                          cuopt::linear_programming::problem_category_t::LP,
                          settings.tolerances.absolute_primal_tolerance,
+                         settings.tolerances.relative_primal_tolerance,
                          presolve_time_limit);
       if (!feasible) {
         return optimization_problem_solution_t<i_t, f_t>(

--- a/cpp/src/mip/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip/presolve/third_party_presolve.cpp
@@ -289,11 +289,20 @@ template <typename f_t>
 void set_presolve_options(papilo::Presolve<f_t>& presolver,
                           problem_category_t category,
                           f_t absolute_tolerance,
+                          f_t relative_tolerance,
                           double time_limit)
 {
-  presolver.getPresolveOptions().tlim    = time_limit;
-  presolver.getPresolveOptions().epsilon = absolute_tolerance;
-  presolver.getPresolveOptions().feastol = absolute_tolerance;
+  presolver.getPresolveOptions().tlim = time_limit;
+
+  if (category == problem_category_t::LP) {
+    presolver.getPresolveOptions().useabsfeas = false;
+    presolver.getPresolveOptions().feastol    = relative_tolerance;
+    presolver.getPresolveOptions().epsilon    = absolute_tolerance;
+  } else if (category == problem_category_t::MIP || category == problem_category_t::IP) {
+    presolver.getPresolveOptions().useabsfeas = true;
+    presolver.getPresolveOptions().feastol    = absolute_tolerance;
+    presolver.getPresolveOptions().epsilon    = absolute_tolerance;
+  }
 }
 
 template <typename i_t, typename f_t>
@@ -301,6 +310,7 @@ std::pair<optimization_problem_t<i_t, f_t>, bool> third_party_presolve_t<i_t, f_
   optimization_problem_t<i_t, f_t> const& op_problem,
   problem_category_t category,
   f_t absolute_tolerance,
+  f_t relative_tolerance,
   double time_limit)
 {
   cuopt_expects(
@@ -316,7 +326,8 @@ std::pair<optimization_problem_t<i_t, f_t>, bool> third_party_presolve_t<i_t, f_
 
   papilo::Presolve<f_t> presolver;
   set_presolve_methods<f_t>(presolver, category);
-  set_presolve_options<f_t>(presolver, category, absolute_tolerance, time_limit);
+  set_presolve_options<f_t>(
+    presolver, category, absolute_tolerance, relative_tolerance, time_limit);
 
   // Disable papilo logs
   presolver.setVerbosityLevel(papilo::VerbosityLevel::kQuiet);

--- a/cpp/src/mip/presolve/third_party_presolve.hpp
+++ b/cpp/src/mip/presolve/third_party_presolve.hpp
@@ -30,6 +30,7 @@ class third_party_presolve_t {
     optimization_problem_t<i_t, f_t> const& op_problem,
     problem_category_t category,
     f_t absolute_tolerance,
+    f_t relative_tolerance,
     double time_limit);
 
   void undo(rmm::device_uvector<f_t>& primal_solution,

--- a/cpp/src/mip/solve.cu
+++ b/cpp/src/mip/solve.cu
@@ -197,6 +197,7 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
         presolver->apply(op_problem,
                          cuopt::linear_programming::problem_category_t::MIP,
                          settings.tolerances.absolute_tolerance,
+                         settings.tolerances.relative_tolerance,
                          presolve_time_limit);
       if (!feasible) {
         return mip_solution_t<i_t, f_t>(mip_termination_status_t::Infeasible,

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -57,7 +57,11 @@ TEST_P(TimeLimitTestFixture, time_limit)
                            method),
             CUOPT_SUCCESS);
   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
-  EXPECT_NEAR(solve_time, target_solve_time, 1.0);
+
+  // Dual simplex is spending some time for factorizing the basis, and this computation does not
+  // check for time limit
+  double excess_allowed_time = 2.0;
+  EXPECT_NEAR(solve_time, target_solve_time, excess_allowed_time);
 }
 INSTANTIATE_TEST_SUITE_P(
   c_api,


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

On the LP benchmark tests, while PDLP and dual simplex stop at a feasible solution, the post solve fails because of infeasibility.  This is because of the way the tolerances are handled. 

- The presolver uses absolute criteria while the LP solver uses relative criteria.  Now, we turn off the absolute criteria for LP problems keep it only for MIP and IP problems
- The default tolerance in the presolver is 1e-6, now we pass the tolerance used by the solver to presolver

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
