### PR TITLE
Fix lexicographic search

### DIFF
--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -685,10 +685,6 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
     k_max = 4;
   }
 
-  // Base number of insertion positions (used to compute grid size after k_max is fixed)
-  const i_t n_lexico_positions = (solution_ptr->get_num_orders() + solution_ptr->get_n_routes() -
-                                  solution_ptr->problem_ptr->order_info.depot_included_);
-
   size_t sh_size = 0;
   bool is_set    = false;
   while (k_max > 1) {
@@ -703,14 +699,12 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
 
   if (k_max == 1 || !is_set) { return false; }
 
-  // Recompute block count with final k_max so kernel's blockIdx.x stays in valid range
-  // (kernel uses delivery_insertion_idx = blockIdx.x / n_lexico_positions, so we must launch
-  // exactly n_lexico_positions * max_neighbors(k_max) blocks for PDP).
-  i_t n_blocks_lexico = n_lexico_positions;
+  // Compute n_blocks_lexico after k_max is finalized by the while-loop above
+  i_t n_blocks_lexico = (solution_ptr->get_num_orders() + solution_ptr->get_n_routes() -
+                         solution_ptr->problem_ptr->order_info.depot_included_);
   if constexpr (REQUEST == request_t::PDP) {
     n_blocks_lexico *= max_neighbors<i_t, REQUEST>(k_max);
   }
-  if (n_blocks_lexico <= 0) { return false; }
 
   // Init global min before call to lexicographic
   const auto max = std::numeric_limits<typename decltype(global_min_p_)::value_type>::max();


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description

## Fix GES lexicographic search cudaErrorInvalidValue (test_lex_smoke)

### Summary
Fixes `cudaErrorInvalidValue` in the guided ejection search (GES) lexicographic kernel for PDP routing. The failure was caused by launching with a block count computed for the initial `k_max` while the loop could reduce `k_max` (and thus the valid block range) before launch.

### Root cause
- `n_blocks_lexico` was set once using the initial `k_max` (e.g. 5).
- The loop that finds a valid shared-memory size can decrement `k_max` (e.g. to 2–4) when `set_shmem_of_kernel` fails.
- The kernel was still launched with the original block count (e.g. 77 for `k_max = 5`) but received the reduced `k_max` (e.g. 2).
- The kernel uses `delivery_insertion_idx_in_permutation = blockIdx.x / n_lexico_positions` and expects the grid size to be `n_lexico_positions * max_neighbors(k_max)`. With too many blocks, `blockIdx.x` went out of the intended range and led to invalid behavior and `cudaErrorInvalidValue`.

### Changes
- **`cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu`**
  - Compute only the number of insertion positions (`n_lexico_positions`) before the loop.
  - After the loop, set `n_blocks_lexico = n_lexico_positions * max_neighbors(k_max)` using the **final** `k_max` so the launch config matches the kernel.
  - If `n_blocks_lexico <= 0`, return `false` and skip the kernel launch.

### Testing
- `pytest python/cuopt/cuopt/tests/routing/test_warnings.py::test_lex_smoke` passes after rebuilding libcuopt.

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
