### PR TITLE
Tweak testing instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Architecture:
 - Clone the repository:
 
 ```bash
-CUOPT_HOME=$(pwd)/cuopt
+export CUOPT_HOME=$(pwd)/cuopt
 git clone https://github.com/NVIDIA/cuopt.git $CUOPT_HOME
 cd $CUOPT_HOME
 ```


### PR DESCRIPTION
The instructions fail for me without `./`.

`WAYPOINT_MATRIXTEST` fails with an obscure error if `CUOPT_HOME` isn't exported.

