### PR TITLE
Exclude L1TESTs from contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,9 @@ cd $CUOPT_HOME/datasets && ./get_test_data.sh
 cd $CUOPT_HOME && datasets/linear_programming/download_pdlp_test_dataset.sh
 datasets/mip/download_miplib_test_dataset.sh
 export RAPIDS_DATASET_ROOT_DIR=$CUOPT_HOME/datasets/
-ctest --test-dir ${CUOPT_HOME}/cpp/build  # libcuopt
+ctest --test-dir ${CUOPT_HOME}/cpp/build -E L1TEST  # libcuopt
 ```
+`L1TEST`s are excluded because they are expensive and not run as part of the typical development process.
 
 To run python tests, run
 


### PR DESCRIPTION
These tests are expensive, currently broken, and aren't covered under CI. New contributors will be confused if they see failing tests, so they should be excluded from the instructions.