### PR TITLE
cuopt service correct definition for status value in lp result spec

### DIFF
--- a/python/cuopt_server/cuopt_server/tests/test_lp.py
+++ b/python/cuopt_server/cuopt_server/tests/test_lp.py
@@ -211,3 +211,31 @@ def test_barrier_solver_options(
         res.json()["response"]["solver_response"],
         LPTerminationStatus.Optimal.name,
     )
+
+
+def test_termination_status_enum_sync():
+    """
+    Ensure local status values in data_definition.py stay in sync
+    with actual LPTerminationStatus and MILPTerminationStatus enums.
+
+    The data_definition module cannot import these enums directly
+    because it triggers CUDA/RMM initialization before the server
+    has configured memory management. So we maintain local copies
+    and this test ensures they stay in sync.
+    """
+    from cuopt_server.utils.linear_programming.data_definition import (
+        LP_STATUS_NAMES,
+        MILP_STATUS_NAMES,
+    )
+
+    expected_lp = {e.name for e in LPTerminationStatus}
+    expected_milp = {e.name for e in MILPTerminationStatus}
+
+    assert LP_STATUS_NAMES == expected_lp, (
+        f"LP_STATUS_NAMES out of sync with LPTerminationStatus enum. "
+        f"Expected: {expected_lp}, Got: {LP_STATUS_NAMES}"
+    )
+    assert MILP_STATUS_NAMES == expected_milp, (
+        f"MILP_STATUS_NAMES out of sync with MILPTerminationStatus enum. "
+        f"Expected: {expected_milp}, Got: {MILP_STATUS_NAMES}"
+    )


### PR DESCRIPTION
The openapi spec for the status value in lp/mip results says "int" but it is actually a string.  This change corrects that.

Unfortunately, the enums defining the values cannot be directly imported because the import causes early cuda initialization which leads to rmm errors.

So, this change uses local copies and then adds a unit test to make sure they don't drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Termination status values in API responses are now human-readable strings (e.g., "Optimal", "Infeasible") instead of numeric codes.
  * Added validation to ensure termination status values are valid.

* **Tests**
  * Added verification test for termination status enumerations synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->