### PR TITLE
Enable singleton stuffing and use papilo default params

### DIFF
--- a/cpp/src/mip/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip/presolve/third_party_presolve.cpp
@@ -279,8 +279,8 @@ void set_presolve_methods(papilo::Presolve<f_t>& presolver, problem_category_t c
   presolver.addPresolveMethod(uptr(new papilo::SimpleProbing<f_t>()));
   presolver.addPresolveMethod(uptr(new papilo::ParallelRowDetection<f_t>()));
   presolver.addPresolveMethod(uptr(new papilo::ParallelColDetection<f_t>()));
-  // FIXME: Postsolve fails with this method
-  // presolver.addPresolveMethod(uptr(new papilo::SingletonStuffing<f_t>()));
+
+  presolver.addPresolveMethod(uptr(new papilo::SingletonStuffing<f_t>()));
   presolver.addPresolveMethod(uptr(new papilo::DualFix<f_t>()));
   presolver.addPresolveMethod(uptr(new papilo::SimplifyInequalities<f_t>()));
 
@@ -303,16 +303,6 @@ void set_presolve_options(papilo::Presolve<f_t>& presolver,
                           double time_limit)
 {
   presolver.getPresolveOptions().tlim = time_limit;
-
-  if (category == problem_category_t::LP) {
-    presolver.getPresolveOptions().useabsfeas = false;
-    presolver.getPresolveOptions().feastol    = relative_tolerance;
-    presolver.getPresolveOptions().epsilon    = absolute_tolerance;
-  } else if (category == problem_category_t::MIP || category == problem_category_t::IP) {
-    presolver.getPresolveOptions().useabsfeas = true;
-    presolver.getPresolveOptions().feastol    = absolute_tolerance;
-    presolver.getPresolveOptions().epsilon    = absolute_tolerance;
-  }
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip/presolve/third_party_presolve.cpp
@@ -260,7 +260,11 @@ void check_postsolve_status(const papilo::PostsolveStatus& status)
 {
   switch (status) {
     case papilo::PostsolveStatus::kOk: CUOPT_LOG_INFO("Post-solve status:: succeeded"); break;
-    case papilo::PostsolveStatus::kFailed: CUOPT_LOG_INFO("Post-solve status:: failed"); break;
+    case papilo::PostsolveStatus::kFailed:
+      CUOPT_LOG_INFO(
+        "Post-solve status:: Post solved solution violates constraints. This is most likely due to "
+        "different tolerances.");
+      break;
   }
 }
 

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -65,128 +65,126 @@ static bool is_incorrect_objective(double reference, double objective)
   return std::abs((reference - objective) / reference) > 0.01;
 }
 
-// TEST(pdlp_class, run_double)
-// {
-//   const raft::handle_t handle_{};
+TEST(pdlp_class, run_double)
+{
+  const raft::handle_t handle_{};
 
-//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
-//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-//     cuopt::mps_parser::parse_mps<int, double>(path, true);
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-//   auto solver_settings   = pdlp_solver_settings_t<int, double>{};
-//   solver_settings.method = cuopt::linear_programming::method_t::PDLP;
+  auto solver_settings   = pdlp_solver_settings_t<int, double>{};
+  solver_settings.method = cuopt::linear_programming::method_t::PDLP;
 
-//   optimization_problem_solution_t<int, double> solution =
-//     solve_lp(&handle_, op_problem, solver_settings);
-//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-//   EXPECT_FALSE(is_incorrect_objective(
-//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-// }
+  optimization_problem_solution_t<int, double> solution =
+    solve_lp(&handle_, op_problem, solver_settings);
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_FALSE(is_incorrect_objective(
+    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+}
 
-// TEST(pdlp_class, run_double_very_low_accuracy)
-// {
-//   const raft::handle_t handle_{};
+TEST(pdlp_class, run_double_very_low_accuracy)
+{
+  const raft::handle_t handle_{};
 
-//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
-//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-//     cuopt::mps_parser::parse_mps<int, double>(path, true);
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
-//   // With all 0 afiro with return an error
-//   // Setting absolute tolerance to the minimal value of 1e-12 will make it work
-//   settings.tolerances.absolute_dual_tolerance   = settings.minimal_absolute_tolerance;
-//   settings.tolerances.relative_dual_tolerance   = 0.0;
-//   settings.tolerances.absolute_primal_tolerance = settings.minimal_absolute_tolerance;
-//   settings.tolerances.relative_primal_tolerance = 0.0;
-//   settings.tolerances.absolute_gap_tolerance    = settings.minimal_absolute_tolerance;
-//   settings.tolerances.relative_gap_tolerance    = 0.0;
-//   settings.method                               = cuopt::linear_programming::method_t::PDLP;
+  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+  // With all 0 afiro with return an error
+  // Setting absolute tolerance to the minimal value of 1e-12 will make it work
+  settings.tolerances.absolute_dual_tolerance   = settings.minimal_absolute_tolerance;
+  settings.tolerances.relative_dual_tolerance   = 0.0;
+  settings.tolerances.absolute_primal_tolerance = settings.minimal_absolute_tolerance;
+  settings.tolerances.relative_primal_tolerance = 0.0;
+  settings.tolerances.absolute_gap_tolerance    = settings.minimal_absolute_tolerance;
+  settings.tolerances.relative_gap_tolerance    = 0.0;
+  settings.method                               = cuopt::linear_programming::method_t::PDLP;
 
-//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
-//   settings); EXPECT_EQ((int)solution.get_termination_status(),
-//   CUOPT_TERIMINATION_STATUS_OPTIMAL); EXPECT_FALSE(is_incorrect_objective(
-//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-// }
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_FALSE(is_incorrect_objective(
+    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+}
 
-// TEST(pdlp_class, run_double_initial_solution)
-// {
-//   const raft::handle_t handle_{};
+TEST(pdlp_class, run_double_initial_solution)
+{
+  const raft::handle_t handle_{};
 
-//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
-//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-//     cuopt::mps_parser::parse_mps<int, double>(path, true);
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-//   std::vector<double> inital_primal_sol(op_problem.get_n_variables());
-//   std::fill(inital_primal_sol.begin(), inital_primal_sol.end(), 1.0);
-//   op_problem.set_initial_primal_solution(inital_primal_sol.data(), inital_primal_sol.size());
+  std::vector<double> inital_primal_sol(op_problem.get_n_variables());
+  std::fill(inital_primal_sol.begin(), inital_primal_sol.end(), 1.0);
+  op_problem.set_initial_primal_solution(inital_primal_sol.data(), inital_primal_sol.size());
 
-//   auto solver_settings   = pdlp_solver_settings_t<int, double>{};
-//   solver_settings.method = cuopt::linear_programming::method_t::PDLP;
+  auto solver_settings   = pdlp_solver_settings_t<int, double>{};
+  solver_settings.method = cuopt::linear_programming::method_t::PDLP;
 
-//   optimization_problem_solution_t<int, double> solution =
-//     solve_lp(&handle_, op_problem, solver_settings);
-//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-//   EXPECT_FALSE(is_incorrect_objective(
-//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-// }
+  optimization_problem_solution_t<int, double> solution =
+    solve_lp(&handle_, op_problem, solver_settings);
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_FALSE(is_incorrect_objective(
+    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+}
 
-// TEST(pdlp_class, run_iteration_limit)
-// {
-//   const raft::handle_t handle_{};
+TEST(pdlp_class, run_iteration_limit)
+{
+  const raft::handle_t handle_{};
 
-//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
-//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-//     cuopt::mps_parser::parse_mps<int, double>(path, true);
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
 
-//   settings.iteration_limit = 10;
-//   // To make sure it doesn't return before the iteration limit
-//   settings.set_optimality_tolerance(0);
-//   settings.method = cuopt::linear_programming::method_t::PDLP;
+  settings.iteration_limit = 10;
+  // To make sure it doesn't return before the iteration limit
+  settings.set_optimality_tolerance(0);
+  settings.method = cuopt::linear_programming::method_t::PDLP;
 
-//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
-//   settings); EXPECT_EQ((int)solution.get_termination_status(),
-//   CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
-//   // By default we would return all 0, we now return what we currently have so not all 0
-//   EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
-//                               solution.get_primal_solution().begin(),
-//                               solution.get_primal_solution().end(),
-//                               thrust::placeholders::_1 == 0.0));
-// }
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
+  // By default we would return all 0, we now return what we currently have so not all 0
+  EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
+                              solution.get_primal_solution().begin(),
+                              solution.get_primal_solution().end(),
+                              thrust::placeholders::_1 == 0.0));
+}
 
-// TEST(pdlp_class, run_time_limit)
-// {
-//   const raft::handle_t handle_{};
-//   auto path = make_path_absolute("linear_programming/savsched1/savsched1.mps");
-//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-//     cuopt::mps_parser::parse_mps<int, double>(path);
+TEST(pdlp_class, run_time_limit)
+{
+  const raft::handle_t handle_{};
+  auto path = make_path_absolute("linear_programming/savsched1/savsched1.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path);
 
-//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
 
-//   // 200 ms
-//   constexpr double time_limit_seconds = 0.2;
-//   settings.time_limit                 = time_limit_seconds;
-//   // To make sure it doesn't return before the time limit
-//   settings.set_optimality_tolerance(0);
-//   settings.method = cuopt::linear_programming::method_t::PDLP;
+  // 200 ms
+  constexpr double time_limit_seconds = 0.2;
+  settings.time_limit                 = time_limit_seconds;
+  // To make sure it doesn't return before the time limit
+  settings.set_optimality_tolerance(0);
+  settings.method = cuopt::linear_programming::method_t::PDLP;
 
-//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
-//   settings);
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
 
-//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
-//   // By default we would return all 0, we now return what we currently have so not all 0
-//   EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
-//                               solution.get_primal_solution().begin(),
-//                               solution.get_primal_solution().end(),
-//                               thrust::placeholders::_1 == 0.0));
-//   // Check that indeed it didn't run for more than x time
-//   EXPECT_TRUE(solution.get_additional_termination_information().solve_time <
-//               (time_limit_seconds * 5) * 1000);
-// }
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
+  // By default we would return all 0, we now return what we currently have so not all 0
+  EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
+                              solution.get_primal_solution().begin(),
+                              solution.get_primal_solution().end(),
+                              thrust::placeholders::_1 == 0.0));
+  // Check that indeed it didn't run for more than x time
+  EXPECT_TRUE(solution.get_additional_termination_information().solve_time <
+              (time_limit_seconds * 5) * 1000);
+}
 
 TEST(pdlp_class, run_sub_mittleman)
 {

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -65,126 +65,128 @@ static bool is_incorrect_objective(double reference, double objective)
   return std::abs((reference - objective) / reference) > 0.01;
 }
 
-TEST(pdlp_class, run_double)
-{
-  const raft::handle_t handle_{};
+// TEST(pdlp_class, run_double)
+// {
+//   const raft::handle_t handle_{};
 
-  auto path = make_path_absolute("linear_programming/afiro_original.mps");
-  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-    cuopt::mps_parser::parse_mps<int, double>(path, true);
+//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
+//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+//     cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-  auto solver_settings   = pdlp_solver_settings_t<int, double>{};
-  solver_settings.method = cuopt::linear_programming::method_t::PDLP;
+//   auto solver_settings   = pdlp_solver_settings_t<int, double>{};
+//   solver_settings.method = cuopt::linear_programming::method_t::PDLP;
 
-  optimization_problem_solution_t<int, double> solution =
-    solve_lp(&handle_, op_problem, solver_settings);
-  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-  EXPECT_FALSE(is_incorrect_objective(
-    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-}
+//   optimization_problem_solution_t<int, double> solution =
+//     solve_lp(&handle_, op_problem, solver_settings);
+//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+//   EXPECT_FALSE(is_incorrect_objective(
+//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+// }
 
-TEST(pdlp_class, run_double_very_low_accuracy)
-{
-  const raft::handle_t handle_{};
+// TEST(pdlp_class, run_double_very_low_accuracy)
+// {
+//   const raft::handle_t handle_{};
 
-  auto path = make_path_absolute("linear_programming/afiro_original.mps");
-  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-    cuopt::mps_parser::parse_mps<int, double>(path, true);
+//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
+//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+//     cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
-  // With all 0 afiro with return an error
-  // Setting absolute tolerance to the minimal value of 1e-12 will make it work
-  settings.tolerances.absolute_dual_tolerance   = settings.minimal_absolute_tolerance;
-  settings.tolerances.relative_dual_tolerance   = 0.0;
-  settings.tolerances.absolute_primal_tolerance = settings.minimal_absolute_tolerance;
-  settings.tolerances.relative_primal_tolerance = 0.0;
-  settings.tolerances.absolute_gap_tolerance    = settings.minimal_absolute_tolerance;
-  settings.tolerances.relative_gap_tolerance    = 0.0;
-  settings.method                               = cuopt::linear_programming::method_t::PDLP;
+//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+//   // With all 0 afiro with return an error
+//   // Setting absolute tolerance to the minimal value of 1e-12 will make it work
+//   settings.tolerances.absolute_dual_tolerance   = settings.minimal_absolute_tolerance;
+//   settings.tolerances.relative_dual_tolerance   = 0.0;
+//   settings.tolerances.absolute_primal_tolerance = settings.minimal_absolute_tolerance;
+//   settings.tolerances.relative_primal_tolerance = 0.0;
+//   settings.tolerances.absolute_gap_tolerance    = settings.minimal_absolute_tolerance;
+//   settings.tolerances.relative_gap_tolerance    = 0.0;
+//   settings.method                               = cuopt::linear_programming::method_t::PDLP;
 
-  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
-  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-  EXPECT_FALSE(is_incorrect_objective(
-    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-}
+//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
+//   settings); EXPECT_EQ((int)solution.get_termination_status(),
+//   CUOPT_TERIMINATION_STATUS_OPTIMAL); EXPECT_FALSE(is_incorrect_objective(
+//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+// }
 
-TEST(pdlp_class, run_double_initial_solution)
-{
-  const raft::handle_t handle_{};
+// TEST(pdlp_class, run_double_initial_solution)
+// {
+//   const raft::handle_t handle_{};
 
-  auto path = make_path_absolute("linear_programming/afiro_original.mps");
-  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-    cuopt::mps_parser::parse_mps<int, double>(path, true);
+//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
+//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+//     cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-  std::vector<double> inital_primal_sol(op_problem.get_n_variables());
-  std::fill(inital_primal_sol.begin(), inital_primal_sol.end(), 1.0);
-  op_problem.set_initial_primal_solution(inital_primal_sol.data(), inital_primal_sol.size());
+//   std::vector<double> inital_primal_sol(op_problem.get_n_variables());
+//   std::fill(inital_primal_sol.begin(), inital_primal_sol.end(), 1.0);
+//   op_problem.set_initial_primal_solution(inital_primal_sol.data(), inital_primal_sol.size());
 
-  auto solver_settings   = pdlp_solver_settings_t<int, double>{};
-  solver_settings.method = cuopt::linear_programming::method_t::PDLP;
+//   auto solver_settings   = pdlp_solver_settings_t<int, double>{};
+//   solver_settings.method = cuopt::linear_programming::method_t::PDLP;
 
-  optimization_problem_solution_t<int, double> solution =
-    solve_lp(&handle_, op_problem, solver_settings);
-  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-  EXPECT_FALSE(is_incorrect_objective(
-    afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
-}
+//   optimization_problem_solution_t<int, double> solution =
+//     solve_lp(&handle_, op_problem, solver_settings);
+//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+//   EXPECT_FALSE(is_incorrect_objective(
+//     afiro_primal_objective, solution.get_additional_termination_information().primal_objective));
+// }
 
-TEST(pdlp_class, run_iteration_limit)
-{
-  const raft::handle_t handle_{};
+// TEST(pdlp_class, run_iteration_limit)
+// {
+//   const raft::handle_t handle_{};
 
-  auto path = make_path_absolute("linear_programming/afiro_original.mps");
-  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-    cuopt::mps_parser::parse_mps<int, double>(path, true);
+//   auto path = make_path_absolute("linear_programming/afiro_original.mps");
+//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+//     cuopt::mps_parser::parse_mps<int, double>(path, true);
 
-  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
 
-  settings.iteration_limit = 10;
-  // To make sure it doesn't return before the iteration limit
-  settings.set_optimality_tolerance(0);
-  settings.method = cuopt::linear_programming::method_t::PDLP;
+//   settings.iteration_limit = 10;
+//   // To make sure it doesn't return before the iteration limit
+//   settings.set_optimality_tolerance(0);
+//   settings.method = cuopt::linear_programming::method_t::PDLP;
 
-  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
-  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
-  // By default we would return all 0, we now return what we currently have so not all 0
-  EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
-                              solution.get_primal_solution().begin(),
-                              solution.get_primal_solution().end(),
-                              thrust::placeholders::_1 == 0.0));
-}
+//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
+//   settings); EXPECT_EQ((int)solution.get_termination_status(),
+//   CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
+//   // By default we would return all 0, we now return what we currently have so not all 0
+//   EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
+//                               solution.get_primal_solution().begin(),
+//                               solution.get_primal_solution().end(),
+//                               thrust::placeholders::_1 == 0.0));
+// }
 
-TEST(pdlp_class, run_time_limit)
-{
-  const raft::handle_t handle_{};
-  auto path = make_path_absolute("linear_programming/savsched1/savsched1.mps");
-  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
-    cuopt::mps_parser::parse_mps<int, double>(path);
+// TEST(pdlp_class, run_time_limit)
+// {
+//   const raft::handle_t handle_{};
+//   auto path = make_path_absolute("linear_programming/savsched1/savsched1.mps");
+//   cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+//     cuopt::mps_parser::parse_mps<int, double>(path);
 
-  cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
-    cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
+//   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings =
+//     cuopt::linear_programming::pdlp_solver_settings_t<int, double>{};
 
-  // 200 ms
-  constexpr double time_limit_seconds = 0.2;
-  settings.time_limit                 = time_limit_seconds;
-  // To make sure it doesn't return before the time limit
-  settings.set_optimality_tolerance(0);
-  settings.method = cuopt::linear_programming::method_t::PDLP;
+//   // 200 ms
+//   constexpr double time_limit_seconds = 0.2;
+//   settings.time_limit                 = time_limit_seconds;
+//   // To make sure it doesn't return before the time limit
+//   settings.set_optimality_tolerance(0);
+//   settings.method = cuopt::linear_programming::method_t::PDLP;
 
-  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+//   optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem,
+//   settings);
 
-  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
-  // By default we would return all 0, we now return what we currently have so not all 0
-  EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
-                              solution.get_primal_solution().begin(),
-                              solution.get_primal_solution().end(),
-                              thrust::placeholders::_1 == 0.0));
-  // Check that indeed it didn't run for more than x time
-  EXPECT_TRUE(solution.get_additional_termination_information().solve_time <
-              (time_limit_seconds * 5) * 1000);
-}
+//   EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
+//   // By default we would return all 0, we now return what we currently have so not all 0
+//   EXPECT_FALSE(thrust::all_of(handle_.get_thrust_policy(),
+//                               solution.get_primal_solution().begin(),
+//                               solution.get_primal_solution().end(),
+//                               thrust::placeholders::_1 == 0.0));
+//   // Check that indeed it didn't run for more than x time
+//   EXPECT_TRUE(solution.get_additional_termination_information().solve_time <
+//               (time_limit_seconds * 5) * 1000);
+// }
 
 TEST(pdlp_class, run_sub_mittleman)
 {
@@ -219,17 +221,21 @@ TEST(pdlp_class, run_sub_mittleman)
     for (auto solver_mode : solver_mode_list) {
       auto settings             = pdlp_solver_settings_t<int, double>{};
       settings.pdlp_solver_mode = solver_mode;
-      const raft::handle_t handle_{};
-      optimization_problem_solution_t<int, double> solution =
-        solve_lp(&handle_, op_problem, settings);
-      EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
-      EXPECT_FALSE(
-        is_incorrect_objective(expected_objective_value,
-                               solution.get_additional_termination_information().primal_objective));
-      test_objective_sanity(op_problem,
-                            solution.get_primal_solution(),
-                            solution.get_additional_termination_information().primal_objective);
-      test_constraint_sanity(op_problem, solution);
+      for (auto [presolve, epsilon] : {std::pair{true, 1e-1}, std::pair{false, 1e-6}}) {
+        settings.presolve = presolve;
+        const raft::handle_t handle_{};
+        optimization_problem_solution_t<int, double> solution =
+          solve_lp(&handle_, op_problem, settings);
+        EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERIMINATION_STATUS_OPTIMAL);
+        EXPECT_FALSE(is_incorrect_objective(
+          expected_objective_value,
+          solution.get_additional_termination_information().primal_objective));
+        test_objective_sanity(op_problem,
+                              solution.get_primal_solution(),
+                              solution.get_additional_termination_information().primal_objective,
+                              epsilon);
+        test_constraint_sanity(op_problem, solution, epsilon, presolve);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR updates the settings for root node papilo presolve.
We reverted previous changes to instead use default settings from Papilo.
These settings allow us to solve more problems with better performance.
We also enable singleton stuffing which after further testing has no negative impact on accuracy and improves the final reduction.
Regarding post-solve accuracy issues we will be addressing them in a follow up PR.