### PR TITLE
Fix find dense columns out of bounds

### DIFF
--- a/cpp/src/dual_simplex/barrier.cu
+++ b/cpp/src/dual_simplex/barrier.cu
@@ -1147,8 +1147,8 @@ class iteration_data_t {
     std::vector<i_t> histogram_row(n + 1, 0);
     max_row_nz = 0;
     for (i_t k = 0; k < m; k++) {
-      histogram_row[row_nz[k]]++;
       cuopt_assert(row_nz[k] <= n, "Row nonzero count exceeds histogram_row size");
+      histogram_row[row_nz[k]]++;
       max_row_nz = std::max(max_row_nz, row_nz[k]);
     }
 #ifdef HISTOGRAM


### PR DESCRIPTION
This PR fixes a bug observed on miplib on H100 during concurrent root solve.
The number of nnz in columns can be equal to m.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced internal safety checks to prevent potential overflow conditions in barrier algorithm computations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->