### PR TITLE
Fix variable bound violation in CPUFJ moves

### DIFF
--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
@@ -590,13 +590,9 @@ __global__ void update_assignment_kernel(typename fj_t<i_t, f_t>::climber_data_t
   // update the assignment and objective proper
   if (FIRST_THREAD) {
     f_t new_val = fj.incumbent_assignment[var_idx] + fj.jump_move_delta[var_idx];
+
     cuopt_assert(fj.pb.check_variable_within_bounds(var_idx, new_val),
                  "assignment not within bounds");
-    // clamping to err on the safe size - assert catches this
-    auto bounds = fj.pb.variable_bounds[var_idx];
-    f_t lb      = get_lower(bounds);
-    f_t ub      = get_upper(bounds);
-    new_val     = min(max(new_val, lb), ub);
     cuopt_assert(isfinite(new_val), "assignment is not finite");
 
     if (fj.pb.is_integer_var(var_idx)) {
@@ -621,6 +617,7 @@ __global__ void update_assignment_kernel(typename fj_t<i_t, f_t>::climber_data_t
       }
     }
 
+    auto bounds          = fj.pb.variable_bounds[var_idx];
     i_t var_range        = get_upper(bounds) - get_lower(bounds);
     double delta_rel_err = fabs(fj.jump_move_delta[var_idx]) / var_range;
     if (delta_rel_err < fj.settings->parameters.small_move_tabu_threshold) {

--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -702,6 +702,21 @@ static void apply_move(fj_cpu_climber_t<i_t, f_t>& fj_cpu,
   raft::random::PCGenerator rng(fj_cpu.settings.seed + fj_cpu.iterations, 0, 0);
 
   cuopt_assert(var_idx < fj_cpu.view.pb.n_variables, "variable index out of bounds");
+  f_t old_val = fj_cpu.h_assignment[var_idx];
+  f_t new_val = old_val + delta;
+  if (is_integer_var<i_t, f_t>(fj_cpu, var_idx)) {
+    cuopt_assert(fj_cpu.view.pb.integer_equal(new_val, round(new_val)), "new_val is not integer");
+    new_val = round(new_val);
+  }
+  // clamp to var bounds
+  new_val = std::min(std::max(new_val, get_lower(fj_cpu.h_var_bounds[var_idx].get())),
+                     get_upper(fj_cpu.h_var_bounds[var_idx].get()));
+  delta   = new_val - old_val;
+  cuopt_assert(isfinite(new_val), "assignment is not finite");
+  cuopt_assert(isfinite(delta), "applied delta is not finite");
+  cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val)),
+               "assignment not within bounds");
+
   // Update the LHSs of all involved constraints.
   auto [offset_begin, offset_end] = reverse_range_for_var<i_t, f_t>(fj_cpu, var_idx);
 
@@ -761,20 +776,7 @@ static void apply_move(fj_cpu_climber_t<i_t, f_t>& fj_cpu,
   }
 
   // update the assignment and objective proper
-  f_t new_val = fj_cpu.h_assignment[var_idx] + delta;
-  if (is_integer_var<i_t, f_t>(fj_cpu, var_idx)) {
-    cuopt_assert(fj_cpu.view.pb.integer_equal(new_val, round(new_val)), "new_val is not integer");
-    new_val = round(new_val);
-  }
-  // clamp to var bounds
-  new_val = std::min(std::max(new_val, get_lower(fj_cpu.h_var_bounds[var_idx].get())),
-                     get_upper(fj_cpu.h_var_bounds[var_idx].get()));
   fj_cpu.h_assignment[var_idx] = new_val;
-
-  cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val)),
-               "assignment not within bounds");
-  cuopt_assert(isfinite(new_val), "assignment is not finite");
-
   fj_cpu.h_incumbent_objective += fj_cpu.h_obj_coeffs[var_idx] * delta;
   if (fj_cpu.h_incumbent_objective < fj_cpu.h_best_objective &&
       fj_cpu.violated_constraints.empty()) {


### PR DESCRIPTION
CPUFJ did not ensure that moves generated were clamped to the variable bounds. This allowed very slight (but within tolerance) bound violations accumulate, resulting in numerically flawed objective values.
This fixes a bug seen on `cbs-cta` where solutions were found that beat the optimal of 0. 


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
