### PR TITLE
Add .github/release.yml for auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+    authors:
+      - rapids-bot[bot]
+      - dependabot[bot]
+  categories:
+    - title: "\U0001F6A8 Breaking Changes"
+      labels:
+        - breaking
+    - title: "\U0001F41B Bug Fixes"
+      labels:
+        - bug
+    - title: "\U0001F4D6 Documentation"
+      labels:
+        - doc
+    - title: "\U0001F680 New Features"
+      labels:
+        - feature request
+    - title: "\U0001F6E0\uFE0F Improvements"
+      labels:
+        - improvement


### PR DESCRIPTION
Adds `.github/release.yml` to configure GitHub's auto-generated release notes with:

- **Label-based categorization**: Breaking Changes, Bug Fixes, Documentation, New Features, Improvements
- **Bot exclusions**: `rapids-bot[bot]`, `dependabot[bot]`
- **Label exclusions**: `ignore-for-release`, `dependencies`

This matches the standard configuration used across rapidsai repos (e.g., [rmm](https://github.com/rapidsai/rmm/blob/main/.github/release.yml)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to improve changelog organization and filtering for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->