### PR TITLE
Remove limiting_resource_adaptor leftover

### DIFF
--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -259,9 +259,7 @@ void run_single_file_mp(std::string file_path,
 {
   std::cout << "running file " << file_path << " on gpu : " << device << std::endl;
   auto memory_resource = make_async();
-  auto limiting_adaptor =
-    rmm::mr::limiting_resource_adaptor(memory_resource.get(), 6ULL * 1024ULL * 1024ULL * 1024ULL);
-  rmm::mr::set_current_device_resource(&limiting_adaptor);
+  rmm::mr::set_current_device_resource(memory_resource.get());
   int sol_found = run_single_file(file_path,
                                   device,
                                   batch_id,


### PR DESCRIPTION
The previous VRAM fix PR left a limiting_resource_adaptor in the code limiting runs on multiple GPUs to 6GB of VRAM. This was not meant to be part of the push, and this PR fixes this mistake.