### PR TITLE
WIP: stabilize nightly builds + tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,15 +24,41 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "sha: full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
+        type: string
+        default: nightly
+  workflow_call:
+    inputs:
+      branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
+        required: true
+        type: string
+      date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
+        required: true
+        type: string
+      sha:
+        description: "sha: full git commit SHA to check out"
+        required: true
+        type: string
+      build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,10 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     shell: bash
     run: |
-      BRANCHES=(
-        branch-25.10
-      )
-      for 
+      MATRIX="
+      - branch: '25.10'
+        sha: "\'$(git ls-remote https://github.com/NVIDIA/cuopt.git refs/heads/branch-25.10 | awk '{print $1}')\'"
+      "
+      echo "date=$(date +%F)" >> ${GITHUB_OUTPUT}
+      echo ""
 
       # latest commit on each branch
       export RAPIDS_SHA="$(git ls-remote ${{ github.repositoryUrl }} refs/heads/${{ }} | awk '{print $1}')"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,52 +5,42 @@ on:
   schedule:
     - cron: "0 5 * * *" # 5am UTC / 1am EST
 
-
-        echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        sha="${{ inputs.sha }}"
-        if [[ "${sha}" == "" ]]; then
-          sha=$(git rev-parse HEAD)
-        fi
-        echo "RAPIDS_SHA=${sha}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        if [[ -n "${{ inputs.build_workflow_name }}" ]]; then
-          echo "RAPIDS_BUILD_WORKFLOW_NAME=${{ inputs.build_workflow_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
-        fi
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - cuopt_version: "25.10"
-jobs:
-  get-run-info:
+  compute-matrix:
+    id: compute-matrix
     runs-on: ubuntu-latest
     shell: bash
     run: |
-      MATRIX="
+      # add more list items here to run nightlies for more branches
+      export CI_MATRIX="
       - branch: '25.10'
-        sha: "\'$(git ls-remote https://github.com/NVIDIA/cuopt.git refs/heads/branch-25.10 | awk '{print $1}')\'"
+        sha: "\'$(git ls-remote ${{ github.repositoryUrl }} refs/heads/branch-25.10 | awk '{print $1}')\'"
       "
-      echo "date=$(date +%F)" >> ${GITHUB_OUTPUT}
-      echo ""
+      MATRIX="$(
+        yq -n -o json 'env(CI_MATRIX)' | \
+      )"
 
-      # latest commit on each branch
-      export RAPIDS_SHA="$(git ls-remote ${{ github.repositoryUrl }} refs/heads/${{ }} | awk '{print $1}')"
+      echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
+      echo "date=$(date +%F)" | tee --append "${GITHUB_OUTPUT}"
   build:
+    needs: [compute-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     uses: ./.github/workflows/build.yaml
     with:
       build_type: nightly
-      branch: branch-${{ matrix.cuopt_version }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
+      branch: ${{ matrix.branch }}
+      date: ${{ needs.compute-matrix.outputs.date }}
+      sha: ${{ matrix.sha }}
   test:
-    needs: build
+    needs: [compute-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     uses: ./.github/workflows/test.yaml
     with:
       build_type: nightly
-      branch: branch-${{ matrix.cuopt_version }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
+      branch: ${{ matrix.branch }}
+      date: ${{ needs.compute-matrix.outputs.date }}
+      sha: ${{ matrix.sha }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,72 +6,49 @@ on:
     - cron: "0 5 * * *" # 5am UTC / 1am EST
 
 
+        echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        sha="${{ inputs.sha }}"
+        if [[ "${sha}" == "" ]]; then
+          sha=$(git rev-parse HEAD)
+        fi
+        echo "RAPIDS_SHA=${sha}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        if [[ -n "${{ inputs.build_workflow_name }}" ]]; then
+          echo "RAPIDS_BUILD_WORKFLOW_NAME=${{ inputs.build_workflow_name }}" | tee --append "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+        fi
+
 jobs:
-  trigger-build:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - cuopt_version: "25.10"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Trigger Pipeline
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          export CUOPT_BRANCH="branch-${{ matrix.cuopt_version }}"
-          export DATE=$(date +%F)
-          export SHA=$(gh api -q '.commit.sha' "repos/nvidia/cuopt/branches/${CUOPT_BRANCH}")
-
-          gh workflow run build.yaml \
-            -f branch="${CUOPT_BRANCH}" \
-            -f sha="${SHA}" \
-            -f date="${DATE}" \
-            -f build_type=nightly
-
-          # Wait a short bit for the workflow to register (optional)
-          sleep 3
-
-          # Get the latest run ID for this workflow on this branch
-          RUN_ID=$(gh run list --workflow=build.yaml --branch="${CUOPT_BRANCH}" --json databaseId --limit 1 | jq -r '.[0].databaseId')
-
-          STATUS=$(gh run view $RUN_ID --json status,conclusion --jq '.status')
-          CONCLUSION=$(gh run view $RUN_ID --json status,conclusion --jq '.conclusion')
-
-          while [[ "$STATUS" != "completed" || "$CONCLUSION" == "null" ]]; do
-            echo "Status: $STATUS, Conclusion: $CONCLUSION — waiting 10 seconds..."
-            sleep 10
-            STATUS=$(gh run view $RUN_ID --json status,conclusion --jq '.status')
-            CONCLUSION=$(gh run view $RUN_ID --json status,conclusion --jq '.conclusion')
-          done
-
-          echo "Workflow run finished with conclusion: $CONCLUSION"
-
-          if [[ "$CONCLUSION" != "success" ]]; then
-            echo "Build did not succeed"
-            exit 1
-          fi
-
-
-  trigger-test:
+jobs:
+  get-run-info:
     runs-on: ubuntu-latest
-    needs: trigger-build
-    strategy:
-      matrix:
-        include:
-          - cuopt_version: "25.10"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Trigger Test
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          export CUOPT_BRANCH="branch-${{ matrix.cuopt_version }}"
-          export DATE=$(date +%F)
-          export SHA=$(gh api -q '.commit.sha' "repos/nvidia/cuopt/branches/${CUOPT_BRANCH}")
+    shell: bash
+    run: |
+      BRANCHES=(
+        branch-25.10
+      )
+      for 
 
-          gh workflow run test.yaml \
-            -f branch=${CUOPT_BRANCH} \
-            -f sha=${SHA} \
-            -f date=${DATE} \
-            -f build_type=nightly
+      # latest commit on each branch
+      export RAPIDS_SHA="$(git ls-remote ${{ github.repositoryUrl }} refs/heads/${{ }} | awk '{print $1}')"
+  build:
+    uses: ./.github/workflows/build.yaml
+    with:
+      build_type: nightly
+      branch: branch-${{ matrix.cuopt_version }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+  test:
+    needs: build
+    uses: ./.github/workflows/test.yaml
+    with:
+      build_type: nightly
+      branch: branch-${{ matrix.cuopt_version }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,15 +19,41 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "sha: full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
+        type: string
+        default: nightly
+  workflow_call:
+    inputs:
+      branch:
+        description: |
+          branch: git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
+        required: true
+        type: string
+      date:
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
+        required: true
+        type: string
+      sha:
+        description: "sha: full git commit SHA to check out"
+        required: true
+        type: string
+      build_type:
+        description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
 


### PR DESCRIPTION
## Description

This project runs nightly builds and tests on a cron schedule:

https://github.com/NVIDIA/cuopt/blob/36a6a1c0edf42cec2cf07c6be3f16531f33515de/.github/workflows/nightly.yaml#L1-L6

Tests need to wait for builds to finish, and that's currently done with some shell scripts that hit the GitHub API, using a mix of `sleep` and polling.

This has sometimes resulted in nightly failures (network errors, timeouts, etc.). This PR proposes reducing the risk of such failures by moving that logic into GitHub Actions configuration directly, specifically:

* making `build.yaml` and `test.yaml` re-usable workflows and having `nightly.yaml` call them with `uses:`
* blocking `test.yaml` until `build.yaml` passes using `needs:`

## Issue

Closes #122 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
