### PR TITLE
Fix issue with barrier incorrectly returning numerical in concurrent

### DIFF
--- a/cpp/src/dual_simplex/barrier.cu
+++ b/cpp/src/dual_simplex/barrier.cu
@@ -3266,14 +3266,15 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time,
     }
 
     iteration_data_t<i_t, f_t> data(lp, num_upper_bounds, settings);
-    if (data.symbolic_status != 0) {
-      settings.log.printf("Error in symbolic analysis\n");
-      return lp_status_t::NUMERICAL_ISSUES;
-    }
     if (settings.concurrent_halt != nullptr && *settings.concurrent_halt == 1) {
       settings.log.printf("Barrier solver halted\n");
       return lp_status_t::CONCURRENT_LIMIT;
     }
+    if (data.symbolic_status != 0) {
+      settings.log.printf("Error in symbolic analysis\n");
+      return lp_status_t::NUMERICAL_ISSUES;
+    }
+
     data.cusparse_dual_residual_ = data.cusparse_view_.create_vector(data.d_dual_residual_);
     data.cusparse_r1_            = data.cusparse_view_.create_vector(data.d_r1_);
     data.cusparse_tmp4_          = data.cusparse_view_.create_vector(data.d_tmp4_);

--- a/cpp/src/mip/diversity/diversity_manager.cu
+++ b/cpp/src/mip/diversity/diversity_manager.cu
@@ -245,7 +245,7 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit)
   lp_dual_optimal_solution.resize(problem_ptr->n_constraints,
                                   problem_ptr->handle_ptr->get_stream());
   problem_ptr->handle_ptr->sync_stream();
-  CUOPT_LOG_INFO("After trivial presolve #constraints %d #variables %d objective offset %f.",
+  CUOPT_LOG_INFO("After trivial presolve: %d constraints, %d variables, objective offset %f.",
                  problem_ptr->n_constraints,
                  problem_ptr->n_variables,
                  problem_ptr->presolve_data.objective_offset);


### PR DESCRIPTION
@tmckayus reported that in concurrent mode, he was seeing lots of barrier numerical status.

This was due to incorrectly setting the status to NUMERIC, when barrier was stopped by PDLP or concurrent.

This PR fixes the issue, by checking for concurrent limit first.  

Logs are also changed for consistency. 