### PR TITLE
Store best dual objective, align root LP bound with relative_mip_gap

### DIFF
--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -727,7 +727,7 @@ void branch_and_bound_t<i_t, f_t>::set_final_solution(mip_solution_t<i_t, f_t>& 
   {
     const f_t root_lp_obj = root_lp_current_lower_bound_.load();
     if (std::isfinite(root_lp_obj)) {
-      settings_.log.printf("Root LP dual objective (last): %.16e\n", root_lp_obj);
+      settings_.log.printf("Root LP dual objective (best): %.16e\n", root_lp_obj);
     }
   }
 
@@ -769,6 +769,14 @@ void branch_and_bound_t<i_t, f_t>::set_final_solution(mip_solution_t<i_t, f_t>& 
   solution.lower_bound        = lower_bound;
   solution.nodes_explored     = exploration_stats_.nodes_explored;
   solution.simplex_iterations = exploration_stats_.total_lp_iters;
+
+  // When returning early (e.g. time limit at root) with -inf, push root LP bound to stats
+  // so relative_mip_gap uses the best bound we have (root_lp_bound is already in user space)
+  const f_t root_lp_bound = root_lp_current_lower_bound_.load();
+  if (!std::isfinite(lower_bound) && std::isfinite(root_lp_bound) &&
+      user_bound_callback_ != nullptr) {
+    user_bound_callback_(root_lp_bound);
+  }
 }
 
 template <typename i_t, typename f_t>
@@ -2026,7 +2034,12 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
   lp_settings.scale_columns                   = false;
   lp_settings.concurrent_halt                 = get_root_concurrent_halt();
   lp_settings.dual_simplex_objective_callback = [this](f_t user_obj) {
-    root_lp_current_lower_bound_.store(user_obj);
+    // Store only the best (tightest) dual objective; it can worsen during iterations
+    const bool is_maximization = original_lp_.obj_scale < 0.0;
+    f_t current                = root_lp_current_lower_bound_.load();
+    const bool update =
+      !std::isfinite(current) || (is_maximization ? (user_obj < current) : (user_obj > current));
+    if (update) { root_lp_current_lower_bound_.store(user_obj); }
   };
   std::vector<i_t> basic_list(original_lp_.num_rows);
   std::vector<i_t> nonbasic_list;

--- a/cpp/src/mip_heuristics/solver.cu
+++ b/cpp/src/mip_heuristics/solver.cu
@@ -272,8 +272,13 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
       context.problem_ptr->clique_table);
     context.branch_and_bound_ptr = branch_and_bound.get();
     auto* stats_ptr              = &context.stats;
-    branch_and_bound->set_user_bound_callback(
-      [stats_ptr](f_t user_bound) { stats_ptr->set_solution_bound(user_bound); });
+    const bool is_minimization   = !context.problem_ptr->maximize;
+    branch_and_bound->set_user_bound_callback([stats_ptr, is_minimization](f_t user_bound) {
+      f_t current          = stats_ptr->get_solution_bound();
+      const bool is_better = !std::isfinite(current) ||
+                             (is_minimization ? (user_bound > current) : (user_bound < current));
+      if (is_better) { stats_ptr->set_solution_bound(user_bound); }
+    });
 
     // Set the primal heuristics -> branch and bound callback
     if (context.settings.determinism_mode == CUOPT_MODE_OPPORTUNISTIC) {


### PR DESCRIPTION
- Callback: store only best (tightest) dual objective; it can worsen during iterations (min: keep largest, max: keep smallest)
- set_final_solution: when returning with -inf, push root_lp_current_lower_bound_ to stats so relative_mip_gap uses the best/tightest bound
- user_bound_callback: only update stats when new bound is better, avoid overwriting e.g. set_simplex_solution with a worse root LP value
- Log line change: 'Root LP dual objective (last)' -> '(best)'