### PR TITLE
Make infra team as default code owner to any files which are not specifically added to a particular group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Default owner for paths with no later, more specific match
+*                  @nvidia/cuopt-infra-codeowners
+
 #cpp code owners
 cpp/               @nvidia/cuopt-engine-codeowners
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
This change make infra team as default code-owners in case a file/folder is not explicitly added in codeowners list to ensure infra team will cover and provide reviews.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA
