### PR TITLE
Update versions1.json as part of version bump

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -152,3 +152,6 @@ elif [[ "${RUN_CONTEXT}" == "release" ]]; then
   sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" docs/cuopt/source/faq.rst
   sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" docs/cuopt/source/cuopt-python/routing/routing-example.ipynb
 fi
+
+# Update docs version switcher to include the new version
+python ci/utils/update_doc_versions.py


### PR DESCRIPTION
`update-version.sh` updates VERSION and all associated files, but `docs/cuopt/source/versions1.json` was not included. This caused the pre-commit style check to fail on main after the 26.04 burndown version bump -- `versions1.json` still referenced 26.04.00 while VERSION had moved to 26.06.00.

This adds a call to `ci/utils/update_doc_versions.py` at the end of `update-version.sh` so the docs version switcher is updated atomically as part of every version bump, rather than relying on the pre-commit hook to catch the gap after the fact.