### PR TITLE
Disable running notebooks while building docs

### DIFF
--- a/docs/cuopt/source/conf.py
+++ b/docs/cuopt/source/conf.py
@@ -94,8 +94,9 @@ swagger = [
 nbsphinx_execute = "never"
 ipython_mplbackend = "str"
 
-# GPU routing example: execution during Sphinx can fail when CUDA/CuPy don't match the
-# docs env. The notebook sets mystnb.execution_mode=off and ships checked-in outputs.
+# GPU routing example: Sphinx execution can fail when CUDA/CuPy don't match the docs
+# environment. Listed paths are skipped by myst-nb; this notebook is rendered from
+# checked-in cell outputs.
 nb_execution_excludepatterns = ["cuopt-python/routing/routing-example.ipynb"]
 
 # Add any files to exclude from the build


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
Disable running notebooks which are added examples while building docs 


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
