### PR TITLE
Return Infeasible if the user problem contains crossing bounds

### DIFF
--- a/cpp/libmps_parser/src/mps_parser.cpp
+++ b/cpp/libmps_parser/src/mps_parser.cpp
@@ -505,9 +505,12 @@ void mps_parser_t<i_t, f_t>::parse_string(char* buf)
       variable_lower_bounds[i] = 0;
       variable_upper_bounds[i] = 1;
     }
-    mps_parser_expects(variable_lower_bounds[i] <= variable_upper_bounds[i],
-                       error_type_t::ValidationError,
-                       "MPS Parser Internal Error - Please contact cuOpt team");
+    if (variable_lower_bounds[i] > variable_upper_bounds[i]) {
+      printf("WARNING: Variable %d has crossing bounds: %f > %f\n",
+             i,
+             variable_lower_bounds[i],
+             variable_upper_bounds[i]);
+    }
   }
 }
 

--- a/cpp/src/linear_programming/cuopt_c.cpp
+++ b/cpp/src/linear_programming/cuopt_c.cpp
@@ -21,6 +21,7 @@
 #include <cuopt/linear_programming/solve.hpp>
 #include <cuopt/linear_programming/solver_settings.hpp>
 #include <cuopt/logger.hpp>
+#include <linear_programming/utilities/problem_checking.cuh>
 
 #include <mps_parser/parser.hpp>
 
@@ -148,7 +149,11 @@ cuopt_int_t cuOptCreateProblem(cuopt_int_t num_constraints,
         variable_types[j] == CUOPT_CONTINUOUS ? var_t::CONTINUOUS : var_t::INTEGER;
     }
     problem_and_stream->op_problem->set_variable_types(variable_types_host.data(), num_variables);
+    problem_checking_t<cuopt_int_t, cuopt_float_t>::check_problem_representation(
+      *problem_and_stream->op_problem);
     *problem_ptr = static_cast<cuOptOptimizationProblem>(problem_and_stream);
+  } catch (const cuopt::logic_error& e) {
+    return static_cast<cuopt_int_t>(e.get_error_type());
   } catch (const raft::exception& e) {
     return CUOPT_INVALID_ARGUMENT;
   }
@@ -205,7 +210,12 @@ cuopt_int_t cuOptCreateRangedProblem(cuopt_int_t num_constraints,
         variable_types[j] == CUOPT_CONTINUOUS ? var_t::CONTINUOUS : var_t::INTEGER;
     }
     problem_and_stream->op_problem->set_variable_types(variable_types_host.data(), num_variables);
+    problem_checking_t<cuopt_int_t, cuopt_float_t>::check_problem_representation(
+      *problem_and_stream->op_problem);
     *problem_ptr = static_cast<cuOptOptimizationProblem>(problem_and_stream);
+  } catch (const cuopt::logic_error& e) {
+    printf("Error: %s, type %d\n", e.what(), static_cast<cuopt_int_t>(e.get_error_type()));
+    return static_cast<cuopt_int_t>(e.get_error_type());
   } catch (const raft::exception& e) {
     return CUOPT_INVALID_ARGUMENT;
   }

--- a/cpp/src/linear_programming/utilities/problem_checking.cu
+++ b/cpp/src/linear_programming/utilities/problem_checking.cu
@@ -338,6 +338,34 @@ void problem_checking_t<i_t, f_t>::check_unscaled_solution(
   }
 }
 
+template <typename i_t, typename f_t>
+bool problem_checking_t<i_t, f_t>::has_crossing_bounds(
+  const optimization_problem_t<i_t, f_t>& op_problem)
+{
+  // Check if all variable bounds are valid (upper >= lower)
+  bool all_variable_bounds_valid = thrust::all_of(
+    op_problem.get_handle_ptr()->get_thrust_policy(),
+    thrust::make_counting_iterator(0),
+    thrust::make_counting_iterator(0) + op_problem.get_variable_upper_bounds().size(),
+    [upper_bounds = make_span(op_problem.get_variable_upper_bounds()),
+     lower_bounds = make_span(op_problem.get_variable_lower_bounds())] __device__(size_t i) {
+      return upper_bounds[i] >= lower_bounds[i];
+    });
+
+  // Check if all constraint bounds are valid (upper >= lower)
+  bool all_constraint_bounds_valid = thrust::all_of(
+    op_problem.get_handle_ptr()->get_thrust_policy(),
+    thrust::make_counting_iterator(0),
+    thrust::make_counting_iterator(0) + op_problem.get_constraint_upper_bounds().size(),
+    [upper_bounds = make_span(op_problem.get_constraint_upper_bounds()),
+     lower_bounds = make_span(op_problem.get_constraint_lower_bounds())] __device__(size_t i) {
+      return upper_bounds[i] >= lower_bounds[i];
+    });
+
+  // Return true if any bounds are invalid (crossing)
+  return !all_variable_bounds_valid || !all_constraint_bounds_valid;
+}
+
 #define INSTANTIATE(F_TYPE) template class problem_checking_t<int, F_TYPE>;
 
 #if MIP_INSTANTIATE_FLOAT

--- a/cpp/src/linear_programming/utilities/problem_checking.cu
+++ b/cpp/src/linear_programming/utilities/problem_checking.cu
@@ -22,6 +22,8 @@
 #include <mip/mip_constants.hpp>
 #include <utilities/copy_helpers.hpp>
 
+#include <mip/problem/problem.cuh>
+
 #include <thrust/functional.h>
 #include <thrust/logical.h>
 #include <thrust/sort.h>

--- a/cpp/src/linear_programming/utilities/problem_checking.cuh
+++ b/cpp/src/linear_programming/utilities/problem_checking.cuh
@@ -20,9 +20,17 @@
 #include <cuopt/linear_programming/optimization_problem.hpp>
 #include <cuopt/linear_programming/pdlp/solver_settings.hpp>
 
-#include <mip/problem/problem.cuh>
+namespace rmm {
+template <typename T>
+class device_uvector;
+}  // namespace rmm
 
 namespace cuopt::linear_programming {
+
+namespace detail {
+template <typename i_t, typename f_t>
+class problem_t;
+}  // namespace detail
 
 template <typename i_t, typename f_t>
 class problem_checking_t {

--- a/cpp/src/linear_programming/utilities/problem_checking.cuh
+++ b/cpp/src/linear_programming/utilities/problem_checking.cuh
@@ -38,6 +38,7 @@ class problem_checking_t {
   static void check_csr_representation(const optimization_problem_t<i_t, f_t>& op_problem);
   // Check all fields and convert row_types to constraints lower/upper bounds if needed
   static void check_problem_representation(const optimization_problem_t<i_t, f_t>& op_problem);
+  static bool has_crossing_bounds(const optimization_problem_t<i_t, f_t>& op_problem);
 
   static void check_scaled_problem(detail::problem_t<i_t, f_t> const& scaled_problem,
                                    detail::problem_t<i_t, f_t> const& op_problem);

--- a/cpp/src/mip/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip/presolve/third_party_presolve.cpp
@@ -26,8 +26,7 @@
 namespace cuopt::linear_programming::detail {
 
 static papilo::PostsolveStorage<double> post_solve_storage_;
-static int presolve_calls_ = 0;
-static bool maximize_      = false;
+static bool maximize_ = false;
 
 template <typename i_t, typename f_t>
 papilo::Problem<f_t> build_papilo_problem(const optimization_problem_t<i_t, f_t>& op_problem)
@@ -317,10 +316,6 @@ std::pair<optimization_problem_t<i_t, f_t>, bool> third_party_presolve_t<i_t, f_
   f_t relative_tolerance,
   double time_limit)
 {
-  cuopt_expects(
-    presolve_calls_ == 0, error_type_t::ValidationError, "Presolve can only be called once");
-  presolve_calls_++;
-
   papilo::Problem<f_t> papilo_problem = build_papilo_problem(op_problem);
 
   CUOPT_LOG_INFO("Unpresolved problem:: %d constraints, %d variables, %d nonzeros",
@@ -340,7 +335,6 @@ std::pair<optimization_problem_t<i_t, f_t>, bool> third_party_presolve_t<i_t, f_
   check_presolve_status(result.status);
   if (result.status == papilo::PresolveStatus::kInfeasible ||
       result.status == papilo::PresolveStatus::kUnbndOrInfeas) {
-    --presolve_calls_;
     return std::make_pair(optimization_problem_t<i_t, f_t>(op_problem.get_handle_ptr()), false);
   }
   post_solve_storage_ = result.postsolve;
@@ -365,9 +359,6 @@ void third_party_presolve_t<i_t, f_t>::undo(rmm::device_uvector<f_t>& primal_sol
                                             bool status_to_skip,
                                             rmm::cuda_stream_view stream_view)
 {
-  --presolve_calls_;
-  cuopt_expects(
-    presolve_calls_ == 0, error_type_t::ValidationError, "Postsolve can only be called once");
   if (status_to_skip) { return; }
   std::vector<f_t> primal_sol_vec_h(primal_solution.size());
   raft::copy(primal_sol_vec_h.data(), primal_solution.data(), primal_solution.size(), stream_view);

--- a/cpp/src/mip/solve.cu
+++ b/cpp/src/mip/solve.cu
@@ -176,6 +176,13 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
     problem_checking_t<i_t, f_t>::check_problem_representation(op_problem);
     problem_checking_t<i_t, f_t>::check_initial_solution_representation(op_problem, settings);
 
+    // Check for crossing bounds. Return infeasible if there are any
+    if (problem_checking_t<i_t, f_t>::has_crossing_bounds(op_problem)) {
+      return mip_solution_t<i_t, f_t>(mip_termination_status_t::Infeasible,
+                                      solver_stats_t<i_t, f_t>{},
+                                      op_problem.get_handle_ptr()->get_stream());
+    }
+
     auto timer = cuopt::timer_t(time_limit);
 
     double presolve_time = 0.0;
@@ -204,7 +211,7 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
                                         op_problem.get_handle_ptr()->get_stream());
       }
 
-      problem       = detail::problem_t<i_t, f_t>(reduced_op_problem);
+      problem       = detail::problem_t<i_t, f_t>(reduced_op_problem, settings.get_tolerances());
       presolve_time = timer.elapsed_time();
       CUOPT_LOG_INFO("Third party presolve time: %f", presolve_time);
     }

--- a/cpp/tests/linear_programming/c_api_tests/c_api_test.c
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_test.c
@@ -950,17 +950,13 @@ cuopt_int_t test_invalid_bounds()
 
   printf("cuOptCreateRangedProblem returned: %d\n", status);
 
-  if (status == CUOPT_VALIDATION_ERROR) {
-    printf("✓ Validation error triggered as expected!\n");
-    printf("This reproduces the 'Variable bounds are invalid' error from MOI wrapper\n");
-    return CUOPT_SUCCESS;  // This is the expected result
-  } else if (status != CUOPT_SUCCESS) {
+  if (status != CUOPT_SUCCESS) {
     printf("✗ Unexpected error: %d\n", status);
     goto DONE;
   }
 
   // If we get here, the problem was created successfully
-  printf("✓ Problem created successfully (unexpected!)\n");
+  printf("✓ Problem created successfully\n");
 
   // Create solver settings
   status = cuOptCreateSolverSettings(&settings);
@@ -986,6 +982,18 @@ cuopt_int_t test_invalid_bounds()
   status = cuOptGetTerminationStatus(solution, &termination_status);
   if (status != CUOPT_SUCCESS) {
     printf("Error getting termination status: %d\n", status);
+    goto DONE;
+  }
+  if (termination_status != CUOPT_TERIMINATION_STATUS_INFEASIBLE) {
+    printf("Error: expected termination status to be %d, but got %d\n",
+           CUOPT_TERIMINATION_STATUS_INFEASIBLE,
+           termination_status);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+  else {
+    printf("✓ Problem found infeasible as expected\n");
+    status = CUOPT_SUCCESS;
     goto DONE;
   }
 

--- a/cpp/tests/linear_programming/c_api_tests/c_api_test.c
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_test.c
@@ -872,3 +872,155 @@ DONE:
 
   return status;
 }
+
+// Test invalid bounds scenario (what MOI wrapper was producing)
+cuopt_int_t test_invalid_bounds()
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuOptSolverSettings settings = NULL;
+  cuOptSolution solution = NULL;
+
+  /* Test the invalid bounds scenario:
+     maximize 2*x
+     subject to:
+     x >= 0.2
+     x <= 0.5
+     x is binary (0 or 1)
+
+     After MOI wrapper processing:
+     - Lower bound = ceil(max(0.0, 0.2)) = 1.0
+     - Upper bound = floor(min(1.0, 0.5)) = 0.0
+     - Result: 1.0 <= x <= 0.0 (INVALID!)
+  */
+
+  cuopt_int_t num_variables = 1;
+  cuopt_int_t num_constraints = 2;
+  cuopt_int_t nnz = 2;
+
+  // CSR format constraint matrix
+  // From the constraints:
+  // x >= 0.2
+  // x <= 0.5
+  cuopt_int_t row_offsets[] = {0, 1, 2};
+  cuopt_int_t column_indices[] = {0, 0};
+  cuopt_float_t values[] = {1.0, 1.0};
+
+  // Objective coefficients
+  // From the objective function: maximize 2*x
+  cuopt_float_t objective_coefficients[] = {2.0};
+
+  // Constraint bounds
+  // From the constraints:
+  // x >= 0.2
+  // x <= 0.5
+  cuopt_float_t constraint_upper_bounds[] = {CUOPT_INFINITY, 0.5};
+  cuopt_float_t constraint_lower_bounds[] = {0.2, -CUOPT_INFINITY};
+
+  // Variable bounds - INVALID: lower > upper
+  // After MOI wrapper processing:
+  cuopt_float_t var_lower_bounds[] = {1.0};  // ceil(max(0.0, 0.2)) = 1.0
+  cuopt_float_t var_upper_bounds[] = {0.0};  // floor(min(1.0, 0.5)) = 0.0
+
+  // Variable types (binary)
+  char variable_types[] = {CUOPT_INTEGER};  // Binary variable
+
+  cuopt_int_t status;
+  cuopt_float_t time;
+  cuopt_int_t termination_status;
+  cuopt_float_t objective_value;
+
+  printf("Testing invalid bounds scenario (MOI wrapper issue)...\n");
+  printf("Problem: Binary variable with bounds 1.0 <= x <= 0.0 (INVALID!)\n");
+
+  // Create the problem
+  status = cuOptCreateRangedProblem(num_constraints,
+                                   num_variables,
+                                   CUOPT_MAXIMIZE,  // maximize
+                                   0.0,            // objective offset
+                                   objective_coefficients,
+                                   row_offsets,
+                                   column_indices,
+                                   values,
+                                   constraint_lower_bounds,
+                                   constraint_upper_bounds,
+                                   var_lower_bounds,
+                                   var_upper_bounds,
+                                   variable_types,
+                                   &problem);
+
+  printf("cuOptCreateRangedProblem returned: %d\n", status);
+
+  if (status == CUOPT_VALIDATION_ERROR) {
+    printf("✓ Validation error triggered as expected!\n");
+    printf("This reproduces the 'Variable bounds are invalid' error from MOI wrapper\n");
+    return CUOPT_SUCCESS;  // This is the expected result
+  } else if (status != CUOPT_SUCCESS) {
+    printf("✗ Unexpected error: %d\n", status);
+    goto DONE;
+  }
+
+  // If we get here, the problem was created successfully
+  printf("✓ Problem created successfully (unexpected!)\n");
+
+  // Create solver settings
+  status = cuOptCreateSolverSettings(&settings);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating solver settings: %d\n", status);
+    goto DONE;
+  }
+
+  // Solve the problem
+  status = cuOptSolve(problem, settings, &solution);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error solving problem: %d\n", status);
+    goto DONE;
+  }
+
+  // Get solution information
+  status = cuOptGetSolveTime(solution, &time);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting solve time: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetTerminationStatus(solution, &termination_status);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting termination status: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveValue(solution, &objective_value);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting objective value: %d\n", status);
+    goto DONE;
+  }
+
+  // Print results
+  printf("\nResults:\n");
+  printf("--------\n");
+  printf("Termination status: %s (%d)\n", termination_status_to_string(termination_status), termination_status);
+  printf("Solve time: %f seconds\n", time);
+  printf("Objective value: %f\n", objective_value);
+
+  // Get and print solution variables
+  cuopt_float_t* solution_values = (cuopt_float_t*)malloc(num_variables * sizeof(cuopt_float_t));
+  status = cuOptGetPrimalSolution(solution, solution_values);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting solution values: %d\n", status);
+    free(solution_values);
+    goto DONE;
+  }
+
+  printf("\nSolution: \n");
+  for (cuopt_int_t i = 0; i < num_variables; i++) {
+    printf("x%d = %f\n", i + 1, solution_values[i]);
+  }
+  free(solution_values);
+
+DONE:
+  cuOptDestroyProblem(&problem);
+  cuOptDestroySolverSettings(&settings);
+  cuOptDestroySolution(&solution);
+
+  return status;
+}

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -24,91 +24,97 @@
 
 #include <gtest/gtest.h>
 
-TEST(c_api, int_size) { EXPECT_EQ(test_int_size(), sizeof(int32_t)); }
+// TEST(c_api, int_size) { EXPECT_EQ(test_int_size(), sizeof(int32_t)); }
 
-TEST(c_api, float_size) { EXPECT_EQ(test_float_size(), sizeof(double)); }
+// TEST(c_api, float_size) { EXPECT_EQ(test_float_size(), sizeof(double)); }
 
-TEST(c_api, afiro)
-{
-  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-  std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
-  int termination_status;
-  EXPECT_EQ(solve_mps_file(filename.c_str(), 60, CUOPT_INFINITY, &termination_status),
-            CUOPT_SUCCESS);
-  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-}
+// TEST(c_api, afiro)
+// {
+//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+//   std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
+//   int termination_status;
+//   EXPECT_EQ(solve_mps_file(filename.c_str(), 60, CUOPT_INFINITY, &termination_status),
+//             CUOPT_SUCCESS);
+//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+// }
 
-// Test both LP and MIP codepaths
-class TimeLimitTestFixture : public ::testing::TestWithParam<std::tuple<std::string, double, int>> {
-};
-TEST_P(TimeLimitTestFixture, time_limit)
-{
-  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-  std::string filename                    = rapidsDatasetRootDir + std::get<0>(GetParam());
-  double target_solve_time                = std::get<1>(GetParam());
-  int method                              = std::get<2>(GetParam());
-  int termination_status;
-  double solve_time = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_EQ(solve_mps_file(filename.c_str(),
-                           target_solve_time,
-                           CUOPT_INFINITY,
-                           &termination_status,
-                           &solve_time,
-                           method),
-            CUOPT_SUCCESS);
-  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
+// // Test both LP and MIP codepaths
+// class TimeLimitTestFixture : public ::testing::TestWithParam<std::tuple<std::string, double,
+// int>> {
+// };
+// TEST_P(TimeLimitTestFixture, time_limit)
+// {
+//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+//   std::string filename                    = rapidsDatasetRootDir + std::get<0>(GetParam());
+//   double target_solve_time                = std::get<1>(GetParam());
+//   int method                              = std::get<2>(GetParam());
+//   int termination_status;
+//   double solve_time = std::numeric_limits<double>::quiet_NaN();
+//   EXPECT_EQ(solve_mps_file(filename.c_str(),
+//                            target_solve_time,
+//                            CUOPT_INFINITY,
+//                            &termination_status,
+//                            &solve_time,
+//                            method),
+//             CUOPT_SUCCESS);
+//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
+//
+// Dual simplex is spending some time for factorizing the basis, and this computation does not
+// check for time limit
+//  double excess_allowed_time = 2.0;
+//   EXPECT_NEAR(solve_time, target_solve_time, excess_allowed_time);
+// }
+// INSTANTIATE_TEST_SUITE_P(
+//   c_api,
+//   TimeLimitTestFixture,
+//   ::testing::Values(
+//     std::make_tuple("/linear_programming/square41/square41.mps",
+//                     5,
+//                     CUOPT_METHOD_DUAL_SIMPLEX),  // LP, Dual Simplex
+//     std::make_tuple("/linear_programming/square41/square41.mps", 5, CUOPT_METHOD_PDLP),  // LP,
+//     PDLP std::make_tuple("/mip/enlight_hard.mps", 5, CUOPT_METHOD_DUAL_SIMPLEX)               //
+//     MIP
+//     ));
 
-  // Dual simplex is spending some time for factorizing the basis, and this computation does not
-  // check for time limit
-  double excess_allowed_time = 2.0;
-  EXPECT_NEAR(solve_time, target_solve_time, excess_allowed_time);
-}
-INSTANTIATE_TEST_SUITE_P(
-  c_api,
-  TimeLimitTestFixture,
-  ::testing::Values(
-    std::make_tuple("/linear_programming/square41/square41.mps",
-                    5,
-                    CUOPT_METHOD_DUAL_SIMPLEX),  // LP, Dual Simplex
-    std::make_tuple("/linear_programming/square41/square41.mps", 5, CUOPT_METHOD_PDLP),  // LP, PDLP
-    std::make_tuple("/mip/enlight_hard.mps", 5, CUOPT_METHOD_DUAL_SIMPLEX)               // MIP
-    ));
+// TEST(c_api, iteration_limit)
+// {
+//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+//   std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
+//   int termination_status;
+//   EXPECT_EQ(solve_mps_file(filename.c_str(), 60, 1, &termination_status), CUOPT_SUCCESS);
+//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
+// }
 
-TEST(c_api, iteration_limit)
-{
-  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-  std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
-  int termination_status;
-  EXPECT_EQ(solve_mps_file(filename.c_str(), 60, 1, &termination_status), CUOPT_SUCCESS);
-  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
-}
+// TEST(c_api, solve_time_bb_preemption)
+// {
+//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+//   std::string filename                    = rapidsDatasetRootDir + "/mip/" + "bb_optimality.mps";
+//   int termination_status;
+//   double solve_time = std::numeric_limits<double>::quiet_NaN();
+//   EXPECT_EQ(solve_mps_file(filename.c_str(), 5, CUOPT_INFINITY, &termination_status,
+//   &solve_time),
+//             CUOPT_SUCCESS);
+//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+//   EXPECT_GT(solve_time, 0);  // solve time should not be equal to 0, even on very simple
+//   instances
+//                              // solved by B&B before the diversity solver has time to run
+// }
 
-TEST(c_api, solve_time_bb_preemption)
-{
-  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-  std::string filename                    = rapidsDatasetRootDir + "/mip/" + "bb_optimality.mps";
-  int termination_status;
-  double solve_time = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_EQ(solve_mps_file(filename.c_str(), 5, CUOPT_INFINITY, &termination_status, &solve_time),
-            CUOPT_SUCCESS);
-  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-  EXPECT_GT(solve_time, 0);  // solve time should not be equal to 0, even on very simple instances
-                             // solved by B&B before the diversity solver has time to run
-}
+// TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
 
-TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
+// TEST(c_api, burglar) { EXPECT_EQ(burglar_problem(), CUOPT_SUCCESS); }
 
-TEST(c_api, burglar) { EXPECT_EQ(burglar_problem(), CUOPT_SUCCESS); }
+// TEST(c_api, test_missing_file) { EXPECT_EQ(test_missing_file(), CUOPT_MPS_FILE_ERROR); }
 
-TEST(c_api, test_missing_file) { EXPECT_EQ(test_missing_file(), CUOPT_MPS_FILE_ERROR); }
+// TEST(c_api, test_infeasible_problem) { EXPECT_EQ(test_infeasible_problem(), CUOPT_SUCCESS); }
 
-TEST(c_api, test_infeasible_problem) { EXPECT_EQ(test_infeasible_problem(), CUOPT_SUCCESS); }
+// TEST(c_api, test_ranged_problem)
+// {
+//   cuopt_int_t termination_status;
+//   cuopt_float_t objective;
+//   EXPECT_EQ(test_ranged_problem(&termination_status, &objective), CUOPT_SUCCESS);
+//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+//   EXPECT_NEAR(objective, 32.0, 1e-3);
+// }
 
-TEST(c_api, test_ranged_problem)
-{
-  cuopt_int_t termination_status;
-  cuopt_float_t objective;
-  EXPECT_EQ(test_ranged_problem(&termination_status, &objective), CUOPT_SUCCESS);
-  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-  EXPECT_NEAR(objective, 32.0, 1e-3);
-}
+TEST(c_api, test_invalid_bounds) { EXPECT_EQ(test_invalid_bounds(), CUOPT_SUCCESS); }

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -24,97 +24,93 @@
 
 #include <gtest/gtest.h>
 
-// TEST(c_api, int_size) { EXPECT_EQ(test_int_size(), sizeof(int32_t)); }
+TEST(c_api, int_size) { EXPECT_EQ(test_int_size(), sizeof(int32_t)); }
 
-// TEST(c_api, float_size) { EXPECT_EQ(test_float_size(), sizeof(double)); }
+TEST(c_api, float_size) { EXPECT_EQ(test_float_size(), sizeof(double)); }
 
-// TEST(c_api, afiro)
-// {
-//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-//   std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
-//   int termination_status;
-//   EXPECT_EQ(solve_mps_file(filename.c_str(), 60, CUOPT_INFINITY, &termination_status),
-//             CUOPT_SUCCESS);
-//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-// }
+TEST(c_api, afiro)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
+  int termination_status;
+  EXPECT_EQ(solve_mps_file(filename.c_str(), 60, CUOPT_INFINITY, &termination_status),
+            CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+}
 
-// // Test both LP and MIP codepaths
-// class TimeLimitTestFixture : public ::testing::TestWithParam<std::tuple<std::string, double,
-// int>> {
-// };
-// TEST_P(TimeLimitTestFixture, time_limit)
-// {
-//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-//   std::string filename                    = rapidsDatasetRootDir + std::get<0>(GetParam());
-//   double target_solve_time                = std::get<1>(GetParam());
-//   int method                              = std::get<2>(GetParam());
-//   int termination_status;
-//   double solve_time = std::numeric_limits<double>::quiet_NaN();
-//   EXPECT_EQ(solve_mps_file(filename.c_str(),
-//                            target_solve_time,
-//                            CUOPT_INFINITY,
-//                            &termination_status,
-//                            &solve_time,
-//                            method),
-//             CUOPT_SUCCESS);
-//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
-//
-// Dual simplex is spending some time for factorizing the basis, and this computation does not
-// check for time limit
-//  double excess_allowed_time = 2.0;
-//   EXPECT_NEAR(solve_time, target_solve_time, excess_allowed_time);
-// }
-// INSTANTIATE_TEST_SUITE_P(
-//   c_api,
-//   TimeLimitTestFixture,
-//   ::testing::Values(
-//     std::make_tuple("/linear_programming/square41/square41.mps",
-//                     5,
-//                     CUOPT_METHOD_DUAL_SIMPLEX),  // LP, Dual Simplex
-//     std::make_tuple("/linear_programming/square41/square41.mps", 5, CUOPT_METHOD_PDLP),  // LP,
-//     PDLP std::make_tuple("/mip/enlight_hard.mps", 5, CUOPT_METHOD_DUAL_SIMPLEX)               //
-//     MIP
-//     ));
+// Test both LP and MIP codepaths
+class TimeLimitTestFixture : public ::testing::TestWithParam<std::tuple<std::string, double, int>> {
+};
+TEST_P(TimeLimitTestFixture, time_limit)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string filename                    = rapidsDatasetRootDir + std::get<0>(GetParam());
+  double target_solve_time                = std::get<1>(GetParam());
+  int method                              = std::get<2>(GetParam());
+  int termination_status;
+  double solve_time = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(solve_mps_file(filename.c_str(),
+                           target_solve_time,
+                           CUOPT_INFINITY,
+                           &termination_status,
+                           &solve_time,
+                           method),
+            CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_TIME_LIMIT);
 
-// TEST(c_api, iteration_limit)
-// {
-//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-//   std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
-//   int termination_status;
-//   EXPECT_EQ(solve_mps_file(filename.c_str(), 60, 1, &termination_status), CUOPT_SUCCESS);
-//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
-// }
+  // Dual simplex is spending some time for factorizing the basis, and this computation does not
+  // check for time limit
+  double excess_allowed_time = 2.0;
+  EXPECT_NEAR(solve_time, target_solve_time, excess_allowed_time);
+}
+INSTANTIATE_TEST_SUITE_P(
+  c_api,
+  TimeLimitTestFixture,
+  ::testing::Values(
+    std::make_tuple("/linear_programming/square41/square41.mps",
+                    5,
+                    CUOPT_METHOD_DUAL_SIMPLEX),  // LP, Dual Simplex
+    std::make_tuple("/linear_programming/square41/square41.mps", 5, CUOPT_METHOD_PDLP),  // LP, PDLP
+    std::make_tuple("/mip/enlight_hard.mps", 5, CUOPT_METHOD_DUAL_SIMPLEX)               // MIP
+    ));
 
-// TEST(c_api, solve_time_bb_preemption)
-// {
-//   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
-//   std::string filename                    = rapidsDatasetRootDir + "/mip/" + "bb_optimality.mps";
-//   int termination_status;
-//   double solve_time = std::numeric_limits<double>::quiet_NaN();
-//   EXPECT_EQ(solve_mps_file(filename.c_str(), 5, CUOPT_INFINITY, &termination_status,
-//   &solve_time),
-//             CUOPT_SUCCESS);
-//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-//   EXPECT_GT(solve_time, 0);  // solve time should not be equal to 0, even on very simple
-//   instances
-//                              // solved by B&B before the diversity solver has time to run
-// }
+TEST(c_api, iteration_limit)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string filename = rapidsDatasetRootDir + "/linear_programming/" + "afiro_original.mps";
+  int termination_status;
+  EXPECT_EQ(solve_mps_file(filename.c_str(), 60, 1, &termination_status), CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT);
+}
 
-// TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
+TEST(c_api, solve_time_bb_preemption)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string filename                    = rapidsDatasetRootDir + "/mip/" + "bb_optimality.mps";
+  int termination_status;
+  double solve_time = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(solve_mps_file(filename.c_str(), 5, CUOPT_INFINITY, &termination_status, &solve_time),
+            CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_GT(solve_time, 0);  // solve time should not be equal to 0, even on very simple instances
+  // solved by B&B before the diversity solver has time to run
+}
 
-// TEST(c_api, burglar) { EXPECT_EQ(burglar_problem(), CUOPT_SUCCESS); }
+TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
 
-// TEST(c_api, test_missing_file) { EXPECT_EQ(test_missing_file(), CUOPT_MPS_FILE_ERROR); }
+TEST(c_api, burglar) { EXPECT_EQ(burglar_problem(), CUOPT_SUCCESS); }
 
-// TEST(c_api, test_infeasible_problem) { EXPECT_EQ(test_infeasible_problem(), CUOPT_SUCCESS); }
+TEST(c_api, test_missing_file) { EXPECT_EQ(test_missing_file(), CUOPT_MPS_FILE_ERROR); }
 
-// TEST(c_api, test_ranged_problem)
-// {
-//   cuopt_int_t termination_status;
-//   cuopt_float_t objective;
-//   EXPECT_EQ(test_ranged_problem(&termination_status, &objective), CUOPT_SUCCESS);
-//   EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
-//   EXPECT_NEAR(objective, 32.0, 1e-3);
-// }
+TEST(c_api, test_infeasible_problem) { EXPECT_EQ(test_infeasible_problem(), CUOPT_SUCCESS); }
+
+TEST(c_api, test_ranged_problem)
+{
+  cuopt_int_t termination_status;
+  cuopt_float_t objective;
+  EXPECT_EQ(test_ranged_problem(&termination_status, &objective), CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERIMINATION_STATUS_OPTIMAL);
+  EXPECT_NEAR(objective, 32.0, 1e-3);
+}
 
 TEST(c_api, test_invalid_bounds) { EXPECT_EQ(test_invalid_bounds(), CUOPT_SUCCESS); }

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
@@ -39,6 +39,7 @@ cuopt_int_t test_missing_file();
 cuopt_int_t test_infeasible_problem();
 cuopt_int_t test_bad_parameter_name();
 cuopt_int_t test_ranged_problem(cuopt_int_t* termination_status_ptr, cuopt_float_t* objective_ptr);
+cuopt_int_t test_invalid_bounds();
 
 #ifdef __cplusplus
 }

--- a/cpp/tests/mip/termination_test.cu
+++ b/cpp/tests/mip/termination_test.cu
@@ -110,6 +110,12 @@ TEST(termination_status, lower_bound_bb_timeout)
   EXPECT_GE(lb, obj_val);
 }
 
+TEST(termination_status, crossing_bounds_infeasible)
+{
+  auto [termination_status, obj_val, lb] = test_mps_file("mip/crossing_var_bounds.mps", 0.5, false);
+  EXPECT_EQ(termination_status, mip_termination_status_t::Infeasible);
+}
+
 TEST(termination_status, bb_infeasible_test)
 {
   // First, check that presolve doesn't reduce the problem to infeasibility

--- a/datasets/mip/crossing_var_bounds.mps
+++ b/datasets/mip/crossing_var_bounds.mps
@@ -1,0 +1,27 @@
+* Optimal solution -28
+NAME          MIP_SAMPLE
+ROWS
+ N  OBJ
+ L  C1
+ L  C2
+ L  C3
+COLUMNS
+ MARK0001  'MARKER'                 'INTORG'
+   X1        OBJ             -7
+   X1        C1              -1
+   X1        C2               5
+   X1        C3              -2
+   X2        OBJ             -2
+   X2        C1               2
+   X2        C2               1
+   X2        C3              -2
+ MARK0001  'MARKER'                 'INTEND'
+RHS
+   RHS       C1               4
+   RHS       C2              20
+   RHS       C3              -7
+BOUNDS
+ UP BOUND     X1               10
+ LO BOUNDS    X1               20
+ UP BOUND     X2               10
+ENDATA


### PR DESCRIPTION
3rd party APIs expect problems with crossing bounds to be treated as infeasible by the solver. 
This PR replaces the previous behavior (exception on crossing bounds in input problem) to align accordingly.
closes #260