### PR TITLE
Fix lower bound calculation during ramp-up phase in parallel B&B

### DIFF
--- a/cpp/src/dual_simplex/branch_and_bound.cpp
+++ b/cpp/src/dual_simplex/branch_and_bound.cpp
@@ -733,7 +733,7 @@ void branch_and_bound_t<i_t, f_t>::exploration_ramp_up(search_tree_t<i_t, f_t>* 
       stats_.last_log             = tic();
 
       f_t obj              = compute_user_objective(original_lp_, upper_bound);
-      f_t user_lower       = compute_user_objective(original_lp_, root_objective_);
+      f_t user_lower       = compute_user_objective(original_lp_, get_lower_bound());
       std::string gap_user = user_mip_gap<f_t>(obj, user_lower);
 
       settings_.log.printf(" %10d   %10lu    %+13.6e    %+10.6e   %6d   %7.1e     %s %9.2f\n",
@@ -1226,7 +1226,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
     }
   }
 
-  f_t lower_bound = heap_.size() > 0 ? heap_.top()->lower_bound : search_tree.root.lower_bound;
+  f_t lower_bound = get_lower_bound();
   return set_final_solution(solution, lower_bound);
 }
 


### PR DESCRIPTION
## Description

Fixed the lower bound calculation during the ramp-up phase in parallel Branch and Bound. Previously, cuOpt was using the root objective as the global lower bound when the heap was empty, which is a pessimistic estimation that doesn't reflect the actual lower bounds calculated by active threads during ramp-up.

**Changes Made:**
- **Line 1229**: Changed from `heap_.size() > 0 ? heap_.top()->lower_bound : search_tree.root.lower_bound` to `get_lower_bound()`
- **Line 736**: Changed from `root_objective_` to `get_lower_bound()` in ramp-up logging

**Why This Fix Works:**
The `get_lower_bound()` function properly considers all sources of lower bound information:
- `lower_bound_ceiling_` (updated during ramp-up when threads encounter numerical issues)
- Heap top node's lower bound (if heap is not empty)
- All `local_lower_bounds_` from active threads (updated as threads solve nodes during ramp-up)

This ensures the lower bound accurately reflects the work done by active threads during ramp-up, not just the pessimistic root objective.

**Example Impact:**
During ramp-up, if threads have solved nodes with lower bounds better than the root objective, the global lower bound will now reflect these improved bounds instead of falling back to the root objective.

## Issue #445 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing

   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA

- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA

