### PR TITLE
fix(build): build package on merge to `release/*` branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "main"
+      - "release/*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:


### PR DESCRIPTION
## Description
We should be building packages when commits are merged into the `release/` branches, otherwise projects can get stuck waiting for nightlies.  Additionally, some packages like `rapids-dask-dependency` don't get built in the nightly runs.

xref: https://github.com/rapidsai/build-planning/issues/224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build workflow configuration updated to trigger on main and release/* branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->