### PR TITLE
Disable flaky barrier tests 

### DIFF
--- a/python/cuopt_server/cuopt_server/tests/test_lp.py
+++ b/python/cuopt_server/cuopt_server/tests/test_lp.py
@@ -148,18 +148,20 @@ def test_sample_milp(
     )
 
 
+@pytest.mark.skip(
+    reason="Enable barrier solver options when issue "
+    "https://github.com/NVIDIA/cuopt/issues/519 is resolved",
+)
 @pytest.mark.parametrize(
     "folding, dualize, ordering, augmented, eliminate_dense, cudss_determ, "
     "dual_initial_point",
     [
         # Test automatic settings (default)
         (-1, -1, -1, -1, True, False, -1),
-        # Enable barrier solver options when this issue is resolved
-        # https://github.com/NVIDIA/cuopt/issues/519
         # Test folding off, no dualization, cuDSS default ordering, ADAT system
-        # (0, 0, 0, 0, True, False, 0),
+        (0, 0, 0, 0, True, False, 0),
         # Test folding on, force dualization, AMD ordering, augmented system
-        # (1, 1, 1, 1, True, True, 1),
+        (1, 1, 1, 1, True, True, 1),
         # Test mixed settings: automatic folding, no dualize, AMD, augmented
         (-1, 0, 1, 1, False, False, 0),
         # Test no folding, automatic dualize, cuDSS default, ADAT


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
This PR disables few barrier tests which are flaky and causes segfault, there is an issue for tracking this, and once the issue is resolved, these tests should be unblocked. 

## Issue
#519 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * The barrier-solver test is now explicitly skipped with an annotated reason referencing a related issue.
  * The test remains parameterized exactly as before; no changes to parameters or test logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->