### PR TITLE
[DRAFT] Fix high GPU memory usage

### DIFF
--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -28,7 +28,10 @@
 #include <raft/core/handle.hpp>
 
 #include <rmm/mr/device/cuda_async_memory_resource.hpp>
+#include <rmm/mr/device/limiting_resource_adaptor.hpp>
+#include <rmm/mr/device/logging_resource_adaptor.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/device/tracking_resource_adaptor.hpp>
 
 #include <rmm/mr/device/owning_wrapper.hpp>
 
@@ -256,7 +259,9 @@ void run_single_file_mp(std::string file_path,
 {
   std::cout << "running file " << file_path << " on gpu : " << device << std::endl;
   auto memory_resource = make_async();
-  rmm::mr::set_current_device_resource(memory_resource.get());
+  auto limiting_adaptor =
+    rmm::mr::limiting_resource_adaptor(memory_resource.get(), 6ULL * 1024ULL * 1024ULL * 1024ULL);
+  rmm::mr::set_current_device_resource(&limiting_adaptor);
   int sol_found = run_single_file(file_path,
                                   device,
                                   batch_id,
@@ -340,6 +345,15 @@ int main(int argc, char* argv[])
     .scan<'g', double>()
     .default_value(std::numeric_limits<double>::max());
 
+  program.add_argument("--memory-limit")
+    .help("memory limit in MB")
+    .scan<'g', double>()
+    .default_value(0);
+
+  program.add_argument("--track-allocations")
+    .help("track allocations (t/f)")
+    .default_value(std::string("f"));
+
   // Parse arguments
   try {
     program.parse_args(argc, argv);
@@ -362,10 +376,12 @@ int main(int argc, char* argv[])
   std::string result_file;
   int batch_num = -1;
 
-  bool heuristics_only = program.get<std::string>("--heuristics-only")[0] == 't';
-  int num_cpu_threads  = program.get<int>("--num-cpu-threads");
-  bool write_log_file  = program.get<std::string>("--write-log-file")[0] == 't';
-  bool log_to_console  = program.get<std::string>("--log-to-console")[0] == 't';
+  bool heuristics_only   = program.get<std::string>("--heuristics-only")[0] == 't';
+  int num_cpu_threads    = program.get<int>("--num-cpu-threads");
+  bool write_log_file    = program.get<std::string>("--write-log-file")[0] == 't';
+  bool log_to_console    = program.get<std::string>("--log-to-console")[0] == 't';
+  double memory_limit    = program.get<double>("--memory-limit");
+  bool track_allocations = program.get<std::string>("--track-allocations")[0] == 't';
 
   if (program.is_used("--out-dir")) {
     out_dir     = program.get<std::string>("--out-dir");
@@ -469,7 +485,17 @@ int main(int argc, char* argv[])
     merge_result_files(out_dir, result_file, n_gpus, batch_num);
   } else {
     auto memory_resource = make_async();
-    rmm::mr::set_current_device_resource(memory_resource.get());
+    if (memory_limit > 0) {
+      auto limiting_adaptor =
+        rmm::mr::limiting_resource_adaptor(memory_resource.get(), memory_limit * 1024ULL * 1024ULL);
+      rmm::mr::set_current_device_resource(&limiting_adaptor);
+    } else if (track_allocations) {
+      rmm::mr::tracking_resource_adaptor tracking_adaptor(memory_resource.get(),
+                                                          /*capture_stacks=*/true);
+      rmm::mr::set_current_device_resource(&tracking_adaptor);
+    } else {
+      rmm::mr::set_current_device_resource(memory_resource.get());
+    }
     run_single_file(path,
                     0,
                     0,

--- a/cpp/src/mip/problem/problem.cu
+++ b/cpp/src/mip/problem/problem.cu
@@ -21,6 +21,7 @@
 #include "problem_kernels.cuh"
 
 #include <utilities/copy_helpers.hpp>
+#include <utilities/cuda_helpers.cuh>
 #include <utilities/macros.cuh>
 
 #include <linear_programming/utils.cuh>
@@ -810,16 +811,21 @@ void problem_t<i_t, f_t>::compute_related_variables(double time_limit)
 
   handle_ptr->sync_stream();
 
+  // previously used constants were based on 40GB of memory. Scale accordingly on smaller GPUs
+  // We can't rely on querying free memory or allocation try/catch
+  // since this would break determinism guarantees (GPU may be shared by other processes)
+  f_t size_factor = std::min(1.0, cuopt::get_device_memory_size() / 1e9 / 40.0);
+
   // TODO: determine optimal number of slices based on available GPU memory? This used to be 2e9 /
   // n_variables
-  i_t max_slice_size = 6e8 / n_variables;
+  i_t max_slice_size = 6e8 * size_factor / n_variables;
 
   rmm::device_uvector<i_t> varmap(max_slice_size * n_variables, handle_ptr->get_stream());
   rmm::device_uvector<i_t> offsets(max_slice_size * n_variables, handle_ptr->get_stream());
 
   related_variables.resize(0, handle_ptr->get_stream());
   // TODO: this used to be 1e8
-  related_variables.reserve(1e8, handle_ptr->get_stream());  // reserve space
+  related_variables.reserve(1e8 * size_factor, handle_ptr->get_stream());  // reserve space
   related_variables_offsets.resize(n_variables + 1, handle_ptr->get_stream());
   related_variables_offsets.set_element_to_zero_async(0, handle_ptr->get_stream());
 
@@ -863,7 +869,7 @@ void problem_t<i_t, f_t>::compute_related_variables(double time_limit)
     auto current_time = std::chrono::high_resolution_clock::now();
     // if the related variable array would wind up being too large for available memory, abort
     // TODO this used to be 1e9
-    if (related_variables.size() > 1e9 ||
+    if (related_variables.size() > 1e9 * size_factor ||
         std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count() >
           time_limit) {
       CUOPT_LOG_DEBUG(

--- a/cpp/src/mip/solve.cu
+++ b/cpp/src/mip/solve.cu
@@ -267,12 +267,13 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
   } catch (const cuopt::logic_error& e) {
     CUOPT_LOG_ERROR("Error in solve_mip: %s", e.what());
     return mip_solution_t<i_t, f_t>{e, op_problem.get_handle_ptr()->get_stream()};
-  } catch (const std::bad_alloc& e) {
-    CUOPT_LOG_ERROR("Error in solve_mip: %s", e.what());
-    return mip_solution_t<i_t, f_t>{
-      cuopt::logic_error("Memory allocation failed", cuopt::error_type_t::RuntimeError),
-      op_problem.get_handle_ptr()->get_stream()};
   }
+  // catch (const std::bad_alloc& e) {
+  //   CUOPT_LOG_ERROR("Error in solve_mip: %s", e.what());
+  //   return mip_solution_t<i_t, f_t>{
+  //     cuopt::logic_error("Memory allocation failed", cuopt::error_type_t::RuntimeError),
+  //     op_problem.get_handle_ptr()->get_stream()};
+  // }
 }
 
 template <typename i_t, typename f_t>


### PR DESCRIPTION
Addresses https://github.com/NVIDIA/cuopt/issues/349

compute_related_variables was heuristically allocating memory based on A100/H100 with >=40GB of VRAM.
This is now automatically adjusted based on the total VRAM of the device

A command-line option has also been added to solve_MPS_file to specify device memory allocation limits for ease of testing.