### PR TITLE
add http timeout values for general, send, and receive to client

### DIFF
--- a/python/cuopt_self_hosted/cuopt_sh_client/cuopt_self_host_client.py
+++ b/python/cuopt_self_hosted/cuopt_sh_client/cuopt_self_host_client.py
@@ -291,6 +291,17 @@ class CuOptServiceSelfHostClient:
             wildcard is used, the result mime_type will be set to the
             content_type mime_type of the original request.
             If not provided, result_type defaults to mime_type.MSGPACK
+    http_general_timeout: int
+            The time in seconds that http will wait before timing out
+            on a general request such as a job status check. Default is 30s.
+    data_send_timeout: int
+            The time in seconds that http will wait before timing out
+            on a problem submission to the server. If set to None,
+            the http_general_timeout value will be used. Default is None.
+    result_receive_timeout: int
+            The time in seconds that http will wait before timing out
+            on receiving a result from the server. If set to None,
+            the http_general_timeout value will be used. Default is None.
     """
 
     # Initialize the CuOptServiceSelfHostClient
@@ -306,12 +317,29 @@ class CuOptServiceSelfHostClient:
         polling_timeout=600,
         timeout_exception=True,
         result_type=mime_type.MSGPACK,
+        http_general_timeout=30,
+        data_send_timeout=None,
+        result_receive_timeout=None,
     ):
         self.timeout_exception = timeout_exception
         self.ip = ip
         self.port = port
         self.only_validate = only_validate
         self.accept_type = result_type
+
+        if not isinstance(http_general_timeout, (int, float)):
+            http_general_timeout = 30
+        self.http_general_timeout = http_general_timeout
+        self.data_send_timeout = (
+            data_send_timeout
+            if isinstance(data_send_timeout, (int, float))
+            else self.http_general_timeout
+        )
+        self.result_receive_timeout = (
+            result_receive_timeout
+            if isinstance(result_receive_timeout, (int, float))
+            else self.http_general_timeout
+        )
 
         self.protocol = "https" if use_https else "http"
         self.verify = False
@@ -377,7 +405,7 @@ class CuOptServiceSelfHostClient:
                 verify=self.verify,
                 headers=headers,
                 params=params,
-                timeout=30,
+                timeout=self.http_general_timeout,
             )
 
             # File has not been created yet
@@ -404,7 +432,7 @@ class CuOptServiceSelfHostClient:
                 self.solution_url + f"/{reqId}/incumbents",
                 verify=self.verify,
                 headers=headers,
-                timeout=30,
+                timeout=self.http_general_timeout,
             )
             response.raise_for_status()
             response = self._get_response(response)
@@ -513,7 +541,7 @@ class CuOptServiceSelfHostClient:
                         self.solution_url + f"/{reqId}",
                         verify=self.verify,
                         headers=headers,
-                        timeout=30,
+                        timeout=self.result_receive_timeout,
                     )
                     response.raise_for_status()
                     response = self._get_response(response)
@@ -594,7 +622,7 @@ class CuOptServiceSelfHostClient:
                 data=data,
                 headers=headers,
                 verify=self.verify,
-                timeout=30,
+                timeout=self.data_send_timeout,
             )
             response.raise_for_status()
             log.debug(response.status_code)
@@ -853,7 +881,7 @@ class CuOptServiceSelfHostClient:
                     "cached": cached,
                 },
                 verify=self.verify,
-                timeout=30,
+                timeout=self.http_general_timeout,
             )
             response.raise_for_status()
             log.debug(response.status_code)
@@ -887,7 +915,7 @@ class CuOptServiceSelfHostClient:
                 self.solution_url + f"/{id}",
                 headers=headers,
                 verify=self.verify,
-                timeout=30,
+                timeout=self.http_general_timeout,
             )
             response.raise_for_status()
             log.debug(response.status_code)
@@ -898,7 +926,7 @@ class CuOptServiceSelfHostClient:
                 response = requests.delete(
                     self.log_url + f"/{id}",
                     verify=self.verify,
-                    timeout=30,
+                    timeout=self.http_general_timeout,
                 )
             except Exception:
                 pass
@@ -938,7 +966,7 @@ class CuOptServiceSelfHostClient:
                 self.solution_url + f"/{data}",
                 verify=self.verify,
                 headers=headers,
-                timeout=30,
+                timeout=self.result_receive_timeout,
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
@@ -976,7 +1004,7 @@ class CuOptServiceSelfHostClient:
                 self.request_url + f"/{id}?status",
                 verify=self.verify,
                 headers=headers,
-                timeout=30,
+                timeout=self.http_general_timeout,
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
@@ -1014,7 +1042,7 @@ class CuOptServiceSelfHostClient:
                 verify=self.verify,
                 data=data,
                 headers=headers,
-                timeout=30,
+                timeout=self.data_send_timeout,
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:

--- a/python/cuopt_self_hosted/cuopt_sh_client/cuopt_sh.py
+++ b/python/cuopt_self_hosted/cuopt_sh_client/cuopt_sh.py
@@ -48,6 +48,7 @@ def status(args):
         self_signed_cert=args.self_signed_cert,
         timeout_exception=False,
         result_type=result_types[args.result_type],
+        http_general_timeout=args.http_timeout,
     )
 
     try:
@@ -73,6 +74,7 @@ def delete_request(args):
         self_signed_cert=args.self_signed_cert,
         timeout_exception=False,
         result_type=result_types[args.result_type],
+        http_general_timeout=args.http_timeout,
     )
 
     try:
@@ -104,6 +106,7 @@ def upload_solution(args):
         self_signed_cert=args.self_signed_cert,
         timeout_exception=False,
         result_type=result_types[args.result_type],
+        http_general_timeout=args.http_timeout,
     )
 
     try:
@@ -129,6 +132,7 @@ def delete_solution(args):
         self_signed_cert=args.self_signed_cert,
         timeout_exception=False,
         result_type=result_types[args.result_type],
+        http_general_timeout=args.http_timeout,
     )
 
     try:
@@ -220,6 +224,7 @@ def solve(args):
         only_validate=args.only_validation,
         timeout_exception=False,
         result_type=result_types[args.result_type],
+        http_general_timeout=args.http_timeout,
     )
 
     try:
@@ -587,6 +592,15 @@ def main():
         help="Upload a solution to be cached on the server. The reqId "
         "returned may be used as an initial solution for VRP.",
     )
+    parser.add_argument(
+        "-ht",
+        "--http-timeout",
+        type=int,
+        default=30,
+        help="Timeout in seconds for http requests. May need to be increased "
+        "for large datasets or slow networks. Default is 30s.",
+    )
+
     args = parser.parse_args()
     set_log_level(levels[args.log_level])
     if args.version:


### PR DESCRIPTION
Some large datasets, or even smaller datasets on a slow network, may take more than 30s to transfer to the server. Add timeout parameters to the cuopt service client to control the timeouts, defaulted to 30s.

Timeout parameters added: http_general_timeout (default 30), result_receive_timeout (default None), and data_send_timeout (default None).  The latter two inherit the value of http_general_timeout if they are None.

All 3 are settable in the client class, however only the general timeout is exposed in the CLI (which should be enough control).

