### PR TITLE
cuopt-server: update dependencies (drop httpx, add psutil)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - gcc_linux-aarch64=14.*
 - gmock
 - gtest
-- httpx
 - ipython
 - jsonref==1.1.0
 - libcurand-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - gcc_linux-64=14.*
 - gmock
 - gtest
-- httpx
 - ipython
 - jsonref==1.1.0
 - libcurand-dev

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - gcc_linux-aarch64=14.*
 - gmock
 - gtest
-- httpx
 - ipython
 - jsonref==1.1.0
 - libcurand-dev

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - gcc_linux-64=14.*
 - gmock
 - gtest
-- httpx
 - ipython
 - jsonref==1.1.0
 - libcurand-dev

--- a/conda/recipes/cuopt-server/recipe.yaml
+++ b/conda/recipes/cuopt-server/recipe.yaml
@@ -34,11 +34,11 @@ requirements:
     - cuopt =${{ version }}
     - fastapi >=0.104.1
     - jsonref =1.1.0
-    - httpx
     - msgpack-python =1.1.0
     - msgpack-numpy =0.4.8
     - numpy >=1.23,<3.0a0
     - pandas>=2
+    - psutil>=5.9,<6.0a0
     - python
     - uvicorn ${{ uvicorn_version }}
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -393,7 +393,6 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - fastapi
-          - httpx
           - *jsonref
           - *msgpack_numpy
           - *pandas

--- a/python/cuopt_server/pyproject.toml
+++ b/python/cuopt_server/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "cuopt==25.10.*,>=0.0.0a0",
     "cupy-cuda13x>=13.6.0",
     "fastapi",
-    "httpx",
     "jsonref==1.1.0",
     "msgpack-numpy==0.4.8",
     "msgpack==1.1.0",


### PR DESCRIPTION
## Description

Fixes two small packaging issues with `cuopt-server`:

* removes unnecessary dependency on `httpx` (`cuopt-server` does not use this)
* declares dependency on `psutil` (this is declared in wheels but was missing in conda packages)

## Notes for Reviewers

### How I found these

Was looking at the conda recipes and checked these things, similar to this:

```shell
git grep httpx
```

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
