### PR TITLE
fix how tests create service subprocess (causes errors with new cuda)

### DIFF
--- a/python/cuopt_server/cuopt_server/tests/test_bill_logging.py
+++ b/python/cuopt_server/cuopt_server/tests/test_bill_logging.py
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import platform
 import shutil
 import signal
@@ -29,16 +30,12 @@ def test_time_limit_logs():
     )
     dataset = json.load(open(dataset_path))
     client = RequestClient(port=5010)
-    env = {
-        "CUOPT_SERVER_IP": "127.0.0.1",
-        "CUOPT_SERVER_PORT": "5010",
-        "CUOPT_SERVER_LOG_LEVEL": "debug",
-        "CUOPT_MAX_SOLVE_TIME_LIMIT": "5",
-    }
+    env = os.environ.copy()
+    env["CUOPT_MAX_SOLVE_TIME_LIMIT"] = "5"
 
     url = "/cuopt/"
 
-    cmd = python_path + " " + server_script
+    cmd = python_path + " " + server_script + " -i 127.0.0.1 -p 5010 -l debug"
     process = pexpect.spawn(cmd, env=env)
 
     try:

--- a/python/cuopt_server/cuopt_server/tests/test_server_health.py
+++ b/python/cuopt_server/cuopt_server/tests/test_server_health.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import shutil
 
 import pexpect
@@ -18,11 +19,14 @@ python_path = shutil.which("python")
 def test_server_health(args):
     env = None
     if args == "env":
-        env = {
-            "CUOPT_SERVER_IP": "127.0.0.1",
-            "CUOPT_SERVER_PORT": "5001",
-            "CUOPT_SERVER_LOG_LEVEL": "error",
-        }
+        env = os.environ.copy()
+        env.update(
+            {
+                "CUOPT_SERVER_IP": "127.0.0.1",
+                "CUOPT_SERVER_PORT": "5001",
+                "CUOPT_SERVER_LOG_LEVEL": "error",
+            }
+        )
         url = (
             "http://"
             + env["CUOPT_SERVER_IP"]

--- a/python/cuopt_server/cuopt_server/tests/utils/utils.py
+++ b/python/cuopt_server/cuopt_server/tests/utils/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -315,12 +315,19 @@ def spinup_wait():
 @pytest.fixture(scope="session")
 def cuoptproc(request):
     global cuoptmain
-    env = {
-        "CUOPT_SERVER_IP": "0.0.0.0",
-        "CUOPT_SERVER_PORT": "5555",
-        "CUOPT_SERVER_LOG_LEVEL": "debug",
-    }
-    cuoptmain = Popen([python_path, server_script, server_module], env=env)
+    cuoptmain = Popen(
+        [
+            python_path,
+            server_script,
+            server_module,
+            "-i",
+            "0.0.0.0",
+            "-p",
+            "5555",
+            "-l",
+            "debug",
+        ]
+    )
     spinup_wait()
 
     def shutdown():


### PR DESCRIPTION
Recent changes in CUDA and related Python libraries exposed a bug in cuOpt service tests where subprocesses to run the server were started without a full copy of the parent environment. This omitted things like the CONDA path, etc. Previously this was harmless, but library loading code in CUDA is more sophisticated now and missing env vars cause unexpected errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test server startup configuration to use explicit command-line arguments instead of environment variables for improved test flexibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->