### PR TITLE
turn off cpu only tests to unblock CI during investigation

### DIFF
--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -382,7 +382,7 @@ class CPUOnlyTestEnvironment {
 
 // TODO: Add numerical assertions once gRPC remote solver replaces the stub implementation.
 // Currently validates that the CPU-only C API path completes without errors.
-TEST(c_api_cpu_only, lp_solve)
+TEST(c_api_cpu_only, DISABLED_lp_solve)
 {
   CPUOnlyTestEnvironment env;
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
@@ -391,7 +391,7 @@ TEST(c_api_cpu_only, lp_solve)
 }
 
 // TODO: Add numerical assertions once gRPC remote solver replaces the stub implementation.
-TEST(c_api_cpu_only, mip_solve)
+TEST(c_api_cpu_only, DISABLED_mip_solve)
 {
   CPUOnlyTestEnvironment env;
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();

--- a/python/cuopt/cuopt/tests/linear_programming/test_cpu_only_execution.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_cpu_only_execution.py
@@ -168,6 +168,8 @@ def _impl_warmstart_cpu_only():
 class TestCPUOnlyExecution:
     """Tests that run with CUDA_VISIBLE_DEVICES='' to simulate CPU-only hosts."""
 
+    pytestmark = pytest.mark.skip(reason="CPU-only tests temporarily disabled")
+
     @pytest.fixture
     def env(self):
         return _cpu_only_env()
@@ -200,6 +202,8 @@ class TestCPUOnlyExecution:
 
 class TestCuoptCliCPUOnly:
     """Test that cuopt_cli runs without CUDA in remote-execution mode."""
+
+    pytestmark = pytest.mark.skip(reason="CPU-only tests temporarily disabled")
 
     @pytest.fixture
     def env(self):


### PR DESCRIPTION
something has changed in the CI environment to cause cpu-only tests related to remote execution to fail, disabling these tests while we investigate root cause for the change