### PR TITLE
wheel builds: react to changes in pip's handling of build constraints

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -21,12 +21,28 @@ sccache --zero-stats
 
 rapids-logger "Building '${package_name}' wheel"
 
+RAPIDS_PIP_WHEEL_ARGS=(
+  -w dist
+  -v
+  --no-deps
+  --disable-pip-version-check
+  --extra-index-url=https://pypi.nvidia.com
+)
+
+# Only use --build-constraint when build isolation is enabled.
+#
+# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
+# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
+# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/573
+if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
+    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
+fi
+
+# unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
+# results in an error from 'pip wheel' when set and --build-constraint is also passed
+unset PIP_CONSTRAINT
 rapids-pip-retry wheel \
-    -w dist \
-    -v \
-    --no-deps \
-    --disable-pip-version-check \
-    --extra-index-url=https://pypi.nvidia.com \
+    "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
     .
 
 sccache --show-adv-stats

--- a/ci/build_wheel_cuopt.sh
+++ b/ci/build_wheel_cuopt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -24,8 +24,8 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 # Download the libcuopt and cuopt-mps-parser wheel built in the previous step and make it
 # available for pip to find.
 #
-# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
-# are used when creating the isolated build environment.
+# env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
+# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUOPT_MPS_PARSER_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuopt_mps_parser" rapids-download-wheels-from-github python)
 LIBCUOPT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libcuopt_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/build-planning/issues/242

Modifying `ci/build_wheel.sh` to

- pass`--build-constraint="${PIP_CONSTRAINT}"` unless build isolation is enabled.
- unset `PIP_CONSTRAINT` (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and results in an error from `pip wheel` when set and `--build-constraint` is also passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pip wheel build configuration to consolidate invocation arguments and improve constraint handling during the wheel creation process.
  * Refined build documentation comments for clarity on constraint behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->