### PR TITLE
Handle inherited module doc string issues

### DIFF
--- a/docs/cuopt/source/conf.py
+++ b/docs/cuopt/source/conf.py
@@ -295,7 +295,10 @@ nitpick_ignore = [
     ("py:obj", "cuopt_sh_client.PDLPSolverMode.bit_count"),
     ("py:obj", "cuopt_sh_client.PDLPSolverMode.bit_length"),
     ("py:obj", "data_model.DataModel.set_data_model_view"),
-    ("py:obj", "cuopt.linear_programming.solver_settings.SolverSettings.to_base_type"),
+    (
+        "py:obj",
+        "cuopt.linear_programming.solver_settings.SolverSettings.to_base_type",
+    ),
     ("c:type", "size_t"),
     ("c:identifier", "int32_t"),
     ("c:identifier", "int8_t"),


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description

Few underlying defined variables created doc string failure, which need not be added to doc. So they have been added to ignore list.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined API docs to hide inherited members for specific types, improving clarity of class reference pages.
  * Added rules to ignore certain malformed type-reference warnings and internal helper methods to reduce noise.
  * Introduced regex-based ignores for inherited members to more robustly filter irrelevant entries.
  * Improved logic that dynamically computes which inherited members to skip, reducing manual configuration and maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->