### PR TITLE
Fix duplicate libmps_parser.so in libcuopt wheel

### DIFF
--- a/cpp/libmps_parser/CMakeLists.txt
+++ b/cpp/libmps_parser/CMakeLists.txt
@@ -136,8 +136,9 @@ endif(BUILD_TESTS)
 
 # ##################################################################################################
 # * mps_parser Install ----------------------------------------------------------------------------
+rapids_cmake_install_lib_dir(mps_parser_lib_dir)
 install(TARGETS mps_parser
-  DESTINATION lib
+  DESTINATION ${mps_parser_lib_dir}
   EXPORT mps-parser-exports)
 
 install(DIRECTORY include/mps_parser/


### PR DESCRIPTION
## Summary
- The `mps_parser` install target in `cpp/libmps_parser/CMakeLists.txt` hardcoded `DESTINATION lib`, while the parent `cpp/CMakeLists.txt` installs to the platform-correct `lib64` (on x86_64) via `rapids_cmake_install_lib_dir()`. This caused `libmps_parser.so` to appear in **both** `lib/` and `lib64/` in the libcuopt wheel, wasting ~350 KB.
- Replaced the hardcoded `lib` with `rapids_cmake_install_lib_dir()` so both install commands resolve to the same directory, eliminating the duplicate.

## Details
In the current `libcuopt_cu13` wheel (`libcuopt_cu13-26.6.0a103`), `libmps_parser.so` (357,240 bytes) appears twice:
```
357240  libcuopt/lib/libmps_parser.so
357240  libcuopt/lib64/libmps_parser.so
```

The root cause is two independent `install(TARGETS mps_parser ...)` commands:
1. `cpp/libmps_parser/CMakeLists.txt:139` → `DESTINATION lib` (hardcoded)
2. `cpp/CMakeLists.txt:576` → `DESTINATION ${_LIB_DEST}` → `lib64` (via `rapids_cmake_install_lib_dir`)

## Test plan
- [ ] Verify the libcuopt wheel only contains `libmps_parser.so` in `lib64/`, not in `lib/`
- [ ] Verify standalone `mps_parser` build still installs to the correct platform lib directory
- [ ] Verify `cuopt-mps-parser` Python wheel build is unaffected (uses `EXCLUDE_FROM_ALL` + custom destinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)