### PR TITLE
Improve iterative refinement

### DIFF
--- a/cpp/src/dual_simplex/barrier.cu
+++ b/cpp/src/dual_simplex/barrier.cu
@@ -1368,11 +1368,18 @@ class iteration_data_t {
     }
   }
 
+  template <typename T>
+  struct axpy_op {
+    T alpha;
+    T beta;
+    __host__ __device__ T operator()(T x, T y) const { return alpha * x + beta * y; }
+  };
+
   // y <- alpha * Augmented * x + beta * y
   void augmented_multiply(f_t alpha,
                           const dense_vector_t<i_t, f_t>& x,
                           f_t beta,
-                          dense_vector_t<i_t, f_t>& y) const
+                          dense_vector_t<i_t, f_t>& y)
   {
     const i_t m                 = A.m;
     const i_t n                 = A.n;
@@ -1381,22 +1388,52 @@ class iteration_data_t {
     dense_vector_t<i_t, f_t> y1 = y.head(n);
     dense_vector_t<i_t, f_t> y2 = y.tail(m);
 
+    rmm::device_uvector<f_t> d_x1(n, handle_ptr->get_stream());
+    rmm::device_uvector<f_t> d_x2(m, handle_ptr->get_stream());
+    rmm::device_uvector<f_t> d_y1(n, handle_ptr->get_stream());
+    rmm::device_uvector<f_t> d_y2(m, handle_ptr->get_stream());
+
+    raft::copy(d_x1.data(), x1.data(), n, handle_ptr->get_stream());
+    raft::copy(d_x2.data(), x2.data(), m, handle_ptr->get_stream());
+    raft::copy(d_y1.data(), y1.data(), n, handle_ptr->get_stream());
+    raft::copy(d_y2.data(), y2.data(), m, handle_ptr->get_stream());
+
     // y1 <- alpha ( -D * x_1 + A^T x_2) + beta * y1
-    dense_vector_t<i_t, f_t> r1(n);
-    diag.pairwise_product(x1, r1);
-    if (Q.n > 0) { matrix_vector_multiply(Q, 1.0, x1, 1.0, r1); }
-    y1.axpy(-alpha, r1, beta);
-    matrix_transpose_vector_multiply(A, alpha, x2, 1.0, y1);
 
+    rmm::device_uvector<f_t> d_r1(n, handle_ptr->get_stream());
+
+    // diag.pairwise_product(x1, r1);
+    // r1 <- D * x_1
+    thrust::transform(handle_ptr->get_thrust_policy(),
+                      d_x1.data(),
+                      d_x1.data() + n,
+                      d_diag_.data(),
+                      d_r1.data(),
+                      thrust::multiplies<f_t>());
+
+    // r1 <- Q x1 + D x1
+    if (Q.n > 0) {
+      // matrix_vector_multiply(Q, 1.0, x1, 1.0, r1);
+      cusparse_Q_view_.spmv(1.0, d_x1, 1.0, d_r1);
+    }
+
+    // y1 <- - alpha * r1 + beta * y1
+    // y1.axpy(-alpha, r1, beta);
+    thrust::transform(handle_ptr->get_thrust_policy(),
+                      d_r1.data(),
+                      d_r1.data() + n,
+                      d_y1.data(),
+                      d_y1.data(),
+                      axpy_op<f_t>{-alpha, beta});
+
+    // matrix_transpose_vector_multiply(A, alpha, x2, 1.0, y1);
+    cusparse_view_.transpose_spmv(alpha, d_x2, 1.0, d_y1);
     // y2 <- alpha ( A*x) + beta * y2
-    matrix_vector_multiply(A, alpha, x1, beta, y2);
+    // matrix_vector_multiply(A, alpha, x1, beta, y2);
+    cusparse_view_.spmv(alpha, d_x1, beta, d_y2);
 
-    for (i_t i = 0; i < n; ++i) {
-      y[i] = y1[i];
-    }
-    for (i_t i = n; i < n + m; ++i) {
-      y[i] = y2[i - n];
-    }
+    raft::copy(y.data(), d_y1.data(), n, stream_view_);
+    raft::copy(y.data() + n, d_y2.data(), m, stream_view_);
   }
 
   raft::handle_t const* handle_ptr;
@@ -1711,8 +1748,8 @@ int barrier_solver_t<i_t, f_t>::initial_point(iteration_data_t<i_t, f_t>& data)
     dense_vector_t<i_t, f_t> soln(lp.num_cols + lp.num_rows);
     i_t solve_status = data.chol->solve(rhs, soln);
     struct op_t {
-      op_t(const iteration_data_t<i_t, f_t>& data) : data_(data) {}
-      const iteration_data_t<i_t, f_t>& data_;
+      op_t(iteration_data_t<i_t, f_t>& data) : data_(data) {}
+      iteration_data_t<i_t, f_t>& data_;
       void a_multiply(f_t alpha,
                       const dense_vector_t<i_t, f_t>& x,
                       f_t beta,
@@ -2410,12 +2447,12 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
     dense_vector_t<i_t, f_t> augmented_soln(lp.num_cols + lp.num_rows);
     data.chol->solve(augmented_rhs, augmented_soln);
     struct op_t {
-      op_t(const iteration_data_t<i_t, f_t>& data) : data_(data) {}
-      const iteration_data_t<i_t, f_t>& data_;
+      op_t(iteration_data_t<i_t, f_t>& data) : data_(data) {}
+      iteration_data_t<i_t, f_t>& data_;
       void a_multiply(f_t alpha,
                       const dense_vector_t<i_t, f_t>& x,
                       f_t beta,
-                      dense_vector_t<i_t, f_t>& y) const
+                      dense_vector_t<i_t, f_t>& y)
       {
         data_.augmented_multiply(alpha, x, beta, y);
       }

--- a/cpp/src/dual_simplex/barrier.cu
+++ b/cpp/src/dual_simplex/barrier.cu
@@ -1434,6 +1434,7 @@ class iteration_data_t {
 
     raft::copy(y.data(), d_y1.data(), n, stream_view_);
     raft::copy(y.data() + n, d_y2.data(), m, stream_view_);
+    handle_ptr->sync_stream();
   }
 
   raft::handle_t const* handle_ptr;

--- a/cpp/src/dual_simplex/cusparse_view.cu
+++ b/cpp/src/dual_simplex/cusparse_view.cu
@@ -268,10 +268,19 @@ void cusparse_view_t<i_t, f_t>::spmv(f_t alpha,
 {
   auto d_x = device_copy(x, handle_ptr_->get_stream());
   auto d_y = device_copy(y, handle_ptr_->get_stream());
-  detail::cusparse_dn_vec_descr_wrapper_t<f_t> x_cusparse = create_vector(d_x);
-  detail::cusparse_dn_vec_descr_wrapper_t<f_t> y_cusparse = create_vector(d_y);
-  spmv(alpha, x_cusparse, beta, y_cusparse);
+  spmv(alpha, d_x, beta, d_y);
   y = cuopt::host_copy<f_t, AllocatorB>(d_y, handle_ptr_->get_stream());
+}
+
+template <typename i_t, typename f_t>
+void cusparse_view_t<i_t, f_t>::spmv(f_t alpha,
+                                     const rmm::device_uvector<f_t>& x,
+                                     f_t beta,
+                                     rmm::device_uvector<f_t>& y)
+{
+  detail::cusparse_dn_vec_descr_wrapper_t<f_t> x_cusparse = create_vector(x);
+  detail::cusparse_dn_vec_descr_wrapper_t<f_t> y_cusparse = create_vector(y);
+  spmv(alpha, x_cusparse, beta, y_cusparse);
 }
 
 template <typename i_t, typename f_t>
@@ -311,10 +320,19 @@ void cusparse_view_t<i_t, f_t>::transpose_spmv(f_t alpha,
 {
   auto d_x = device_copy(x, handle_ptr_->get_stream());
   auto d_y = device_copy(y, handle_ptr_->get_stream());
-  detail::cusparse_dn_vec_descr_wrapper_t<f_t> x_cusparse = create_vector(d_x);
-  detail::cusparse_dn_vec_descr_wrapper_t<f_t> y_cusparse = create_vector(d_y);
-  transpose_spmv(alpha, x_cusparse, beta, y_cusparse);
+  transpose_spmv(alpha, d_x, beta, d_y);
   y = cuopt::host_copy<f_t, AllocatorB>(d_y, handle_ptr_->get_stream());
+}
+
+template <typename i_t, typename f_t>
+void cusparse_view_t<i_t, f_t>::transpose_spmv(f_t alpha,
+                                               const rmm::device_uvector<f_t>& x,
+                                               f_t beta,
+                                               rmm::device_uvector<f_t>& y)
+{
+  detail::cusparse_dn_vec_descr_wrapper_t<f_t> x_cusparse = create_vector(x);
+  detail::cusparse_dn_vec_descr_wrapper_t<f_t> y_cusparse = create_vector(y);
+  transpose_spmv(alpha, x_cusparse, beta, y_cusparse);
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/dual_simplex/cusparse_view.hpp
+++ b/cpp/src/dual_simplex/cusparse_view.hpp
@@ -36,6 +36,7 @@ class cusparse_view_t {
             const std::vector<f_t, AllocatorA>& x,
             f_t beta,
             std::vector<f_t, AllocatorB>& y);
+  void spmv(f_t alpha, rmm::device_uvector<f_t> const& x, f_t beta, rmm::device_uvector<f_t>& y);
   void spmv(f_t alpha,
             detail::cusparse_dn_vec_descr_wrapper_t<f_t> const& x,
             f_t beta,
@@ -45,6 +46,10 @@ class cusparse_view_t {
                       const std::vector<f_t, AllocatorA>& x,
                       f_t beta,
                       std::vector<f_t, AllocatorB>& y);
+  void transpose_spmv(f_t alpha,
+                      rmm::device_uvector<f_t> const& x,
+                      f_t beta,
+                      rmm::device_uvector<f_t>& y);
   void transpose_spmv(f_t alpha,
                       detail::cusparse_dn_vec_descr_wrapper_t<f_t> const& x,
                       f_t beta,

--- a/cpp/src/dual_simplex/iterative_refinement.hpp
+++ b/cpp/src/dual_simplex/iterative_refinement.hpp
@@ -30,8 +30,6 @@ void iterative_refinement_simple(T& op,
 
   f_t error = vector_norm_inf<i_t, f_t>(r);
   if (show_iterative_refinement_info) {
-    // printf(
-    //  "Iterative refinement. Initial error %e || x || %.16e\n", error, vector_norm2<i_t, f_t>(x));
     CUOPT_LOG_INFO(
       "Iterative refinement. Initial error %e || x || %.16e", error, vector_norm2<i_t, f_t>(x));
   }
@@ -50,8 +48,6 @@ void iterative_refinement_simple(T& op,
     if (new_error > error) {
       x = x_sav;
       if (show_iterative_refinement_info) {
-        // printf("%d Iterative refinement error increased %e %e. Stopping\n", iter, error,
-        // new_error);
         CUOPT_LOG_INFO(
           "Iterative refinement. Iter %d error increased %e %e. Stopping", iter, error, new_error);
       }
@@ -61,11 +57,6 @@ void iterative_refinement_simple(T& op,
     x_sav = x;
     iter++;
     if (show_iterative_refinement_info) {
-      // printf("%d Iterative refinement error %e. || x || %.16e || dx || %.16e Continuing\n",
-      //        iter,
-      //        error,
-      //        vector_norm2<i_t, f_t>(x),
-      //        vector_norm2<i_t, f_t>(delta_x));
       CUOPT_LOG_INFO(
         "Iterative refinement. Iter %d error %e. || x || %.16e || dx || %.16e Continuing",
         iter,
@@ -181,10 +172,7 @@ void iterative_refinement_gmres(T& op,
       e1[k]      = temp_e;
 
       rel_res = std::abs(e1[k + 1]);  // / bnorm;
-      if (show_info) {
-        // printf("GMRES IR: iter %d residual = %e\n", k+1, rel_res * bnorm);
-        CUOPT_LOG_INFO("GMRES IR: iter %d residual = %e", k + 1, rel_res);
-      }
+      if (show_info) { CUOPT_LOG_INFO("GMRES IR: iter %d residual = %e", k + 1, rel_res); }
 
       if (rel_res < tol) {
         k++;  // reached convergence
@@ -221,7 +209,6 @@ void iterative_refinement_gmres(T& op,
     auto l2_residual = vector_norm2<i_t, f_t>(r);
 
     if (show_info) {
-      // printf("GMRES IR: after outer_iter %d residual = %e\n", outer_iter, residual);
       CUOPT_LOG_INFO("GMRES IR: after outer_iter %d residual = %e, l2_residual = %e",
                      outer_iter,
                      residual,
@@ -235,8 +222,6 @@ void iterative_refinement_gmres(T& op,
     } else {
       // Residual increased or stagnated, restore best and stop
       if (show_info) {
-        //  printf("GMRES IR: residual increased from %e to %e, stopping\n", best_residual,
-        //  residual);
         CUOPT_LOG_INFO(
           "GMRES IR: residual increased from %e to %e, stopping", best_residual, residual);
       }

--- a/cpp/src/dual_simplex/iterative_refinement.hpp
+++ b/cpp/src/dual_simplex/iterative_refinement.hpp
@@ -76,8 +76,11 @@ void iterative_refinement_gmres(T& op,
                                 dense_vector_t<i_t, f_t>& x)
 {
   // Parameters
-  const int max_restarts = 1;
-  const int m            = 30;  // Krylov space dimension
+  // Ideally, we do not need to restart here. But having restarts helps as a checkpoint to get
+  // better solutions in case of true residual is far from the measured residual and true residuals
+  // are not converging after some point
+  const int max_restarts = 3;
+  const int m            = 10;  // Krylov space dimension
   const f_t tol          = 1e-8;
 
   dense_vector_t<i_t, f_t> r(x.size());
@@ -206,9 +209,8 @@ void iterative_refinement_gmres(T& op,
 
     residual = vector_norm_inf<i_t, f_t>(r);
 
-    auto l2_residual = vector_norm2<i_t, f_t>(r);
-
     if (show_info) {
+      auto l2_residual = vector_norm2<i_t, f_t>(r);
       CUOPT_LOG_INFO("GMRES IR: after outer_iter %d residual = %e, l2_residual = %e",
                      outer_iter,
                      residual,

--- a/cpp/src/dual_simplex/iterative_refinement.hpp
+++ b/cpp/src/dual_simplex/iterative_refinement.hpp
@@ -18,9 +18,9 @@
 namespace cuopt::linear_programming::dual_simplex {
 
 template <typename i_t, typename f_t, typename T>
-void iterative_refinement(const T& op,
-                          const dense_vector_t<i_t, f_t>& b,
-                          dense_vector_t<i_t, f_t>& x)
+void iterative_refinement_simple(T& op,
+                                 const dense_vector_t<i_t, f_t>& b,
+                                 dense_vector_t<i_t, f_t>& x)
 {
   dense_vector_t<i_t, f_t> x_sav            = x;
   dense_vector_t<i_t, f_t> r                = b;
@@ -30,8 +30,10 @@ void iterative_refinement(const T& op,
 
   f_t error = vector_norm_inf<i_t, f_t>(r);
   if (show_iterative_refinement_info) {
-    printf(
-      "Iterative refinement. Initial error %e || x || %.16e\n", error, vector_norm2<i_t, f_t>(x));
+    // printf(
+    //  "Iterative refinement. Initial error %e || x || %.16e\n", error, vector_norm2<i_t, f_t>(x));
+    CUOPT_LOG_INFO(
+      "Iterative refinement. Initial error %e || x || %.16e", error, vector_norm2<i_t, f_t>(x));
   }
   dense_vector_t<i_t, f_t> delta_x(x.size());
   i_t iter = 0;
@@ -48,7 +50,10 @@ void iterative_refinement(const T& op,
     if (new_error > error) {
       x = x_sav;
       if (show_iterative_refinement_info) {
-        printf("%d Iterative refinement error increased %e %e. Stopping\n", iter, error, new_error);
+        // printf("%d Iterative refinement error increased %e %e. Stopping\n", iter, error,
+        // new_error);
+        CUOPT_LOG_INFO(
+          "Iterative refinement. Iter %d error increased %e %e. Stopping", iter, error, new_error);
       }
       break;
     }
@@ -56,13 +61,203 @@ void iterative_refinement(const T& op,
     x_sav = x;
     iter++;
     if (show_iterative_refinement_info) {
-      printf("%d Iterative refinement error %e. || x || %.16e || dx || %.16e Continuing\n",
-             iter,
-             error,
-             vector_norm2<i_t, f_t>(x),
-             vector_norm2<i_t, f_t>(delta_x));
+      // printf("%d Iterative refinement error %e. || x || %.16e || dx || %.16e Continuing\n",
+      //        iter,
+      //        error,
+      //        vector_norm2<i_t, f_t>(x),
+      //        vector_norm2<i_t, f_t>(delta_x));
+      CUOPT_LOG_INFO(
+        "Iterative refinement. Iter %d error %e. || x || %.16e || dx || %.16e Continuing",
+        iter,
+        error,
+        vector_norm2<i_t, f_t>(x),
+        vector_norm2<i_t, f_t>(delta_x));
     }
   }
+}
+
+/**
+@brief Iterative refinement with GMRES as solver
+ */
+template <typename i_t, typename f_t, typename T>
+void iterative_refinement_gmres(T& op,
+                                const dense_vector_t<i_t, f_t>& b,
+                                dense_vector_t<i_t, f_t>& x)
+{
+  // Parameters
+  const int max_restarts = 1;
+  const int m            = 30;  // Krylov space dimension
+  const f_t tol          = 1e-8;
+
+  dense_vector_t<i_t, f_t> r(x.size());
+  dense_vector_t<i_t, f_t> x_sav = x;
+  dense_vector_t<i_t, f_t> delta_x(x.size());
+
+  // Host workspace for the Hessenberg matrix and other small arrays
+  std::vector<std::vector<f_t>> H(m + 1, std::vector<f_t>(m, 0.0));
+  std::vector<f_t> cs(m, 0.0);
+  std::vector<f_t> sn(m, 0.0);
+  std::vector<f_t> e1(m + 1, 0.0);
+  std::vector<f_t> y(m, 0.0);
+
+  bool show_info = false;
+
+  f_t bnorm      = max(1.0, vector_norm_inf<i_t, f_t>(b));
+  f_t rel_res    = 1.0;
+  int outer_iter = 0;
+
+  // r = b - A*x
+  r = b;
+  op.a_multiply(-1.0, x, 1.0, r);
+
+  f_t norm_r = vector_norm_inf<i_t, f_t>(r);
+  if (show_info) { CUOPT_LOG_INFO("GMRES IR: initial residual = %e, |b| = %e", norm_r, bnorm); }
+  if (norm_r <= 1e-8) { return; }
+
+  f_t residual      = norm_r;
+  f_t best_residual = norm_r;
+
+  // Main loop
+  while (residual > tol && outer_iter < max_restarts) {
+    // For right preconditioning: Apply preconditioner on Krylov directions, not on the residual.
+    // So, start GMRES on r = b - A*x. v0 = r / ||r||
+    std::vector<dense_vector_t<i_t, f_t>> V;
+    std::vector<dense_vector_t<i_t, f_t>> Z;  // Store preconditioned vectors Z[k] = M^{-1} V[k]
+    for (int k = 0; k < m + 1; ++k) {
+      V.emplace_back(x.size());
+      Z.emplace_back(x.size());
+    }
+    // v0 = r / ||r||
+    f_t rnorm     = vector_norm2<i_t, f_t>(r);
+    f_t inv_rnorm = (rnorm > 0) ? (f_t(1) / rnorm) : f_t(1);
+    V[0]          = r;
+    V[0].multiply_scalar(inv_rnorm);
+    e1.assign(m + 1, 0.0);
+    e1[0] = rnorm;
+
+    // Hessenberg building
+    int k = 0;
+    for (; k < m; ++k) {
+      // Z[k] = M^{-1} V[k], i.e., apply right preconditioner and store
+      op.solve(V[k], Z[k]);
+
+      // w = A * Z[k]
+      op.a_multiply(1.0, Z[k], 0.0, V[k + 1]);
+
+      // Modified Gram-Schmidt orthogonalization
+      for (int j = 0; j <= k; ++j) {
+        // H[j][k] = dot(w, V[j])
+        f_t hij = V[k + 1].inner_product(V[j]);
+        H[j][k] = hij;
+        // w -= H[j][k] * V[j]
+        V[k + 1].axpy(-hij, V[j], 1.0);
+      }
+
+      // H[k+1][k] = ||w||
+      f_t h_k1k   = vector_norm2<i_t, f_t>(V[k + 1]);
+      H[k + 1][k] = h_k1k;
+      if (h_k1k != 0.0) {
+        // V[k+1] = V[k+1] / H[k+1][k]
+        f_t inv_h = f_t(1) / h_k1k;
+        V[k + 1].multiply_scalar(inv_h);
+      }
+
+      // Apply Given's rotations to new column
+      for (int i = 0; i < k; ++i) {
+        f_t temp    = cs[i] * H[i][k] + sn[i] * H[i + 1][k];
+        H[i + 1][k] = -sn[i] * H[i][k] + cs[i] * H[i + 1][k];
+        H[i][k]     = temp;
+      }
+      // Compute k-th Given's rotation
+      f_t delta   = std::sqrt(H[k][k] * H[k][k] + H[k + 1][k] * H[k + 1][k]);
+      cs[k]       = (delta == 0) ? 1.0 : H[k][k] / delta;
+      sn[k]       = (delta == 0) ? 0.0 : H[k + 1][k] / delta;
+      H[k][k]     = cs[k] * H[k][k] + sn[k] * H[k + 1][k];
+      H[k + 1][k] = 0.0;
+
+      // Update the residual norm
+      f_t temp_e = cs[k] * e1[k] + sn[k] * e1[k + 1];
+      e1[k + 1]  = -sn[k] * e1[k] + cs[k] * e1[k + 1];
+      e1[k]      = temp_e;
+
+      rel_res = std::abs(e1[k + 1]);  // / bnorm;
+      if (show_info) {
+        // printf("GMRES IR: iter %d residual = %e\n", k+1, rel_res * bnorm);
+        CUOPT_LOG_INFO("GMRES IR: iter %d residual = %e", k + 1, rel_res);
+      }
+
+      if (rel_res < tol) {
+        k++;  // reached convergence
+        break;
+      }
+    }  // end Arnoldi loop
+
+    // Solve least squares H y = e
+    // Back-substitution (H is (k+1)xk upper Hessenberg, cs/sin already applied)
+    std::fill(y.begin(), y.end(), 0.0);
+    for (int i = k - 1; i >= 0; --i) {
+      f_t s = e1[i];
+      for (int j = i + 1; j < k; ++j) {
+        s -= H[i][j] * y[j];
+      }
+      y[i] = s / H[i][i];
+    }
+
+    // Compute GMRES update: delta_x = sum_j y_j * Z[j], where Z[j] = M^{-1} V[j]
+    std::fill(delta_x.begin(), delta_x.end(), 0.0);
+    for (int j = 0; j < k; ++j) {
+      delta_x.axpy(y[j], Z[j], 1.0);
+    }
+
+    // Update x = x + delta_x
+    x.axpy(1.0, delta_x, 1.0);
+
+    // r = b - A*x
+    r = b;
+    op.a_multiply(-1.0, x, 1.0, r);
+
+    residual = vector_norm_inf<i_t, f_t>(r);
+
+    auto l2_residual = vector_norm2<i_t, f_t>(r);
+
+    if (show_info) {
+      // printf("GMRES IR: after outer_iter %d residual = %e\n", outer_iter, residual);
+      CUOPT_LOG_INFO("GMRES IR: after outer_iter %d residual = %e, l2_residual = %e",
+                     outer_iter,
+                     residual,
+                     l2_residual);
+    }
+
+    // Track best solution
+    if (residual < best_residual) {
+      best_residual = residual;
+      x_sav         = x;
+    } else {
+      // Residual increased or stagnated, restore best and stop
+      if (show_info) {
+        //  printf("GMRES IR: residual increased from %e to %e, stopping\n", best_residual,
+        //  residual);
+        CUOPT_LOG_INFO(
+          "GMRES IR: residual increased from %e to %e, stopping", best_residual, residual);
+      }
+      x = x_sav;
+      break;
+    }
+
+    ++outer_iter;
+  }
+}
+
+template <typename i_t, typename f_t, typename T>
+void iterative_refinement(T& op, const dense_vector_t<i_t, f_t>& b, dense_vector_t<i_t, f_t>& x)
+{
+  const bool is_qp = op.data_.Q.n > 0;
+  if (is_qp) {
+    iterative_refinement_gmres(op, b, x);
+  } else {
+    iterative_refinement_simple(op, b, x);
+  }
+  return;
 }
 
 }  // namespace cuopt::linear_programming::dual_simplex


### PR DESCRIPTION
This PR adds GMRES based iterative refinement.  The cholesky (or LDL) factorization is used as the preconditioning strategy for the GMRES iterations.   For now, this is enabled only for QP problems. 

Additional:
  * GPU-accelerated augmented multiply
  * Native device-vector support for sparse matrix multiply 