### PR TITLE
Disable TBB because of a bug in CliqueMerging presolver

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -201,6 +201,8 @@ find_package(TBB REQUIRED)
 set(BUILD_TESTING OFF CACHE BOOL "Disable test build for papilo")
 set(PAPILO_NO_BINARIES ON)
 option(LUSOL "Disable LUSOL" OFF)
+# Disable TBB because of a bug in CliqueMerging parallel version
+set(TBB OFF CACHE BOOL "Disable TBB for papilo")
 
 FetchContent_MakeAvailable(papilo)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -190,9 +190,9 @@ FetchContent_Declare(
   # does not have some of the presolvers and settings that we need
   # Mainly, probing and clique merging.
   # This is the reason we are using the development branch
-  # commit from Sep 26, 2025. Once these changes are merged into the main branch,
+  # commit from Oct 8, 2025. Once these changes are merged into the main branch,
   #we can switch to the main branch.
-  GIT_TAG "34a40781fa14f8870cb6368cffb6c0eda2f47511"
+  GIT_TAG "24ccf5752656df0f15dd9aabe5b97feae829b9ec"
   GIT_PROGRESS TRUE
   SYSTEM
 )


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->

## Description
<!-- Add brief description here -->
A bug in parallel implementation of CliqueMerging presolver is making the infeasible problem a feasible one. Disabling TBB until the bug is fixed. 

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->
Closes #458  

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
