### PR TITLE
Add optional timestamps enabled by env CUOPT_EXTRA_TIMESTAMPS

### DIFF
--- a/cpp/src/linear_programming/cuopt_c.cpp
+++ b/cpp/src/linear_programming/cuopt_c.cpp
@@ -27,7 +27,9 @@
 #include <cuopt/version_config.hpp>
 
 #include <memory>
+#include <cstdlib>
 #include <string>
+
 
 using namespace cuopt::mps_parser;
 using namespace cuopt::linear_programming;
@@ -74,6 +76,29 @@ cuopt_int_t cuOptGetVersion(cuopt_int_t* version_major,
   return CUOPT_SUCCESS;
 }
 
+bool extraTimestamps() {
+    const char* envValue = std::getenv("CUOPT_EXTRA_TIMESTAMPS");
+    if (envValue == nullptr) {
+        return false;
+    }
+    
+    std::string value(envValue);
+    return (value == "True" || value == "true" || value == "1");
+}
+
+
+double getCurrentTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    return std::chrono::duration<double>(now.time_since_epoch()).count();
+}
+
+void printTimestamp(const std::string& label) {
+    if (extraTimestamps()) {    
+        std::cout << std::fixed << std::setprecision(6);
+        std::cout << std::endl << label << ": " << getCurrentTimestamp() << std::endl;
+    }
+}
+
 cuopt_int_t cuOptReadProblem(const char* filename, cuOptOptimizationProblem* problem_ptr)
 {
   problem_and_stream_view_t* problem_and_stream = new problem_and_stream_view_t();
@@ -115,6 +140,9 @@ cuopt_int_t cuOptCreateProblem(cuopt_int_t num_constraints,
                                const char* variable_types,
                                cuOptOptimizationProblem* problem_ptr)
 {
+
+  printTimestamp("CUOPT_CREATE_PROBLEM");
+  
   if (problem_ptr == nullptr || objective_coefficients == nullptr ||
       constraint_matrix_row_offsets == nullptr || constraint_matrix_column_indices == nullptr ||
       constraint_matrix_coefficent_values == nullptr || constraint_sense == nullptr ||
@@ -170,6 +198,9 @@ cuopt_int_t cuOptCreateRangedProblem(cuopt_int_t num_constraints,
                                      const char* variable_types,
                                      cuOptOptimizationProblem* problem_ptr)
 {
+
+  printTimestamp("CUOPT_CREATE_PROBLEM");
+  
   if (problem_ptr == nullptr || objective_coefficients == nullptr ||
       constraint_matrix_row_offsets == nullptr || constraint_matrix_column_indices == nullptr ||
       constraint_matrix_coefficent_values == nullptr || constraint_lower_bounds == nullptr ||
@@ -596,6 +627,8 @@ cuopt_int_t cuOptSolve(cuOptOptimizationProblem problem,
                        cuOptSolverSettings settings,
                        cuOptSolution* solution_ptr)
 {
+  printTimestamp("CUOPT_SOLVE_START");
+
   if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
   if (settings == nullptr) { return CUOPT_INVALID_ARGUMENT; }
   if (solution_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
@@ -614,6 +647,9 @@ cuopt_int_t cuOptSolve(cuOptOptimizationProblem problem,
     solution_and_stream_view->mip_solution_ptr = new mip_solution_t<cuopt_int_t, cuopt_float_t>(
       solve_mip<cuopt_int_t, cuopt_float_t>(*op_problem, mip_settings));
     *solution_ptr = static_cast<cuOptSolution>(solution_and_stream_view);
+
+    printTimestamp("CUOPT_SOLVE_RETURN");
+    
     return static_cast<cuopt_int_t>(
       solution_and_stream_view->mip_solution_ptr->get_error_status().get_error_type());
   } else {
@@ -629,6 +665,9 @@ cuopt_int_t cuOptSolve(cuOptOptimizationProblem problem,
       new optimization_problem_solution_t<cuopt_int_t, cuopt_float_t>(
         solve_lp<cuopt_int_t, cuopt_float_t>(*op_problem, pdlp_settings));
     *solution_ptr = static_cast<cuOptSolution>(solution_and_stream_view);
+
+    printTimestamp("CUOPT_SOLVE_RETURN");
+
     return static_cast<cuopt_int_t>(
       solution_and_stream_view->lp_solution_ptr->get_error_status().get_error_type());
   }

--- a/python/cuopt/cuopt/linear_programming/data_model/data_model.py
+++ b/python/cuopt/cuopt/linear_programming/data_model/data_model.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+import os
+
 from . import data_model_wrapper
 from .utilities import catch_cuopt_exception
 
@@ -151,6 +154,8 @@ class DataModel(data_model_wrapper.DataModel):
     """
 
     def __init__(self):
+        if os.environ.get("CUOPT_EXTRA_TIMESTAMPS", False) in (True, "True", "true"):
+            print(f"CUOPT_CREATE_PROBLEM: {time.time()}")
         super().__init__()
 
     @catch_cuopt_exception

--- a/python/cuopt/cuopt/linear_programming/problem.py
+++ b/python/cuopt/cuopt/linear_programming/problem.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from enum import Enum
-
+import time
 import numpy as np
 
 import cuopt.linear_programming.data_model as data_model
@@ -950,6 +950,10 @@ class Problem:
         >>> problem.solve()
         """
 
+        # Move optional timing marker to the beginning of the
+        # routine
+        dm = data_model.DataModel()
+        
         # iterate through the constraints and construct the constraint matrix
         n = len(self.vars)
         self.row_pointers = [0]
@@ -975,7 +979,6 @@ class Problem:
             self.upper_bound[j] = self.vars[j].getUpperBound()
 
         # Initialize datamodel
-        dm = data_model.DataModel()
         dm.set_csr_constraint_matrix(
             np.array(self.values),
             np.array(self.column_indicies),

--- a/python/cuopt/cuopt/linear_programming/solver/solver.py
+++ b/python/cuopt/cuopt/linear_programming/solver/solver.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+import os
+
 from cuopt.linear_programming.solver import solver_wrapper
 from cuopt.linear_programming.solver_settings import SolverSettings
 from cuopt.utilities import catch_cuopt_exception
@@ -78,6 +81,11 @@ def Solve(data_model, solver_settings=None):
     >>> # Print the value of one specific variable
     >>> print(solution.get_vars()["var_name"])
     """
+
+    emit_stamps = os.environ.get("CUOPT_EXTRA_TIMESTAMPS", False) in (True, "True", "true")
+    if emit_stamps:
+        print(f"CUOPT_SOLVE_START: {time.time()}")
+
     if solver_settings is None:
         solver_settings = SolverSettings()
 
@@ -95,11 +103,14 @@ def Solve(data_model, solver_settings=None):
             # Mixed types - fallback to comprehensive check
             return any(vt == "I" or vt == b"I" for vt in var_types)
 
-    return solver_wrapper.Solve(
+    s = solver_wrapper.Solve(
         data_model,
         solver_settings,
         mip=is_mip(data_model.get_variable_types()),
     )
+    if emit_stamps:
+        print(f"CUOPT_SOLVE_RETURN: {time.time()}")
+    return s
 
 
 @catch_cuopt_exception


### PR DESCRIPTION
This change adds optional internal timestamps which can be enabled with env var CUOPT_EXTRA_TIMESTAMPS=True.

The timestamps are to allow benchmarking scripts to key off of the events in order to calculate problem setup and teardown time. 