### PR TITLE
Fix initial solution accepted index update in generate_initial()

### DIFF
--- a/cpp/src/routing/diversity/diverse_solver.hpp
+++ b/cpp/src/routing/diversity/diverse_solver.hpp
@@ -865,9 +865,9 @@ struct solve {
           temp_pair.first = injection_info.solutions[next_injection];
           if (!p->has_vehicle_fixed_costs()) {
             auto injection_it = next_injection;
-            while (injection_it < injection_info.n_sol &&
+            while (injection_it < injection_info.n_sol-1 &&
                    temp_pair.first.sol.get_n_routes() > target_vehicles_) {
-              temp_pair.first = injection_info.solutions[injection_it++];
+              temp_pair.first = injection_info.solutions[++injection_it];
             }
             next_injection = injection_it;
           }


### PR DESCRIPTION
## Description

Fix index handling when selecting initial solutions in `generate_initial()`.

- Adjust while-loop bound from `injection_it < n_sol` to `injection_it < n_sol - 1` to prevent advancing past the last valid index.
- Change candidate selection to use pre-increment (`++injection_it`) when assigning to `temp_pair.first`, ensuring the selected solution and `next_injection` remain aligned.

After the loop, next_injection now points to the same candidate stored in `temp_pair.first`, preventing incorrect updates to accepted.

## Issue
Closes #338
