### PR TITLE
Add support for cuda13 container and fix cuda13 lib issues in wheel

### DIFF
--- a/.github/workflows/build_test_publish_images.yaml
+++ b/.github/workflows/build_test_publish_images.yaml
@@ -32,11 +32,11 @@ on:
         description: 'JSON array of architectures to build for'
       cuda_ver:
         type: string
-        default: '["12.9.0"]'
+        default: '["12.9.0", "13.0.0"]'
         description: 'JSON array of CUDA versions to build for'
       python_ver:
         type: string
-        default: '["3.12.11"]'
+        default: '["3.13.7"]'
         description: 'JSON array of Python versions to build for'
       linux_ver:
         type: string

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repo is also hosted as a [COIN-OR](http://github.com/coin-or/cuopt/) projec
 
 ### CUDA/GPU requirements
 
-* CUDA 12.0+
+* CUDA 12.0+ or CUDA 13.0+
 * NVIDIA driver >= 525.60.13 (Linux) and >= 527.41 (Windows)
 * Volta architecture or better (Compute Capability >=7.0)
 
@@ -77,6 +77,25 @@ pip install --pre \
   cuopt-server-cu12==25.10.* cuopt-sh-client==25.10.*
 ```
 
+For CUDA 13.x:
+
+```bash
+pip install \
+  --extra-index-url=https://pypi.nvidia.com \
+  nvidia-cuda-runtime==13.0.* \
+  cuopt-server-cu13==25.10.* cuopt-sh-client==25.10.*
+```
+
+Development wheels are available as nightlies, please update `--extra-index-url` to `https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/` to install latest nightly packages.
+```bash
+pip install --pre \
+  --extra-index-url=https://pypi.nvidia.com \
+  --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
+  nvidia-cuda-runtime==13.0.* \
+  cuopt-server-cu13==25.10.* cuopt-sh-client==25.10.*
+```
+
+
 ### Conda
 
 cuOpt can be installed with conda (via [miniforge](https://github.com/conda-forge/miniforge)):
@@ -95,10 +114,14 @@ of our latest development branch. Just replace `-c rapidsai` with `-c rapidsai-n
 Users can pull the cuOpt container from the NVIDIA container registry.
 
 ```bash
+# For CUDA 12.x
 docker pull nvidia/cuopt:latest-cuda12.9-py312
+
+# For CUDA 13.x
+docker pull nvidia/cuopt:latest-cuda13.0-py312
 ```
 
-Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py312`` tag. For example, to use cuOpt 25.5.0, you can use the ``25.5.0-cuda12.8-py312`` tag. Please refer to `cuOpt dockerhub page <https://hub.docker.com/r/nvidia/cuopt>`_ for the list of available tags.
+Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py312`` or ``<version>-cuda13.0-py312`` tag. For example, to use cuOpt 25.5.0, you can use the ``25.5.0-cuda12.8-py312`` or ``25.5.0-cuda13.0-py312`` tag. Please refer to `cuOpt dockerhub page <https://hub.docker.com/r/nvidia/cuopt>`_ for the list of available tags.
 
 More information about the cuOpt container can be found [here](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-server/quick-start.html#container-from-docker-hub).
 

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -54,15 +54,21 @@ ARG CUOPT_VER
 ARG PYTHON_SHORT_VER
 
 # Install cuOpt as root to make it available to all users
-RUN cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
+RUN \
+    cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
     cuda_major_minor=$(echo ${CUDA_VER} | cut -d'.' -f1-2) && \
+    if [ "$cuda_suffix" = "cu13" ]; then \
+      nvidia_cuda_runtime_pkg="nvidia-cuda-runtime==${cuda_major_minor}.*"; \
+    else \
+      nvidia_cuda_runtime_pkg="nvidia-cuda-runtime-${cuda_suffix}==${cuda_major_minor}.*"; \
+    fi && \
     python -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
       --no-cache-dir \
       "cuopt-server-${cuda_suffix}==${CUOPT_VER}" \
       "cuopt-sh-client==${CUOPT_VER}" \
-      "nvidia-cuda-runtime-${cuda_suffix}==${cuda_major_minor}.*" && \
+      ${nvidia_cuda_runtime_pkg} && \
     python -m pip list
 
 # Remove gcc to save space, gcc was required for building psutils

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -57,17 +57,13 @@ ARG PYTHON_SHORT_VER
 RUN \
     cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
     cuda_major_minor=$(echo ${CUDA_VER} | cut -d'.' -f1-2) && \
-    if [ "$cuda_suffix" = "cu13" ]; then \
-      nvidia_cuda_runtime_pkg="nvidia-cuda-runtime==${cuda_major_minor}.*"; \
-    else \
-      nvidia_cuda_runtime_pkg="nvidia-cuda-runtime-${cuda_suffix}==${cuda_major_minor}.*"; \
-    fi && \
     python -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
       --no-cache-dir \
       "cuopt-server-${cuda_suffix}==${CUOPT_VER}" \
       "cuopt-sh-client==${CUOPT_VER}" \
+      "cuda-toolkit[cudart]==${cuda_major_minor}.*" \
       ${nvidia_cuda_runtime_pkg} && \
     python -m pip list
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -757,11 +757,11 @@ dependencies:
               cuda: "13.*"
               use_cuda_wheels: "true"
             packages:
-              - nvidia-cublas-cu13
-              - nvidia-curand-cu13
-              - nvidia-cusparse-cu13
-              - nvidia-cusolver-cu13
-              - nvidia-nvtx-cu13
+              - nvidia-cublas
+              - nvidia-curand
+              - nvidia-cusparse
+              - nvidia-cusolver
+              - nvidia-nvtx
           # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
           # (e.g. for DLFW and pip devcontainers)
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -748,20 +748,12 @@ dependencies:
               cuda: "12.*"
               use_cuda_wheels: "true"
             packages:
-              - nvidia-cublas-cu12
-              - nvidia-curand-cu12
-              - nvidia-cusparse-cu12
-              - nvidia-cusolver-cu12
-              - nvidia-nvtx-cu12
+              - cuda-toolkit[cublas,curand,cusolver,cusparse,nvtx]==12.*
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "true"
             packages:
-              - nvidia-cublas
-              - nvidia-curand
-              - nvidia-cusparse
-              - nvidia-cusolver
-              - nvidia-nvtx
+              - cuda-toolkit[cublas,curand,cusolver,cusparse,nvtx]==13.*
           # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
           # (e.g. for DLFW and pip devcontainers)
           - matrix:

--- a/docs/cuopt/source/cuopt-c/quick-start.rst
+++ b/docs/cuopt/source/cuopt-c/quick-start.rst
@@ -20,7 +20,7 @@ This wheel is a Python wrapper around the C++ library and eases installation and
 
     # CUDA 13
     pip install --extra-index-url=https://pypi.nvidia.com \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'libcuopt-cu13==25.10.*'
 
     # CUDA 12
@@ -36,7 +36,7 @@ This wheel is a Python wrapper around the C++ library and eases installation and
 
     # CUDA 13
     pip install --pre --extra-index-url=https://pypi.nvidia.com --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'libcuopt-cu13==25.10.*'
 
     # CUDA 12

--- a/docs/cuopt/source/cuopt-python/quick-start.rst
+++ b/docs/cuopt/source/cuopt-python/quick-start.rst
@@ -14,7 +14,7 @@ pip
 
     # CUDA 13
     pip install --extra-index-url=https://pypi.nvidia.com \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'cuopt-cu13==25.10.*'
 
     # CUDA 12
@@ -30,7 +30,7 @@ pip
 
     # CUDA 13
     pip install --pre --extra-index-url=https://pypi.nvidia.com --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'cuopt-cu13==25.10.*'
 
     # CUDA 12

--- a/docs/cuopt/source/cuopt-server/quick-start.rst
+++ b/docs/cuopt/source/cuopt-server/quick-start.rst
@@ -12,7 +12,7 @@ pip
 
     # CUDA 13
     pip install --extra-index-url=https://pypi.nvidia.com \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'cuopt-server-cu13==25.10.*' \
       'cuopt-sh-client==25.10.*'
 
@@ -29,7 +29,7 @@ pip
 
     # CUDA 13
     pip install --pre --extra-index-url=https://pypi.nvidia.com --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
-      'nvidia-cuda-runtime-cu13==13.0.*' \
+      'nvidia-cuda-runtime==13.0.*' \
       'cuopt-server-cu13==25.10.*' \
       'cuopt-sh-client==25.10.*'
 

--- a/python/libcuopt/CMakeLists.txt
+++ b/python/libcuopt/CMakeLists.txt
@@ -69,6 +69,8 @@ set(rpaths
   "$ORIGIN/../../nvidia/curand/lib"
   "$ORIGIN/../../nvidia/cusolver/lib"
   "$ORIGIN/../../nvidia/cusparse/lib"
+  # For CUDA 13.x
+  "$ORIGIN/../../nvidia/cu13/lib"
 )
 
 set_property(TARGET cuopt PROPERTY INSTALL_RPATH ${rpaths} APPEND)


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
- This PR adds support for cuda 13 container for nightly and release
- Also updates python version to 3.13
- Also cuda-toolkits have stopped using cu13 suffixes and they need to be fixed in dependencies
- This also requires addition to RPATH since the paths are different for cu13

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA
