### PR TITLE
Fix variables out of bounds caused by CPUFJ LP scratch thread

### DIFF
--- a/cpp/src/mip/diversity/diversity_manager.cu
+++ b/cpp/src/mip/diversity/diversity_manager.cu
@@ -427,6 +427,7 @@ solution_t<i_t, f_t> diversity_manager_t<i_t, f_t>::run_solver()
     }
     // in case the pdlp returned var boudns that are out of bounds
     clamp_within_var_bounds(lp_optimal_solution, problem_ptr, problem_ptr->handle_ptr);
+    ls.start_cpufj_lptopt_scratch_threads(population);
   }
 
   population.add_solutions_from_vec(std::move(initial_sol_vector));

--- a/cpp/src/mip/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip/feasibility_jump/fj_cpu.cu
@@ -708,6 +708,9 @@ static void init_fj_cpu(fj_cpu_climber_t<i_t, f_t>& fj_cpu,
   auto& problem   = *solution.problem_ptr;
   auto handle_ptr = solution.handle_ptr;
 
+  auto sol_copy = solution;
+  clamp_within_var_bounds(sol_copy.assignment, &problem, handle_ptr);
+
   // build a cpu-based fj_view_t
   fj_cpu.view    = typename fj_t<i_t, f_t>::climber_data_t::view_t{};
   fj_cpu.view.pb = problem.view();
@@ -734,8 +737,9 @@ static void init_fj_cpu(fj_cpu_climber_t<i_t, f_t>& fj_cpu,
   fj_cpu.h_cstr_right_weights = right_weights;
   fj_cpu.max_weight           = 1.0;
   fj_cpu.h_objective_weight   = objective_weight;
-  fj_cpu.h_assignment         = solution.get_host_assignment();
-  fj_cpu.h_best_assignment    = solution.get_host_assignment();
+  auto h_assignment           = sol_copy.get_host_assignment();
+  fj_cpu.h_assignment         = h_assignment;
+  fj_cpu.h_best_assignment    = std::move(h_assignment);
   fj_cpu.h_lhs.resize(fj_cpu.pb_ptr->n_constraints);
   fj_cpu.h_lhs_sumcomp.resize(fj_cpu.pb_ptr->n_constraints, 0);
   fj_cpu.h_tabu_nodec_until.resize(fj_cpu.pb_ptr->n_variables, 0);

--- a/cpp/src/mip/local_search/local_search.cu
+++ b/cpp/src/mip/local_search/local_search.cu
@@ -182,6 +182,15 @@ void local_search_t<i_t, f_t>::start_cpufj_scratch_threads(population_t<i_t, f_t
   for (auto& cpu_fj : scratch_cpu_fj) {
     cpu_fj.start_cpu_solver();
   }
+}
+
+template <typename i_t, typename f_t>
+void local_search_t<i_t, f_t>::start_cpufj_lptopt_scratch_threads(
+  population_t<i_t, f_t>& population)
+{
+  pop_ptr = &population;
+
+  std::vector<f_t> default_weights(context.problem_ptr->n_constraints, 1.);
 
   solution_t<i_t, f_t> solution_lp(*context.problem_ptr);
   solution_lp.copy_new_assignment(host_copy(lp_optimal_solution));

--- a/cpp/src/mip/local_search/local_search.cuh
+++ b/cpp/src/mip/local_search/local_search.cuh
@@ -83,6 +83,7 @@ class local_search_t {
                  rmm::device_uvector<f_t>& lp_optimal_solution_);
 
   void start_cpufj_scratch_threads(population_t<i_t, f_t>& population);
+  void start_cpufj_lptopt_scratch_threads(population_t<i_t, f_t>& population);
   void stop_cpufj_scratch_threads();
   void generate_fast_solution(solution_t<i_t, f_t>& solution, timer_t timer);
   bool generate_solution(solution_t<i_t, f_t>& solution,


### PR DESCRIPTION
If the CPUFJ LP scratch thread is started before the LP relaxation solution is found (if one is found), the initial solution vector may not satisfy the problem variable bounds. This PR fixes the issue by ensuring the CPUFJ LP thread is started only after such a solution is found. The initial solution is also projected to the variable bounds to ensure no such violation can exist.

Closes https://github.com/NVIDIA/cuopt/issues/423