### PR TITLE
apply -UNDEBUG to coupt flags instead of global settings

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -109,6 +109,8 @@ if(BUILD_MSAN)
   add_link_options(-fsanitize=memory)
 endif(BUILD_MSAN)
 
+# Note: -UNDEBUG is applied via CUOPT_CXX_FLAGS / CUOPT_CUDA_FLAGS (not add_definitions)
+# to avoid leaking into dependencies that are built in-tree.
 if(DEFINE_ASSERT)
   add_definitions(-DASSERT_MODE)
   list(APPEND CUOPT_CXX_FLAGS -UNDEBUG)
@@ -185,11 +187,6 @@ elseif(CMAKE_CUDA_LINEINFO)
   list(APPEND CUOPT_CUDA_FLAGS -lineinfo)
   set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS_RELEASE} -lineinfo")
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
-
-# Note: -UNDEBUG is applied via CUOPT_CXX_FLAGS / CUOPT_CUDA_FLAGS (not add_definitions)
-# to avoid leaking into dependencies that are built in-tree.
-# See the DEFINE_ASSERT block near the top of this file.
-
 
 # ##################################################################################################
 # - find CPM based dependencies  ------------------------------------------------------------------

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -382,7 +382,7 @@ class CPUOnlyTestEnvironment {
 
 // TODO: Add numerical assertions once gRPC remote solver replaces the stub implementation.
 // Currently validates that the CPU-only C API path completes without errors.
-TEST(c_api_cpu_only, DISABLED_lp_solve)
+TEST(c_api_cpu_only, lp_solve)
 {
   CPUOnlyTestEnvironment env;
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
@@ -391,7 +391,7 @@ TEST(c_api_cpu_only, DISABLED_lp_solve)
 }
 
 // TODO: Add numerical assertions once gRPC remote solver replaces the stub implementation.
-TEST(c_api_cpu_only, DISABLED_mip_solve)
+TEST(c_api_cpu_only, mip_solve)
 {
   CPUOnlyTestEnvironment env;
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();

--- a/python/cuopt/cuopt/tests/linear_programming/test_cpu_only_execution.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_cpu_only_execution.py
@@ -168,8 +168,6 @@ def _impl_warmstart_cpu_only():
 class TestCPUOnlyExecution:
     """Tests that run with CUDA_VISIBLE_DEVICES='' to simulate CPU-only hosts."""
 
-    pytestmark = pytest.mark.skip(reason="CPU-only tests temporarily disabled")
-
     @pytest.fixture
     def env(self):
         return _cpu_only_env()
@@ -202,8 +200,6 @@ class TestCPUOnlyExecution:
 
 class TestCuoptCliCPUOnly:
     """Test that cuopt_cli runs without CUDA in remote-execution mode."""
-
-    pytestmark = pytest.mark.skip(reason="CPU-only tests temporarily disabled")
 
     @pytest.fixture
     def env(self):


### PR DESCRIPTION
don't pass -UNDEBUG to other libraries we may build