### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Please install conda if you don't have it already. You can install [miniforge](h
 # create the conda environment (assuming in base `cuopt` directory)
 # note: cuOpt currently doesn't support `channel_priority: strict`;
 # use `channel_priority: flexible` instead
-conda env create --name cuopt_dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+conda env create --name cuopt_dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 # activate the environment
 conda activate cuopt_dev
 ```


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contribution guidelines updated to reference the environment YAML using dynamic architecture substitution (via uname -m) instead of a fixed architecture filename.
  * Environment setup instructions now reflect automatic system-architecture detection during environment selection.
  * No other behavior or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->