### PR TITLE
Update release branch to 26.02 for upcoming release nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         cuopt_branch:
           - "main"
-          - "release/26.02
+          - "release/26.02"
     steps:
       - uses: actions/checkout@v4
       - name: Trigger Pipeline


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright year range in project metadata to include 2026.
  * Adjusted nightly build workflow to track the newer release branch (updated release version reference).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->