### PR TITLE
fix(cuda_helpers): clear sticky error and avoid cache poisoning in set_shmem_of_kernel

### DIFF
--- a/cpp/src/utilities/cuda_helpers.cuh
+++ b/cpp/src/utilities/cuda_helpers.cuh
@@ -12,13 +12,13 @@
 #include <thrust/host_vector.h>
 #include <thrust/tuple.h>
 #include <mutex>
-#include <shared_mutex>
 #include <raft/core/device_span.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>
+#include <shared_mutex>
 #include <unordered_map>
 
 namespace cuopt {

--- a/cpp/src/utilities/cuda_helpers.cuh
+++ b/cpp/src/utilities/cuda_helpers.cuh
@@ -12,6 +12,7 @@
 #include <thrust/host_vector.h>
 #include <thrust/tuple.h>
 #include <mutex>
+#include <shared_mutex>
 #include <raft/core/device_span.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
@@ -175,29 +176,49 @@ HDI To bit_cast(const From& src)
   return *(To*)(&src);
 }
 
+/**
+ * @brief Raises the dynamic shared-memory limit for a CUDA kernel, with caching.
+ *
+ * Calls cudaFuncSetAttribute(cudaFuncAttributeMaxDynamicSharedMemorySize) only when
+ * @p dynamic_request_size exceeds the previously set limit for @p function.  The
+ * per-kernel high-water mark is stored in a process-wide cache so that repeated
+ * calls with the same or smaller sizes are cheap shared-lock reads.
+ *
+ * Thread safety: safe to call concurrently from multiple host threads.
+ *
+ * @param function             Host pointer to the __global__ kernel function.
+ * @param dynamic_request_size Requested dynamic shared memory in bytes.
+ *                             A value of 0 is a no-op and always returns true.
+ * @return true  if the attribute was successfully set (or was already sufficient).
+ * @return false if cudaFuncSetAttribute failed (e.g. size exceeds device limit);
+ *               the sticky CUDA error is consumed so it cannot surface later.
+ */
 template <typename Function>
 inline bool set_shmem_of_kernel(Function* function, size_t dynamic_request_size)
 {
-  static std::mutex mtx;
+  static std::shared_mutex mtx;
   static std::unordered_map<Function*, size_t> shmem_sizes;
 
   if (dynamic_request_size != 0) {
     dynamic_request_size = raft::alignTo(dynamic_request_size, size_t(1024));
-    size_t current_size  = shmem_sizes[function];
-    if (dynamic_request_size > current_size) {
-      std::lock_guard<std::mutex> lock(mtx);
-      current_size = shmem_sizes[function];
 
-      if (dynamic_request_size > current_size) {
-        auto err = cudaFuncSetAttribute(
-          function, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_request_size);
-        if (err == cudaSuccess) {
-          shmem_sizes[function] = dynamic_request_size;
-          return true;
-        } else {
-          cudaGetLastError();  // clear sticky error so later RAFT_CHECK_CUDA doesn't catch it
-          return false;
-        }
+    {
+      std::shared_lock<std::shared_mutex> rlock(mtx);
+      auto it = shmem_sizes.find(function);
+      if (it != shmem_sizes.end() && dynamic_request_size <= it->second) { return true; }
+    }
+
+    std::unique_lock<std::shared_mutex> wlock(mtx);
+    size_t current_size = shmem_sizes.count(function) ? shmem_sizes[function] : 0;
+    if (dynamic_request_size > current_size) {
+      auto err = cudaFuncSetAttribute(
+        function, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_request_size);
+      if (err == cudaSuccess) {
+        shmem_sizes[function] = dynamic_request_size;
+        return true;
+      } else {
+        cudaGetLastError();  // clear sticky error so later RAFT_CHECK_CUDA doesn't catch it
+        return false;
       }
     }
   }

--- a/cpp/src/utilities/cuda_helpers.cuh
+++ b/cpp/src/utilities/cuda_helpers.cuh
@@ -189,10 +189,15 @@ inline bool set_shmem_of_kernel(Function* function, size_t dynamic_request_size)
       current_size = shmem_sizes[function];
 
       if (dynamic_request_size > current_size) {
-        cudaFuncSetAttribute(
+        auto err = cudaFuncSetAttribute(
           function, cudaFuncAttributeMaxDynamicSharedMemorySize, dynamic_request_size);
-        shmem_sizes[function] = dynamic_request_size;
-        return (cudaSuccess == cudaGetLastError());
+        if (err == cudaSuccess) {
+          shmem_sizes[function] = dynamic_request_size;
+          return true;
+        } else {
+          cudaGetLastError();  // clear sticky error so later RAFT_CHECK_CUDA doesn't catch it
+          return false;
+        }
       }
     }
   }

--- a/cpp/tests/routing/CMakeLists.txt
+++ b/cpp/tests/routing/CMakeLists.txt
@@ -33,4 +33,5 @@ ConfigureTest(ROUTING_UNIT_TEST
       ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/objective_function.cu
       ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/top_k.cu
       ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/batch_tsp.cu
+      ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/set_shmem_of_kernel.cu
 )

--- a/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
+++ b/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
@@ -76,7 +76,8 @@ TEST(set_shmem_of_kernel, no_sticky_error_after_failure)
     << "cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerBlockOptin) failed";
   size_t too_large = static_cast<size_t>(shmem_max) + 1024;
 
-  EXPECT_FALSE(set_shmem_of_kernel(kernel_sticky_error, too_large));  // confirm failure branch taken
+  EXPECT_FALSE(
+    set_shmem_of_kernel(kernel_sticky_error, too_large));  // confirm failure branch taken
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 

--- a/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
+++ b/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
@@ -14,42 +14,51 @@
 namespace cuopt {
 namespace test {
 
+/// @brief Dummy kernel used to test a zero-byte shared-memory request.
 __global__ void kernel_zero() {}
+/// @brief Dummy kernel used to test a normal (within-limit) shared-memory request.
 __global__ void kernel_normal() {}
+/// @brief Dummy kernel used to test a too-large shared-memory request (first call).
 __global__ void kernel_too_large_a() {}
+/// @brief Dummy kernel used to test a too-large shared-memory request (repeated call).
 __global__ void kernel_too_large_b() {}
+/// @brief Dummy kernel used to verify that a failed request leaves no sticky CUDA error.
 __global__ void kernel_sticky_error() {}
 
-// Zero request is a no-op and must return true.
+/// @brief Zero request is a no-op and must return true.
 TEST(set_shmem_of_kernel, zero_request)
 {
   EXPECT_TRUE(set_shmem_of_kernel(kernel_zero, 0));
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 
-// A modest request well within device limits must succeed.
+/// @brief A modest request well within device limits must succeed.
 TEST(set_shmem_of_kernel, normal_request)
 {
   EXPECT_TRUE(set_shmem_of_kernel(kernel_normal, 4096));
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 
-// Requesting more shared memory than the device supports must return false.
+/// @brief Requesting more shared memory than the device supports must return false.
 TEST(set_shmem_of_kernel, too_large_returns_false)
 {
   int shmem_max{};
-  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  ASSERT_EQ(cudaSuccess,
+            cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0))
+    << "cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerBlockOptin) failed";
   size_t too_large = static_cast<size_t>(shmem_max) + 1024;
 
   EXPECT_FALSE(set_shmem_of_kernel(kernel_too_large_a, too_large));
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 
-// A second call with the same too-large size must still return false
+/// @brief A second call with the same too-large size must still return false.
 TEST(set_shmem_of_kernel, cache_not_poisoned_on_failure)
 {
   int shmem_max{};
-  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  ASSERT_EQ(cudaSuccess,
+            cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0))
+    << "cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerBlockOptin) failed";
   size_t too_large = static_cast<size_t>(shmem_max) + 1024;
 
   EXPECT_FALSE(set_shmem_of_kernel(kernel_too_large_b, too_large));
@@ -57,15 +66,17 @@ TEST(set_shmem_of_kernel, cache_not_poisoned_on_failure)
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 
-// A failed call must not leave a sticky CUDA error that would be caught
-// later by an unrelated RAFT_CHECK_CUDA.
+/// @brief A failed call must not leave a sticky CUDA error that would be caught
+/// later by an unrelated RAFT_CHECK_CUDA.
 TEST(set_shmem_of_kernel, no_sticky_error_after_failure)
 {
   int shmem_max{};
-  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  ASSERT_EQ(cudaSuccess,
+            cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0))
+    << "cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerBlockOptin) failed";
   size_t too_large = static_cast<size_t>(shmem_max) + 1024;
 
-  set_shmem_of_kernel(kernel_sticky_error, too_large);
+  EXPECT_FALSE(set_shmem_of_kernel(kernel_sticky_error, too_large));  // confirm failure branch taken
   EXPECT_EQ(cudaSuccess, cudaGetLastError());
 }
 

--- a/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
+++ b/cpp/tests/routing/unit_tests/set_shmem_of_kernel.cu
@@ -1,0 +1,73 @@
+/* clang-format off */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* clang-format on */
+
+#include <utilities/cuda_helpers.cuh>
+
+#include <utilities/base_fixture.hpp>
+
+#include <gtest/gtest.h>
+
+namespace cuopt {
+namespace test {
+
+__global__ void kernel_zero() {}
+__global__ void kernel_normal() {}
+__global__ void kernel_too_large_a() {}
+__global__ void kernel_too_large_b() {}
+__global__ void kernel_sticky_error() {}
+
+// Zero request is a no-op and must return true.
+TEST(set_shmem_of_kernel, zero_request)
+{
+  EXPECT_TRUE(set_shmem_of_kernel(kernel_zero, 0));
+  EXPECT_EQ(cudaSuccess, cudaGetLastError());
+}
+
+// A modest request well within device limits must succeed.
+TEST(set_shmem_of_kernel, normal_request)
+{
+  EXPECT_TRUE(set_shmem_of_kernel(kernel_normal, 4096));
+  EXPECT_EQ(cudaSuccess, cudaGetLastError());
+}
+
+// Requesting more shared memory than the device supports must return false.
+TEST(set_shmem_of_kernel, too_large_returns_false)
+{
+  int shmem_max{};
+  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  size_t too_large = static_cast<size_t>(shmem_max) + 1024;
+
+  EXPECT_FALSE(set_shmem_of_kernel(kernel_too_large_a, too_large));
+  EXPECT_EQ(cudaSuccess, cudaGetLastError());
+}
+
+// A second call with the same too-large size must still return false
+TEST(set_shmem_of_kernel, cache_not_poisoned_on_failure)
+{
+  int shmem_max{};
+  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  size_t too_large = static_cast<size_t>(shmem_max) + 1024;
+
+  EXPECT_FALSE(set_shmem_of_kernel(kernel_too_large_b, too_large));
+  EXPECT_FALSE(set_shmem_of_kernel(kernel_too_large_b, too_large));  // must not return true
+  EXPECT_EQ(cudaSuccess, cudaGetLastError());
+}
+
+// A failed call must not leave a sticky CUDA error that would be caught
+// later by an unrelated RAFT_CHECK_CUDA.
+TEST(set_shmem_of_kernel, no_sticky_error_after_failure)
+{
+  int shmem_max{};
+  cudaDeviceGetAttribute(&shmem_max, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  size_t too_large = static_cast<size_t>(shmem_max) + 1024;
+
+  set_shmem_of_kernel(kernel_sticky_error, too_large);
+  EXPECT_EQ(cudaSuccess, cudaGetLastError());
+}
+
+}  // namespace test
+}  // namespace cuopt


### PR DESCRIPTION
## Description

When cudaFuncSetAttribute fails (e.g. requested size exceeds device limit),
the previous implementation stored the failed size in the shmem_sizes cache
and left a sticky CUDA error in the last-error slot.  Subsequent calls for
the same kernel would see the cached (invalid) size and skip the attribute
call, silently proceeding without the required shared memory.  The sticky
error would later be caught by an unrelated RAFT_CHECK_CUDA, producing a
confusing cudaErrorInvalidValue crash.

Fix:
- Only update the cache on success.
- On failure, consume the error with cudaGetLastError() so it cannot
  surface later, then return false.
- Add five unit tests in ROUTING_UNIT_TEST covering zero request, normal
  request, too-large returns false, cache not poisoned on failure, and
  no sticky error after failure.

## Issue

https://github.com/NVIDIA/cuopt/issues/1094

## Checklist

- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - Added tests
   - Confirmed that the issue 1094 is not reproducing after the fix
- Documentation
   - NA
