### PR TITLE
Implement node presolve

### DIFF
--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -676,6 +676,10 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
 
     nodes_explored++;
     if (lp_status == dual::status_t::DUAL_UNBOUNDED) {
+      if (!feasible) {
+        settings.log.printf("Infeasible after bounds strengthening. Fathoming node %d.\n",
+                            nodes_explored);
+      }
       node_ptr->lower_bound = inf;
       std::vector<mip_node_t<i_t, f_t>*> stack;
       node_ptr->set_status(node_status_t::INFEASIBLE, stack);

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -529,6 +529,8 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
                          std::move(up_child));  // child pointers moved into the tree
   lp_problem_t leaf_problem =
     original_lp;  // Make a copy of the original LP. We will modify its bounds at each leaf
+  csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
+  original_lp.A.transpose(Arow);
   f_t gap            = get_upper_bound() - lower_bound;
   i_t nodes_explored = 0;
   settings.log.printf(
@@ -631,8 +633,11 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     // Set the correct bounds for the leaf problem
     leaf_problem.lower = original_lp.lower;
     leaf_problem.upper = original_lp.upper;
-    // FIXME:: should we get the bounds from the node/parent instead of the original problem?
-    node_ptr->get_variable_bounds(leaf_problem.lower, leaf_problem.upper);
+    std::vector<bool> bounds_changed(original_lp.num_cols, false);
+    // Technically, we can get the already strengthened bounds from the node/parent instead of
+    // getting it from the original problem and re-strengthening. But this requires storing
+    // two vectors at each node and potentially cause memory issues
+    node_ptr->get_variable_bounds(leaf_problem.lower, leaf_problem.upper, bounds_changed);
 
     std::vector<variable_status_t>& leaf_vstatus = node_ptr->vstatus;
     lp_solution_t<i_t, f_t> leaf_solution(leaf_problem.num_rows, leaf_problem.num_cols);
@@ -648,7 +653,8 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
 
     // in B&B we only have equality constraints, leave it empty for default
     std::vector<char> row_sense;
-    bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, var_types);
+    bool feasible =
+      bound_strengthening(row_sense, lp_settings, leaf_problem, Arow, var_types, bounds_changed);
 
     dual::status_t lp_status = dual::status_t::DUAL_UNBOUNDED;
 

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -642,8 +642,19 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     std::vector<f_t> leaf_edge_norms      = edge_norms;  // = node.steepest_edge_norms;
     simplex_solver_settings_t lp_settings = settings;
     lp_settings.set_log(false);
-    lp_settings.cut_off      = upper_bound + settings.dual_tol;
-    lp_settings.inside_mip   = 2;
+    lp_settings.cut_off    = upper_bound + settings.dual_tol;
+    lp_settings.inside_mip = 2;
+
+    // in B&B we only have equality constraints
+    std::vector<char> row_sense(leaf_problem.num_rows, 'E');
+    std::vector<i_t> is_int(leaf_problem.num_cols, 0);
+    // FIXME:: populate is_int correctly
+    bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, is_int);
+
+    if (!feasible) {
+      // do something here
+    }
+
     dual::status_t lp_status = dual_phase2(2,
                                            0,
                                            lp_start_time,

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -651,24 +651,25 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     // FIXME:: populate is_int correctly
     bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, is_int);
 
-    if (!feasible) {
-      // do something here
-    }
+    dual::status_t lp_status = dual::status_t::DUAL_UNBOUNDED;
 
-    dual::status_t lp_status = dual_phase2(2,
-                                           0,
-                                           lp_start_time,
-                                           leaf_problem,
-                                           lp_settings,
-                                           leaf_vstatus,
-                                           leaf_solution,
-                                           node_iter,
-                                           leaf_edge_norms);
-    if (lp_status == dual::status_t::NUMERICAL) {
-      settings.log.printf("Numerical issue node %d. Resolving from scratch.\n", nodes_explored);
-      lp_status_t second_status = solve_linear_program_advanced(
-        leaf_problem, lp_start_time, lp_settings, leaf_solution, leaf_vstatus, leaf_edge_norms);
-      lp_status = convert_lp_status_to_dual_status(second_status);
+    // If the problem is infeasible after bounds strengthening, we don't need to solve the LP
+    if (feasible) {
+      lp_status = dual_phase2(2,
+                              0,
+                              lp_start_time,
+                              leaf_problem,
+                              lp_settings,
+                              leaf_vstatus,
+                              leaf_solution,
+                              node_iter,
+                              leaf_edge_norms);
+      if (lp_status == dual::status_t::NUMERICAL) {
+        settings.log.printf("Numerical issue node %d. Resolving from scratch.\n", nodes_explored);
+        lp_status_t second_status = solve_linear_program_advanced(
+          leaf_problem, lp_start_time, lp_settings, leaf_solution, leaf_vstatus, leaf_edge_norms);
+        lp_status = convert_lp_status_to_dual_status(second_status);
+      }
     }
     total_lp_solve_time += toc(lp_start_time);
     total_lp_iters += node_iter;

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -646,8 +646,8 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     lp_settings.cut_off    = upper_bound + settings.dual_tol;
     lp_settings.inside_mip = 2;
 
-    // in B&B we only have equality constraints
-    std::vector<char> row_sense(leaf_problem.num_rows, 'E');
+    // in B&B we only have equality constraints, leave it empty for default
+    std::vector<char> row_sense;
     bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, var_types);
 
     dual::status_t lp_status = dual::status_t::DUAL_UNBOUNDED;

--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -631,6 +631,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     // Set the correct bounds for the leaf problem
     leaf_problem.lower = original_lp.lower;
     leaf_problem.upper = original_lp.upper;
+    // FIXME:: should we get the bounds from the node/parent instead of the original problem?
     node_ptr->get_variable_bounds(leaf_problem.lower, leaf_problem.upper);
 
     std::vector<variable_status_t>& leaf_vstatus = node_ptr->vstatus;
@@ -647,9 +648,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
 
     // in B&B we only have equality constraints
     std::vector<char> row_sense(leaf_problem.num_rows, 'E');
-    std::vector<i_t> is_int(leaf_problem.num_cols, 0);
-    // FIXME:: populate is_int correctly
-    bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, is_int);
+    bool feasible = bound_strengthening(row_sense, lp_settings, leaf_problem, var_types);
 
     dual::status_t lp_status = dual::status_t::DUAL_UNBOUNDED;
 

--- a/cpp/src/dual_simplex/mip_node.hpp
+++ b/cpp/src/dual_simplex/mip_node.hpp
@@ -79,22 +79,27 @@ class mip_node_t {
     children[1] = nullptr;
   }
 
-  void get_variable_bounds(std::vector<f_t>& lower, std::vector<f_t>& upper) const
+  void get_variable_bounds(std::vector<f_t>& lower,
+                           std::vector<f_t>& upper,
+                           std::vector<bool>& bounds_changed) const
   {
+    std::fill(bounds_changed.begin(), bounds_changed.end(), false);
     // Apply the bounds at the current node
     assert(lower.size() > branch_var);
     assert(upper.size() > branch_var);
     lower[branch_var]                = branch_var_lower;
     upper[branch_var]                = branch_var_upper;
+    bounds_changed[branch_var]       = true;
     mip_node_t<i_t, f_t>* parent_ptr = parent;
     while (parent_ptr != nullptr) {
       if (parent_ptr->node_id == 0) { break; }
       assert(parent_ptr->branch_var >= 0);
       assert(lower.size() > parent_ptr->branch_var);
       assert(upper.size() > parent_ptr->branch_var);
-      lower[parent_ptr->branch_var] = parent_ptr->branch_var_lower;
-      upper[parent_ptr->branch_var] = parent_ptr->branch_var_upper;
-      parent_ptr                    = parent_ptr->parent;
+      lower[parent_ptr->branch_var]          = parent_ptr->branch_var_lower;
+      upper[parent_ptr->branch_var]          = parent_ptr->branch_var_upper;
+      bounds_changed[parent_ptr->branch_var] = true;
+      parent_ptr                             = parent_ptr->parent;
     }
   }
 

--- a/cpp/src/dual_simplex/phase2.hpp
+++ b/cpp/src/dual_simplex/phase2.hpp
@@ -38,7 +38,22 @@ enum class status_t {
   CONCURRENT_LIMIT = 6,
   UNSET            = 7
 };
+
+static std::string status_to_string(status_t status)
+{
+  switch (status) {
+    case status_t::OPTIMAL: return "OPTIMAL";
+    case status_t::DUAL_UNBOUNDED: return "DUAL_UNBOUNDED";
+    case status_t::NUMERICAL: return "NUMERICAL";
+    case status_t::CUTOFF: return "CUTOFF";
+    case status_t::TIME_LIMIT: return "TIME_LIMIT";
+    case status_t::ITERATION_LIMIT: return "ITERATION_LIMIT";
+    case status_t::CONCURRENT_LIMIT: return "CONCURRENT_LIMIT";
+    case status_t::UNSET: return "UNSET";
+  }
+  return "UNKNOWN";
 }
+}  // namespace dual
 
 template <typename i_t, typename f_t>
 dual::status_t dual_phase2(i_t phase,

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -79,29 +79,36 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
   problem.A.transpose(Arow);
 
-  std::vector<f_t> min_activity(m);
-  std::vector<f_t> max_activity(m);
+  std::vector<f_t> delta_min_activity(m);
+  std::vector<f_t> delta_max_activity(m);
   std::vector<f_t> constraint_lb(m);
   std::vector<f_t> constraint_ub(m);
 
-  // FIXME:: Instead of initializing constraint_changed to true, we can only look 
+  // FIXME:: Instead of initializing constraint_changed to true, we can only look
   // at the constraints corresponding to branched variable in branch and bound
-  // This is because, the parent LP already checked for feasibility of the constraints 
+  // This is because, the parent LP already checked for feasibility of the constraints
   // without the branched variable bounds
   std::vector<bool> constraint_changed(m, true);
   std::vector<bool> variable_changed(n, false);
   std::vector<bool> constraint_changed_next(m, false);
 
-  for (i_t i = 0; i < m; ++i) {
-    if (row_sense[i] == 'L') {
-      constraint_ub[i] = problem.rhs[i];
-      constraint_lb[i] = -inf;
-    } else if (row_sense[i] == 'G') {
-      constraint_lb[i] = problem.rhs[i];
-      constraint_ub[i] = inf;
-    } else {
-      constraint_lb[i] = problem.rhs[i];
-      constraint_ub[i] = problem.rhs[i];
+  const bool is_row_sense_empty = row_sense.empty();
+  if (is_row_sense_empty) {
+    std::copy(problem.rhs.begin(), problem.rhs.end(), constraint_lb.begin());
+    std::copy(problem.rhs.begin(), problem.rhs.end(), constraint_ub.begin());
+  } else {
+    //  Set the constraint bounds
+    for (i_t i = 0; i < m; ++i) {
+      if (row_sense[i] == 'E') {
+        constraint_lb[i] = problem.rhs[i];
+        constraint_ub[i] = problem.rhs[i];
+      } else if (row_sense[i] == 'L') {
+        constraint_ub[i] = problem.rhs[i];
+        constraint_lb[i] = -inf;
+      } else {
+        constraint_lb[i] = problem.rhs[i];
+        constraint_ub[i] = inf;
+      }
     }
   }
 
@@ -154,8 +161,8 @@ bool bound_strengthening(const std::vector<char>& row_sense,
         return false;
       }
 
-      min_activity[i] = min_a;
-      max_activity[i] = max_a;
+      delta_min_activity[i] = cnst_ub - min_a;
+      delta_max_activity[i] = cnst_lb - max_a;
     }
 
     i_t num_bounds_changed = 0;
@@ -175,15 +182,12 @@ bool bound_strengthening(const std::vector<char>& row_sense,
 
         if (!constraint_changed[i]) { continue; }
         const f_t a_ik = problem.A.x[p];
-        f_t min_a      = min_activity[i];
-        f_t max_a      = max_activity[i];
-        f_t cnst_lb    = constraint_lb[i];
-        f_t cnst_ub    = constraint_ub[i];
-        min_a -= (a_ik < 0) ? a_ik * old_ub : a_ik * old_lb;
-        max_a -= (a_ik > 0) ? a_ik * old_ub : a_ik * old_lb;
 
-        f_t delta_min_act = cnst_ub - min_a;
-        f_t delta_max_act = cnst_lb - max_a;
+        f_t delta_min_act = delta_min_activity[i];
+        f_t delta_max_act = delta_max_activity[i];
+
+        delta_min_act += (a_ik < 0) ? a_ik * old_ub : a_ik * old_lb;
+        delta_max_act += (a_ik > 0) ? a_ik * old_ub : a_ik * old_lb;
 
         new_lb = std::max(new_lb, update_lb(old_lb, a_ik, delta_min_act, delta_max_act));
         new_ub = std::min(new_ub, update_ub(old_ub, a_ik, delta_min_act, delta_max_act));
@@ -203,8 +207,6 @@ bool bound_strengthening(const std::vector<char>& row_sense,
       new_ub = std::min(new_ub, problem.upper[k]);
 
       if (new_lb > new_ub + 1e-6) {
-        // std::cout << "Iter:: " << iter << ", Infeasible variable after update " << k << ", " <<
-        // new_lb << " > " << new_ub << std::endl;
         settings.log.printf(
           "Iter:: %d, Infeasible variable after update %d, %e > %e\n", iter, k, new_lb, new_ub);
         return false;

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -44,6 +44,27 @@ static inline bool check_infeasibility(f_t min_a, f_t max_a, f_t cnst_lb, f_t cn
   return (min_a > cnst_ub + eps) || (max_a < cnst_lb - eps);
 }
 
+#define DEBUG_BOUND_STRENGTHENING 0
+
+template <typename i_t, typename f_t>
+void print_bounds_stats(const std::vector<f_t>& lower,
+                        const std::vector<f_t>& upper,
+                        const simplex_solver_settings_t<i_t, f_t>& settings,
+                        const std::string msg)
+{
+#if DEBUG_BOUND_STRENGTHENING
+  f_t lb_norm = 0.0;
+  f_t ub_norm = 0.0;
+
+  i_t sz = lower.size();
+  for (i_t i = 0; i < sz; ++i) {
+    if (std::isfinite(lower[i])) { lb_norm += abs(lower[i]); }
+    if (std::isfinite(upper[i])) { ub_norm += abs(upper[i]); }
+  }
+  settings.log.printf("%s :: lb norm %e, ub norm %e\n", msg.c_str(), lb_norm, ub_norm);
+#endif
+}
+
 template <typename i_t, typename f_t>
 bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
@@ -62,6 +83,9 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   std::vector<f_t> constraint_lb(m);
   std::vector<f_t> constraint_ub(m);
 
+  i_t num_finite_lower_bounds = 0;
+  i_t num_finite_upper_bounds = 0;
+
   for (i_t i = 0; i < m; ++i) {
     if (row_sense[i] == 'L') {
       constraint_ub[i] = problem.rhs[i];
@@ -77,6 +101,14 @@ bool bound_strengthening(const std::vector<char>& row_sense,
 
   std::vector<f_t> lower = problem.lower;
   std::vector<f_t> upper = problem.upper;
+  print_bounds_stats(lower, upper, settings, "Initial bounds");
+  for (i_t i = 0; i < n; ++i) {
+    if (lower[i] > upper[i]) {
+      // std::cout << "Infeasible variable " << i << ", lower " << lower[i] << ", upper " <<
+      // upper[i] << std::endl;
+      return false;
+    }
+  }
 
   std::vector<i_t> updated_variables_list;
   updated_variables_list.reserve(n);
@@ -86,8 +118,9 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   const i_t iter_limit             = 10;
   i_t total_strengthened_variables = 0;
   while (iter < iter_limit) {
+    // std::cout << " XXXXXXXXXX  Iter:: " << iter << std::endl;
     // Derive bounds on the constraints
-    settings.log.printf("Running bound strengthening on %d rows\n", static_cast<i_t>(n));
+    // settings.log.printf("Running bound strengthening on %d rows\n", static_cast<i_t>(n));
 
     // Compute the min and max activity of the constraints
     // FIXME:: use changed constraints logic
@@ -113,6 +146,13 @@ bool bound_strengthening(const std::vector<char>& row_sense,
         if (lower[j] == -inf && a_ij > 0) { min_a = -inf; }
         if (upper[j] == inf && a_ij < 0) { min_a = -inf; }
       }
+
+      if (max_a < min_a) {
+        // std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", min_a " << min_a
+        // << ", max_a " << max_a << std::endl;
+        return false;
+      }
+
       min_activity[i] = min_a;
       max_activity[i] = max_a;
     }
@@ -142,9 +182,6 @@ bool bound_strengthening(const std::vector<char>& row_sense,
             cnst_ub,
             min_a,
             max_a);
-          std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", cnst_lb "
-                    << cnst_lb << ", cnst_ub " << cnst_ub << ", min_a " << min_a << ", max_a "
-                    << max_a << std::endl;
           return false;
         }
 
@@ -167,11 +204,21 @@ bool bound_strengthening(const std::vector<char>& row_sense,
           new_ub = std::floor(new_ub + settings.integer_tol);
         }
 
+        if (std::isfinite(old_lb)) { assert(std::isfinite(new_lb)); }
+        if (std::isfinite(old_ub)) { assert(std::isfinite(new_ub)); }
+
         bool lb_updated = abs(new_lb - old_lb) > 1e3 * settings.primal_tol;
         bool ub_updated = abs(new_ub - old_ub) > 1e3 * settings.primal_tol;
 
         if (lb_updated) { lower[k] = new_lb; }
         if (ub_updated) { upper[k] = new_ub; }
+
+        if (lower[k] > upper[k] + 1e-6) {
+          // std::cout << "Iter:: " << iter << ", Infeasible variable after update " << k << ",
+          // lower " << lower[k] << ", upper " << upper[k] << std::endl;
+          return false;
+        }
+        lower[k] = std::min(lower[k], upper[k]);
 
         bool bounds_changed = lb_updated || ub_updated;
         if (bounds_changed) {
@@ -181,12 +228,17 @@ bool bound_strengthening(const std::vector<char>& row_sense,
       }
     }
 
-    if (num_bounds_changed == 0) { break; }
+    if (num_bounds_changed == 0) {
+      settings.log.printf("No bounds changed, iter %d\n", iter + 1);
+      break;
+    } else {
+      settings.log.printf("Num bounds changed %d, iter %d\n", num_bounds_changed, iter + 1);
+    }
 
     // Update the bounds on the constraints
-    settings.log.printf("Round %d: Strengthend %d variables\n",
-                        iter,
-                        static_cast<i_t>(updated_variables_list.size()));
+    // settings.log.printf("Round %d: Strengthend %d variables\n",
+    //                     iter,
+    //                     static_cast<i_t>(updated_variables_list.size()));
     total_strengthened_variables += updated_variables_list.size();
     for (i_t j : updated_variables_list) {
       updated_variables_mark[j] = 0;
@@ -194,9 +246,48 @@ bool bound_strengthening(const std::vector<char>& row_sense,
     updated_variables_list.clear();
     iter++;
   }
-  settings.log.printf("Total strengthened variables %d\n", total_strengthened_variables);
+  // settings.log.printf("Total strengthened variables %d\n", total_strengthened_variables);
+
+#if DEBUG_BOUND_STRENGTHENING
+  f_t lb_change      = 0.0;
+  f_t ub_change      = 0.0;
+  int num_lb_changed = 0;
+  int num_ub_changed = 0;
+
+  for (i_t i = 0; i < n; ++i) {
+    if (lower[i] > problem.lower[i] + settings.primal_tol ||
+        (!std::isfinite(problem.lower[i]) && std::isfinite(lower[i]))) {
+      num_lb_changed++;
+      lb_change +=
+        std::isfinite(problem.lower[i])
+          ? (lower[i] - problem.lower[i]) / (1e-6 + std::max(abs(lower[i]), abs(problem.lower[i])))
+          : 1.0;
+    }
+    if (upper[i] < problem.upper[i] - settings.primal_tol ||
+        (!std::isfinite(problem.upper[i]) && std::isfinite(upper[i]))) {
+      num_ub_changed++;
+      ub_change +=
+        std::isfinite(problem.upper[i])
+          ? (problem.upper[i] - upper[i]) / (1e-6 + std::max(abs(problem.upper[i]), abs(upper[i])))
+          : 1.0;
+    }
+  }
+
+  if (num_lb_changed > 0 || num_ub_changed > 0) {
+    settings.log.printf(
+      "lb change %e, ub change %e, num lb changed %d, num ub changed %d, iter %d\n",
+      100 * lb_change / std::max(1, num_lb_changed),
+      100 * ub_change / std::max(1, num_ub_changed),
+      num_lb_changed,
+      num_ub_changed,
+      iter);
+  }
+  print_bounds_stats(lower, upper, settings, "Final bounds");
+#endif
+
   problem.lower = lower;
   problem.upper = upper;
+
   return true;
 }
 

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -70,14 +70,12 @@ template <typename i_t, typename f_t>
 bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
                          lp_problem_t<i_t, f_t>& problem,
-                         const std::vector<variable_type_t>& var_types)
+                         const csc_matrix_t<i_t, f_t>& Arow,
+                         const std::vector<variable_type_t>& var_types,
+                         const std::vector<bool>& bounds_changed)
 {
   const i_t m = problem.num_rows;
   const i_t n = problem.num_cols;
-
-  // FIXME:: pre-compute transpose and store
-  csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
-  problem.A.transpose(Arow);
 
   std::vector<f_t> delta_min_activity(m);
   std::vector<f_t> delta_max_activity(m);
@@ -91,6 +89,20 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   std::vector<bool> constraint_changed(m, true);
   std::vector<bool> variable_changed(n, false);
   std::vector<bool> constraint_changed_next(m, false);
+
+  if (false && !bounds_changed.empty()) {
+    std::fill(constraint_changed.begin(), constraint_changed.end(), false);
+    for (i_t i = 0; i < n; ++i) {
+      if (bounds_changed[i]) {
+        const i_t row_start = problem.A.col_start[i];
+        const i_t row_end   = problem.A.col_start[i + 1];
+        for (i_t p = row_start; p < row_end; ++p) {
+          const i_t j           = problem.A.i[p];
+          constraint_changed[j] = true;
+        }
+      }
+    }
+  }
 
   const bool is_row_sense_empty = row_sense.empty();
   if (is_row_sense_empty) {
@@ -825,7 +837,9 @@ void convert_user_problem(const user_problem_t<i_t, f_t>& user_problem,
   constexpr bool run_bound_strengthening = false;
   if constexpr (run_bound_strengthening) {
     settings.log.printf("Running bound strengthening\n");
-    bound_strengthening(row_sense, settings, problem);
+    csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
+    problem.A.transpose(Arow);
+    bound_strengthening(row_sense, settings, problem, Arow);
   }
 
   // The original problem may have a variable without a lower bound
@@ -1216,7 +1230,9 @@ template bool bound_strengthening<int, double>(
   const std::vector<char>& row_sense,
   const simplex_solver_settings_t<int, double>& settings,
   lp_problem_t<int, double>& problem,
-  const std::vector<variable_type_t>& var_types);
+  const csc_matrix_t<int, double>& Arow,
+  const std::vector<variable_type_t>& var_types,
+  const std::vector<bool>& bounds_changed);
 #endif
 
 }  // namespace cuopt::linear_programming::dual_simplex

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -47,7 +47,7 @@ template <typename i_t, typename f_t>
 bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
                          lp_problem_t<i_t, f_t>& problem,
-                         const std::vector<i_t>& is_int)
+                         const std::vector<variable_type_t>& var_types)
 {
   const i_t m = problem.num_rows;
   const i_t n = problem.num_cols;
@@ -146,7 +146,8 @@ bool bound_strengthening(const std::vector<char>& row_sense,
         f_t new_ub        = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
 
         // Integer rounding
-        if (!is_int.empty() && is_int[k]) {
+        if (!var_types.empty() &&
+            (var_types[k] == variable_type_t::INTEGER || var_types[k] == variable_type_t::BINARY)) {
           new_lb = std::ceil(new_lb - settings.integer_tol);
           new_ub = std::floor(new_ub + settings.integer_tol);
         }
@@ -1121,7 +1122,7 @@ template bool bound_strengthening<int, double>(
   const std::vector<char>& row_sense,
   const simplex_solver_settings_t<int, double>& settings,
   lp_problem_t<int, double>& problem,
-  const std::vector<int>& is_int);
+  const std::vector<variable_type_t>& var_types);
 #endif
 
 }  // namespace cuopt::linear_programming::dual_simplex

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -18,6 +18,7 @@
 #include <dual_simplex/presolve.hpp>
 
 #include <dual_simplex/right_looking_lu.hpp>
+#include <dual_simplex/tic_toc.hpp>
 
 #include <cmath>
 #include <iostream>
@@ -74,17 +75,18 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   const i_t m = problem.num_rows;
   const i_t n = problem.num_cols;
 
-  std::vector<f_t> min_activity(m);
-  std::vector<f_t> max_activity(m);
-
+  // FIXME:: pre-compute transpose and store
   csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
   problem.A.transpose(Arow);
 
+  std::vector<f_t> min_activity(m);
+  std::vector<f_t> max_activity(m);
   std::vector<f_t> constraint_lb(m);
   std::vector<f_t> constraint_ub(m);
 
-  i_t num_finite_lower_bounds = 0;
-  i_t num_finite_upper_bounds = 0;
+  std::vector<bool> constraint_changed(m, true);
+  std::vector<bool> variable_changed(n, false);
+  std::vector<bool> constraint_changed_next(m, false);
 
   for (i_t i = 0; i < m; ++i) {
     if (row_sense[i] == 'L') {
@@ -102,29 +104,12 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   std::vector<f_t> lower = problem.lower;
   std::vector<f_t> upper = problem.upper;
   print_bounds_stats(lower, upper, settings, "Initial bounds");
-  for (i_t i = 0; i < n; ++i) {
-    if (lower[i] > upper[i]) {
-      // std::cout << "Infeasible variable " << i << ", lower " << lower[i] << ", upper " <<
-      // upper[i] << std::endl;
-      return false;
-    }
-  }
 
-  std::vector<i_t> updated_variables_list;
-  updated_variables_list.reserve(n);
-  std::vector<i_t> updated_variables_mark(n, 0);
-
-  i_t iter                         = 0;
-  const i_t iter_limit             = 10;
-  i_t total_strengthened_variables = 0;
+  i_t iter             = 0;
+  const i_t iter_limit = 10;
   while (iter < iter_limit) {
-    // std::cout << " XXXXXXXXXX  Iter:: " << iter << std::endl;
-    // Derive bounds on the constraints
-    // settings.log.printf("Running bound strengthening on %d rows\n", static_cast<i_t>(n));
-
-    // Compute the min and max activity of the constraints
-    // FIXME:: use changed constraints logic
     for (i_t i = 0; i < m; ++i) {
+      if (!constraint_changed[i]) { continue; }
       const i_t row_start = Arow.col_start[i];
       const i_t row_end   = Arow.col_start[i + 1];
 
@@ -133,6 +118,8 @@ bool bound_strengthening(const std::vector<char>& row_sense,
       for (i_t p = row_start; p < row_end; ++p) {
         const i_t j    = Arow.i[p];
         const f_t a_ij = Arow.x[p];
+
+        variable_changed[j] = true;
         if (a_ij > 0) {
           min_a += a_ij * lower[j];
           max_a += a_ij * upper[j];
@@ -148,8 +135,24 @@ bool bound_strengthening(const std::vector<char>& row_sense,
       }
 
       if (max_a < min_a) {
-        // std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", min_a " << min_a
-        // << ", max_a " << max_a << std::endl;
+        settings.log.printf(
+          "Iter:: %d, Infeasible constraint %d, min_a %e, max_a %e\n", iter, i, min_a, max_a);
+        return false;
+      }
+
+      f_t cnst_lb = constraint_lb[i];
+      f_t cnst_ub = constraint_ub[i];
+      bool is_infeasible =
+        check_infeasibility<i_t, f_t>(min_a, max_a, cnst_lb, cnst_ub, settings.primal_tol);
+      if (is_infeasible) {
+        settings.log.printf(
+          "Iter:: %d, Infeasible constraint %d, cnst_lb %e, cnst_ub %e, min_a %e, max_a %e\n",
+          iter,
+          i,
+          cnst_lb,
+          cnst_ub,
+          min_a,
+          max_a);
         return false;
       }
 
@@ -158,94 +161,79 @@ bool bound_strengthening(const std::vector<char>& row_sense,
     }
 
     i_t num_bounds_changed = 0;
-    // FIXME:: Use the transpose of Arow here to update variable bounds
-    // Use the activities to derive new bounds on the variables
-    for (i_t i = 0; i < m; ++i) {
-      const i_t row_start = Arow.col_start[i];
-      const i_t row_end   = Arow.col_start[i + 1];
+
+    for (i_t k = 0; k < n; ++k) {
+      if (!variable_changed[k]) { continue; }
+      f_t old_lb = lower[k];
+      f_t old_ub = upper[k];
+
+      f_t new_lb = old_lb;
+      f_t new_ub = old_ub;
+
+      const i_t row_start = problem.A.col_start[k];
+      const i_t row_end   = problem.A.col_start[k + 1];
       for (i_t p = row_start; p < row_end; ++p) {
-        const i_t k    = Arow.i[p];
-        const f_t a_ik = Arow.x[p];
+        const i_t i = problem.A.i[p];
 
-        f_t min_a   = min_activity[i];
-        f_t max_a   = max_activity[i];
-        f_t cnst_lb = constraint_lb[i];
-        f_t cnst_ub = constraint_ub[i];
-
-        bool is_infeasible =
-          check_infeasibility<i_t, f_t>(min_a, max_a, cnst_lb, cnst_ub, settings.primal_tol);
-        if (is_infeasible) {
-          settings.log.printf(
-            "Infeasible constraint %d, cnst_lb %e, cnst_ub %e, min_a %e, max_a %e\n",
-            i,
-            cnst_lb,
-            cnst_ub,
-            min_a,
-            max_a);
-          return false;
-        }
-
-        f_t old_lb = lower[k];
-        f_t old_ub = upper[k];
-
+        if (!constraint_changed[i]) { continue; }
+        const f_t a_ik = problem.A.x[p];
+        f_t min_a      = min_activity[i];
+        f_t max_a      = max_activity[i];
+        f_t cnst_lb    = constraint_lb[i];
+        f_t cnst_ub    = constraint_ub[i];
         min_a -= (a_ik < 0) ? a_ik * old_ub : a_ik * old_lb;
         max_a -= (a_ik > 0) ? a_ik * old_ub : a_ik * old_lb;
 
         f_t delta_min_act = cnst_ub - min_a;
         f_t delta_max_act = cnst_lb - max_a;
 
-        f_t new_lb = update_lb(old_lb, a_ik, delta_min_act, delta_max_act);
-        f_t new_ub = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
+        new_lb = std::max(new_lb, update_lb(old_lb, a_ik, delta_min_act, delta_max_act));
+        new_ub = std::min(new_ub, update_ub(old_ub, a_ik, delta_min_act, delta_max_act));
+      }
 
-        // Integer rounding
-        if (!var_types.empty() &&
-            (var_types[k] == variable_type_t::INTEGER || var_types[k] == variable_type_t::BINARY)) {
-          new_lb = std::ceil(new_lb - settings.integer_tol);
-          new_ub = std::floor(new_ub + settings.integer_tol);
-        }
+      // Integer rounding
+      if (!var_types.empty() &&
+          (var_types[k] == variable_type_t::INTEGER || var_types[k] == variable_type_t::BINARY)) {
+        new_lb = std::ceil(new_lb - settings.integer_tol);
+        new_ub = std::floor(new_ub + settings.integer_tol);
+      }
 
-        if (std::isfinite(old_lb)) { assert(std::isfinite(new_lb)); }
-        if (std::isfinite(old_ub)) { assert(std::isfinite(new_ub)); }
+      bool lb_updated = abs(new_lb - old_lb) > 1e3 * settings.primal_tol;
+      bool ub_updated = abs(new_ub - old_ub) > 1e3 * settings.primal_tol;
 
-        bool lb_updated = abs(new_lb - old_lb) > 1e3 * settings.primal_tol;
-        bool ub_updated = abs(new_ub - old_ub) > 1e3 * settings.primal_tol;
+      new_lb = std::max(new_lb, problem.lower[k]);
+      new_ub = std::min(new_ub, problem.upper[k]);
 
-        if (lb_updated) { lower[k] = new_lb; }
-        if (ub_updated) { upper[k] = new_ub; }
-
-        if (lower[k] > upper[k] + 1e-6) {
-          // std::cout << "Iter:: " << iter << ", Infeasible variable after update " << k << ",
-          // lower " << lower[k] << ", upper " << upper[k] << std::endl;
-          return false;
-        }
-        lower[k] = std::min(lower[k], upper[k]);
-
-        bool bounds_changed = lb_updated || ub_updated;
-        if (bounds_changed) {
-          num_bounds_changed++;
-          if (!updated_variables_mark[k]) { updated_variables_list.push_back(k); }
+      if (new_lb > new_ub + 1e-6) {
+        // std::cout << "Iter:: " << iter << ", Infeasible variable after update " << k << ", " <<
+        // new_lb << " > " << new_ub << std::endl;
+        settings.log.printf(
+          "Iter:: %d, Infeasible variable after update %d, %e > %e\n", iter, k, new_lb, new_ub);
+        return false;
+      }
+      if (new_lb != old_lb || new_ub != old_ub) {
+        for (i_t p = row_start; p < row_end; ++p) {
+          const i_t i                = problem.A.i[p];
+          constraint_changed_next[i] = true;
         }
       }
+
+      lower[k] = std::min(new_lb, new_ub);
+      upper[k] = std::max(new_lb, new_ub);
+
+      bool bounds_changed = lb_updated || ub_updated;
+      if (bounds_changed) { num_bounds_changed++; }
     }
 
-    if (num_bounds_changed == 0) {
-      settings.log.printf("No bounds changed, iter %d\n", iter + 1);
-      break;
-    } else {
-      settings.log.printf("Num bounds changed %d, iter %d\n", num_bounds_changed, iter + 1);
-    }
+    if (num_bounds_changed == 0) { break; }
 
-    // Update the bounds on the constraints
-    // settings.log.printf("Round %d: Strengthend %d variables\n",
-    //                     iter,
-    //                     static_cast<i_t>(updated_variables_list.size()));
-    total_strengthened_variables += updated_variables_list.size();
-    for (i_t j : updated_variables_list) {
-      updated_variables_mark[j] = 0;
-    }
-    updated_variables_list.clear();
+    std::swap(constraint_changed, constraint_changed_next);
+    std::fill(constraint_changed_next.begin(), constraint_changed_next.end(), false);
+    std::fill(variable_changed.begin(), variable_changed.end(), false);
+
     iter++;
   }
+
   // settings.log.printf("Total strengthened variables %d\n", total_strengthened_variables);
 
 #if DEBUG_BOUND_STRENGTHENING

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -133,15 +133,21 @@ bool bound_strengthening(const std::vector<char>& row_sense,
 
         bool is_infeasible =
           check_infeasibility<i_t, f_t>(min_a, max_a, cnst_lb, cnst_ub, settings.primal_tol);
-        if (is_infeasible) { return false; }
+        if (is_infeasible) { 
+          settings.log.printf("Infeasible constraint %d, cnst_lb %e, cnst_ub %e, min_a %e, max_a %e\n", i, cnst_lb, cnst_ub, min_a, max_a);
+          std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", cnst_lb " << cnst_lb << ", cnst_ub " << cnst_ub << ", min_a " << min_a << ", max_a " << max_a << std::endl;
+          return false; 
+        }
 
-        min_a -= (a_ik < 0) ? a_ik * cnst_ub : a_ik * cnst_lb;
-        max_a -= (a_ik > 0) ? a_ik * cnst_ub : a_ik * cnst_lb;
+        f_t old_lb        = lower[k];
+        f_t old_ub        = upper[k];
+
+        min_a -= (a_ik < 0) ? a_ik * old_ub : a_ik * old_lb;
+        max_a -= (a_ik > 0) ? a_ik * old_ub : a_ik * old_lb;
 
         f_t delta_min_act = cnst_ub - min_a;
         f_t delta_max_act = cnst_lb - max_a;
-        f_t old_lb        = lower[k];
-        f_t old_ub        = upper[k];
+
         f_t new_lb        = update_lb(old_lb, a_ik, delta_min_act, delta_max_act);
         f_t new_ub        = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
 

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -20,6 +20,7 @@
 #include <dual_simplex/right_looking_lu.hpp>
 
 #include <cmath>
+#include <iostream>
 
 namespace cuopt::linear_programming::dual_simplex {
 
@@ -133,14 +134,22 @@ bool bound_strengthening(const std::vector<char>& row_sense,
 
         bool is_infeasible =
           check_infeasibility<i_t, f_t>(min_a, max_a, cnst_lb, cnst_ub, settings.primal_tol);
-        if (is_infeasible) { 
-          settings.log.printf("Infeasible constraint %d, cnst_lb %e, cnst_ub %e, min_a %e, max_a %e\n", i, cnst_lb, cnst_ub, min_a, max_a);
-          std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", cnst_lb " << cnst_lb << ", cnst_ub " << cnst_ub << ", min_a " << min_a << ", max_a " << max_a << std::endl;
-          return false; 
+        if (is_infeasible) {
+          settings.log.printf(
+            "Infeasible constraint %d, cnst_lb %e, cnst_ub %e, min_a %e, max_a %e\n",
+            i,
+            cnst_lb,
+            cnst_ub,
+            min_a,
+            max_a);
+          std::cout << "Iter:: " << iter << ", Infeasible constraint " << i << ", cnst_lb "
+                    << cnst_lb << ", cnst_ub " << cnst_ub << ", min_a " << min_a << ", max_a "
+                    << max_a << std::endl;
+          return false;
         }
 
-        f_t old_lb        = lower[k];
-        f_t old_ub        = upper[k];
+        f_t old_lb = lower[k];
+        f_t old_ub = upper[k];
 
         min_a -= (a_ik < 0) ? a_ik * old_ub : a_ik * old_lb;
         max_a -= (a_ik > 0) ? a_ik * old_ub : a_ik * old_lb;
@@ -148,8 +157,8 @@ bool bound_strengthening(const std::vector<char>& row_sense,
         f_t delta_min_act = cnst_ub - min_a;
         f_t delta_max_act = cnst_lb - max_a;
 
-        f_t new_lb        = update_lb(old_lb, a_ik, delta_min_act, delta_max_act);
-        f_t new_ub        = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
+        f_t new_lb = update_lb(old_lb, a_ik, delta_min_act, delta_max_act);
+        f_t new_ub = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
 
         // Integer rounding
         if (!var_types.empty() &&

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -84,6 +84,10 @@ bool bound_strengthening(const std::vector<char>& row_sense,
   std::vector<f_t> constraint_lb(m);
   std::vector<f_t> constraint_ub(m);
 
+  // FIXME:: Instead of initializing constraint_changed to true, we can only look 
+  // at the constraints corresponding to branched variable in branch and bound
+  // This is because, the parent LP already checked for feasibility of the constraints 
+  // without the branched variable bounds
   std::vector<bool> constraint_changed(m, true);
   std::vector<bool> variable_changed(n, false);
   std::vector<bool> constraint_changed_next(m, false);

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -23,26 +23,55 @@
 
 namespace cuopt::linear_programming::dual_simplex {
 
+template <typename f_t>
+static inline f_t update_lb(f_t curr_lb, f_t coeff, f_t delta_min_act, f_t delta_max_act)
+{
+  auto comp_bnd = (coeff < 0.) ? delta_min_act / coeff : delta_max_act / coeff;
+  return std::max(curr_lb, comp_bnd);
+}
+
+template <typename f_t>
+static inline f_t update_ub(f_t curr_ub, f_t coeff, f_t delta_min_act, f_t delta_max_act)
+{
+  auto comp_bnd = (coeff < 0.) ? delta_max_act / coeff : delta_min_act / coeff;
+  return std::min(curr_ub, comp_bnd);
+}
+
 template <typename i_t, typename f_t>
-void bound_strengthening(const std::vector<char>& row_sense,
+static inline bool check_infeasibility(f_t min_a, f_t max_a, f_t cnst_lb, f_t cnst_ub, f_t eps)
+{
+  return (min_a > cnst_ub + eps) || (max_a < cnst_lb - eps);
+}
+
+template <typename i_t, typename f_t>
+bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
-                         lp_problem_t<i_t, f_t>& problem)
+                         lp_problem_t<i_t, f_t>& problem,
+                         const std::vector<i_t>& is_int)
 {
   const i_t m = problem.num_rows;
   const i_t n = problem.num_cols;
 
-  std::vector<f_t> constraint_lower(m);
-  std::vector<i_t> num_lower_infinity(m);
-  std::vector<i_t> num_upper_infinity(m);
+  std::vector<f_t> min_activity(m);
+  std::vector<f_t> max_activity(m);
 
   csc_matrix_t<i_t, f_t> Arow(1, 1, 1);
   problem.A.transpose(Arow);
 
-  std::vector<i_t> less_rows;
-  less_rows.reserve(m);
+  std::vector<f_t> constraint_lb(m);
+  std::vector<f_t> constraint_ub(m);
 
   for (i_t i = 0; i < m; ++i) {
-    if (row_sense[i] == 'L') { less_rows.push_back(i); }
+    if (row_sense[i] == 'L') {
+      constraint_ub[i] = problem.rhs[i];
+      constraint_lb[i] = -inf;
+    } else if (row_sense[i] == 'G') {
+      constraint_lb[i] = problem.rhs[i];
+      constraint_ub[i] = inf;
+    } else {
+      constraint_lb[i] = problem.rhs[i];
+      constraint_ub[i] = problem.rhs[i];
+    }
   }
 
   std::vector<f_t> lower = problem.lower;
@@ -55,73 +84,88 @@ void bound_strengthening(const std::vector<char>& row_sense,
   i_t iter                         = 0;
   const i_t iter_limit             = 10;
   i_t total_strengthened_variables = 0;
-  settings.log.printf("Less equal rows %d\n", less_rows.size());
-  while (iter < iter_limit && less_rows.size() > 0) {
+  while (iter < iter_limit) {
     // Derive bounds on the constraints
-    settings.log.printf("Running bound strengthening on %d rows\n",
-                        static_cast<i_t>(less_rows.size()));
-    for (i_t i : less_rows) {
-      const i_t row_start   = Arow.col_start[i];
-      const i_t row_end     = Arow.col_start[i + 1];
-      num_lower_infinity[i] = 0;
-      num_upper_infinity[i] = 0;
+    settings.log.printf("Running bound strengthening on %d rows\n", static_cast<i_t>(n));
 
-      f_t lower_limit = 0.0;
+    // Compute the min and max activity of the constraints
+    // FIXME:: use changed constraints logic
+    for (i_t i = 0; i < m; ++i) {
+      const i_t row_start = Arow.col_start[i];
+      const i_t row_end   = Arow.col_start[i + 1];
+
+      f_t min_a = 0.0;
+      f_t max_a = 0.0;
       for (i_t p = row_start; p < row_end; ++p) {
         const i_t j    = Arow.i[p];
         const f_t a_ij = Arow.x[p];
         if (a_ij > 0) {
-          lower_limit += a_ij * lower[j];
+          min_a += a_ij * lower[j];
+          max_a += a_ij * upper[j];
         } else if (a_ij < 0) {
-          lower_limit += a_ij * upper[j];
+          min_a += a_ij * upper[j];
+          max_a += a_ij * lower[j];
         }
-        if (lower[j] == -inf && a_ij > 0) {
-          num_lower_infinity[i]++;
-          lower_limit = -inf;
-        }
-        if (upper[j] == inf && a_ij < 0) {
-          num_lower_infinity[i]++;
-          lower_limit = -inf;
-        }
+        if (upper[j] == inf && a_ij > 0) { max_a = inf; }
+        if (lower[j] == -inf && a_ij < 0) { max_a = inf; }
+
+        if (lower[j] == -inf && a_ij > 0) { min_a = -inf; }
+        if (upper[j] == inf && a_ij < 0) { min_a = -inf; }
       }
-      constraint_lower[i] = lower_limit;
+      min_activity[i] = min_a;
+      max_activity[i] = max_a;
     }
 
-    // Use the constraint bounds to derive new bounds on the variables
-    for (i_t i : less_rows) {
-      if (std::isfinite(constraint_lower[i]) && num_lower_infinity[i] == 0) {
-        const i_t row_start = Arow.col_start[i];
-        const i_t row_end   = Arow.col_start[i + 1];
-        for (i_t p = row_start; p < row_end; ++p) {
-          const i_t k    = Arow.i[p];
-          const f_t a_ik = Arow.x[p];
-          if (a_ik > 0) {
-            const f_t new_upper = lower[k] + (problem.rhs[i] - constraint_lower[i]) / a_ik;
-            if (new_upper < upper[k]) {
-              upper[k] = new_upper;
-              if (lower[k] > upper[k]) {
-                settings.log.printf(
-                  "\t INFEASIBLE!!!!!!!!!!!!!!!!! constraint_lower %e lower %e rhs %e\n",
-                  constraint_lower[i],
-                  lower[k],
-                  problem.rhs[i]);
-              }
-              if (!updated_variables_mark[k]) { updated_variables_list.push_back(k); }
-            }
-          } else if (a_ik < 0) {
-            const f_t new_lower = upper[k] + (problem.rhs[i] - constraint_lower[i]) / a_ik;
-            if (new_lower > lower[k]) {
-              lower[k] = new_lower;
-              if (lower[k] > upper[k]) {
-                settings.log.printf("\t INFEASIBLE !!!!!!!!!!!!!!!!!!1\n");
-              }
-              if (!updated_variables_mark[k]) { updated_variables_list.push_back(k); }
-            }
-          }
+    i_t num_bounds_changed = 0;
+    // FIXME:: Use the transpose of Arow here to update variable bounds
+    // Use the activities to derive new bounds on the variables
+    for (i_t i = 0; i < m; ++i) {
+      const i_t row_start = Arow.col_start[i];
+      const i_t row_end   = Arow.col_start[i + 1];
+      for (i_t p = row_start; p < row_end; ++p) {
+        const i_t k    = Arow.i[p];
+        const f_t a_ik = Arow.x[p];
+
+        f_t min_a   = min_activity[i];
+        f_t max_a   = max_activity[i];
+        f_t cnst_lb = constraint_lb[i];
+        f_t cnst_ub = constraint_ub[i];
+
+        bool is_infeasible =
+          check_infeasibility<i_t, f_t>(min_a, max_a, cnst_lb, cnst_ub, settings.primal_tol);
+        if (is_infeasible) { return false; }
+
+        min_a -= (a_ik < 0) ? a_ik * cnst_ub : a_ik * cnst_lb;
+        max_a -= (a_ik > 0) ? a_ik * cnst_ub : a_ik * cnst_lb;
+
+        f_t delta_min_act = cnst_ub - min_a;
+        f_t delta_max_act = cnst_lb - max_a;
+        f_t old_lb        = lower[k];
+        f_t old_ub        = upper[k];
+        f_t new_lb        = update_lb(old_lb, a_ik, delta_min_act, delta_max_act);
+        f_t new_ub        = update_ub(old_ub, a_ik, delta_min_act, delta_max_act);
+
+        // Integer rounding
+        if (!is_int.empty() && is_int[k]) {
+          new_lb = std::ceil(new_lb - settings.integer_tol);
+          new_ub = std::floor(new_ub + settings.integer_tol);
+        }
+
+        bool lb_updated = abs(new_lb - old_lb) > 1e3 * settings.primal_tol;
+        bool ub_updated = abs(new_ub - old_ub) > 1e3 * settings.primal_tol;
+
+        if (lb_updated) { lower[k] = new_lb; }
+        if (ub_updated) { upper[k] = new_ub; }
+
+        bool bounds_changed = lb_updated || ub_updated;
+        if (bounds_changed) {
+          num_bounds_changed++;
+          if (!updated_variables_mark[k]) { updated_variables_list.push_back(k); }
         }
       }
     }
-    less_rows.clear();
+
+    if (num_bounds_changed == 0) { break; }
 
     // Update the bounds on the constraints
     settings.log.printf("Round %d: Strengthend %d variables\n",
@@ -130,12 +174,6 @@ void bound_strengthening(const std::vector<char>& row_sense,
     total_strengthened_variables += updated_variables_list.size();
     for (i_t j : updated_variables_list) {
       updated_variables_mark[j] = 0;
-      const i_t col_start       = problem.A.col_start[j];
-      const i_t col_end         = problem.A.col_start[j + 1];
-      for (i_t p = col_start; p < col_end; ++p) {
-        const i_t i = problem.A.i[p];
-        less_rows.push_back(i);
-      }
     }
     updated_variables_list.clear();
     iter++;
@@ -143,6 +181,7 @@ void bound_strengthening(const std::vector<char>& row_sense,
   settings.log.printf("Total strengthened variables %d\n", total_strengthened_variables);
   problem.lower = lower;
   problem.upper = upper;
+  return true;
 }
 
 template <typename i_t, typename f_t>
@@ -1077,6 +1116,12 @@ template void uncrush_solution<int, double>(const presolve_info_t<int, double>& 
                                             const std::vector<double>& crushed_z,
                                             std::vector<double>& uncrushed_x,
                                             std::vector<double>& uncrushed_z);
+
+template bool bound_strengthening<int, double>(
+  const std::vector<char>& row_sense,
+  const simplex_solver_settings_t<int, double>& settings,
+  lp_problem_t<int, double>& problem,
+  const std::vector<int>& is_int);
 #endif
 
 }  // namespace cuopt::linear_programming::dual_simplex

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -138,12 +138,6 @@ bool bound_strengthening(const std::vector<char>& row_sense,
         if (upper[j] == inf && a_ij < 0) { min_a = -inf; }
       }
 
-      if (max_a < min_a) {
-        settings.log.printf(
-          "Iter:: %d, Infeasible constraint %d, min_a %e, max_a %e\n", iter, i, min_a, max_a);
-        return false;
-      }
-
       f_t cnst_lb = constraint_lb[i];
       f_t cnst_ub = constraint_ub[i];
       bool is_infeasible =

--- a/cpp/src/dual_simplex/presolve.hpp
+++ b/cpp/src/dual_simplex/presolve.hpp
@@ -131,10 +131,11 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
                       std::vector<f_t>& uncrushed_x,
                       std::vector<f_t>& uncrushed_z);
 
+// For pure LP bounds strengthening, var_types should be defaulted (i.e. left empty)
 template <typename i_t, typename f_t>
 bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
                          lp_problem_t<i_t, f_t>& problem,
-                         const std::vector<i_t>& is_int = {});
+                         const std::vector<variable_type_t>& var_types = {});
 
 }  // namespace cuopt::linear_programming::dual_simplex

--- a/cpp/src/dual_simplex/presolve.hpp
+++ b/cpp/src/dual_simplex/presolve.hpp
@@ -136,6 +136,8 @@ template <typename i_t, typename f_t>
 bool bound_strengthening(const std::vector<char>& row_sense,
                          const simplex_solver_settings_t<i_t, f_t>& settings,
                          lp_problem_t<i_t, f_t>& problem,
-                         const std::vector<variable_type_t>& var_types = {});
+                         const csc_matrix_t<i_t, f_t>& Arow,
+                         const std::vector<variable_type_t>& var_types = {},
+                         const std::vector<bool>& bounds_changed       = {});
 
 }  // namespace cuopt::linear_programming::dual_simplex

--- a/cpp/src/dual_simplex/presolve.hpp
+++ b/cpp/src/dual_simplex/presolve.hpp
@@ -131,4 +131,10 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
                       std::vector<f_t>& uncrushed_x,
                       std::vector<f_t>& uncrushed_z);
 
+template <typename i_t, typename f_t>
+bool bound_strengthening(const std::vector<char>& row_sense,
+                         const simplex_solver_settings_t<i_t, f_t>& settings,
+                         lp_problem_t<i_t, f_t>& problem,
+                         const std::vector<i_t>& is_int = {});
+
 }  // namespace cuopt::linear_programming::dual_simplex


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
This PR implements node presolve using the bounds strengthening algorithm. At each node in branch-and-bound tree,  host presolve is run to (i) improve the bounds on the variables (ii) to detect infeasibility and fathom nodes accordingly

**Details**

- The bounds strengthening takes into account of integrality constraints. This leads to more infeasibility detection than doing the dual simplex. 
- Bounds strengthening is done only starting with the constraints that are associated with the branched variables (all up to the root node) only.  For examples, if the current node is depth 7, only constraints relating to these 7 variables are considered changed for the first iteration of bounds strengthening. This greatly improves the performance of the node presolve
- This bounds strengthening is performed on the cpu

## Issue
Closes #276 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
