### PR TITLE
DO NOT MERGE

### DIFF
--- a/cpp/src/mip/presolve/load_balanced_bounds_presolve_helpers.cuh
+++ b/cpp/src/mip/presolve/load_balanced_bounds_presolve_helpers.cuh
@@ -76,6 +76,7 @@ struct heavy_vertex_meta_t {
 
   __device__ __forceinline__ void operator()(i_t id) const
   {
+    asm("trap;");
     vertex_id[offsets[id]] = id;
     if (id != 0) {
       pseudo_block_id[offsets[id]] = offsets[id - 1] - offsets[id] + 1;


### PR DESCRIPTION
This commits adds a `asm("trap;")` instruction in the same line PR #344 does an `assert(false)`.

The two PRs should fail the same tests if assertions are enabled in the CI.

Please run the CIs for this PR: it will settle the discussion about asserts on CI on issue #332.