### PR TITLE
Fix FJ numerical issue turning a solution infeasible 

### DIFF
--- a/cpp/src/mip/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip/feasibility_jump/feasibility_jump.cu
@@ -1055,6 +1055,7 @@ i_t fj_t<i_t, f_t>::solve(solution_t<i_t, f_t>& solution)
   resize_vectors(solution.handle_ptr);
 
   bool is_initial_feasible = solution.compute_feasibility();
+  auto initial_solution    = solution;
   // if we're in rounding mode, split the time/iteration limit between the first and second stage
   cuopt_assert(settings.parameters.rounding_second_stage_split >= 0 &&
                  settings.parameters.rounding_second_stage_split <= 1,
@@ -1126,11 +1127,11 @@ i_t fj_t<i_t, f_t>::solve(solution_t<i_t, f_t>& solution)
   bool is_new_feasible = solution.compute_feasibility();
 
   if (is_initial_feasible && !is_new_feasible) {
-    CUOPT_LOG_ERROR(
-      "Feasibility jump caused feasible solution to become infeasible\n"
-      "Best excess is %g",
+    CUOPT_LOG_WARN(
+      "Feasibility jump caused feasible solution to become infeasible: Best excess is %g",
       climbers[0]->best_excess.value(handle_ptr->get_stream()));
-    cuopt_assert(false, "Feasibility jump caused feasible solution to become infeasible");
+    solution.copy_from(initial_solution);
+    cuopt_assert(solution.compute_feasibility(), "Reverted solution should be feasible");
   }
 
   return is_new_feasible;

--- a/cpp/src/mip/feasibility_jump/feasibility_jump.cuh
+++ b/cpp/src/mip/feasibility_jump/feasibility_jump.cuh
@@ -56,7 +56,7 @@ struct fj_hyper_parameters_t {
   int global_move_update_period      = 10;
   int heavy_move_update_period       = 50;
   int sync_period                    = 200;
-  int lhs_refresh_period             = 1000;
+  int lhs_refresh_period             = 500;
   int allow_infeasibility_iterations = 200;
   // The value added to the objective weight everytime a new best solution is
   // found in order to move towards better solutions
@@ -530,7 +530,7 @@ class fj_t {
                                                           pb.constraint_upper_bounds[cstr],
                                                           pb.tolerances.absolute_tolerance,
                                                           pb.tolerances.relative_tolerance);
-        return max((f_t)0, cstr_tolerance - MACHINE_EPSILON);
+        return max((f_t)1e-12, cstr_tolerance - MACHINE_EPSILON);
       }
 
       DI bool cstr_satisfied(i_t cstr, f_t lhs) const


### PR DESCRIPTION
closes #360

On some numerically tricky problems, the infeasibility excess may be close enough to the tolerance that FJ considers it feasible, but solution_t does not. 
This PR ensures that FJ doesn't return this new solution if solution_t::compute_feasibility() considers it infeasible.
The refresh period for the computation of constraint LHS values is also reduced to minimize error.