### PR TITLE
WIP: build pure-Python wheels without waiting for dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,6 @@ jobs:
       package-name: cuopt
       package-type: python
   wheel-build-cuopt-server:
-    needs: wheel-build-cuopt
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
     with:
@@ -186,7 +185,6 @@ jobs:
       container_image: "rapidsai/ci-conda:25.10-latest"
       script: "ci/build_docs.sh"
   wheel-build-cuopt-sh-client:
-    needs: wheel-build-cuopt
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
     with:
@@ -212,7 +210,10 @@ jobs:
       package-name: cuopt_sh_client
       package-type: python
   build-images:
-    needs: [wheel-publish-cuopt, wheel-publish-cuopt-server]
+    needs:
+      - wheel-publish-cuopt
+      - wheel-publish-cuopt-server
+      - wheel-publish-sh-client
     uses: ./.github/workflows/build_test_publish_images.yaml
     secrets: inherit
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -198,7 +198,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_cuopt.sh
   wheel-build-cuopt-server:
-    needs: wheel-build-cuopt
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
     with:


### PR DESCRIPTION
## Description

Looking closely at the CI dependency graphs while working on #122, I noticed some opportunities to improve the end-to-end time for PR CI and nightly builds.

`wheel-build-{libB}` jobs only need to wait for `wheel-build-{libA}` jobs to complete if **building** `libB` wheels requires `libA`. This updates job dependencies here to follow that rule.

* `wheel-build-cuopt-server`: start building immediately
* `wheel-build-cuopt-sh-client`: start building immediately
* `build-images`: adds `wheel-build-sh-client` to jobs this needs to wait for (branch / nightly builds only)
  - https://github.com/NVIDIA/cuopt/blob/933d810e517567f4b5cb3cd507b350eb30457a70/ci/docker/Dockerfile#L65

## Issue

Noticed while working towards #122

## Notes for Reviewers

### Benefits of these changes

Reduced end-to-end time for PR builds and probably for branch/nightly builds.

Reduced risk of failed or incorrect container-image builds resulting from `build-images` starting before there are `cuopt-sh-client` packages available.

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
