### PR TITLE
fix(security): remove insecure SSL verification bypass in dataset downloaders

### DIFF
--- a/benchmarks/linear_programming/utils/get_datasets.py
+++ b/benchmarks/linear_programming/utils/get_datasets.py
@@ -5,7 +5,6 @@ import os
 import argparse
 import urllib.request
 import urllib.parse
-import ssl
 import subprocess
 
 
@@ -632,14 +631,7 @@ def download(url, dst):
     if os.path.exists(dst):
         return
     print(f"Downloading {url} into {dst}...")
-    # Bypass SSL verification for plato.asu.edu URLs
-    if "plato.asu.edu" in url:
-        context = ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-        response = urllib.request.urlopen(url, context=context)
-    else:
-        response = urllib.request.urlopen(url)
+    response = urllib.request.urlopen(url)
     data = response.read()
     with open(dst, "wb") as fp:
         fp.write(data)

--- a/regression/get_datasets.py
+++ b/regression/get_datasets.py
@@ -5,7 +5,6 @@ import os
 import sys
 import urllib.request
 import urllib.parse
-import ssl
 import subprocess
 
 
@@ -824,14 +823,7 @@ def download(url, dst):
     if os.path.exists(dst):
         return
     print(f"Downloading {url} into {dst}...")
-    # Bypass SSL verification for plato.asu.edu URLs
-    if "plato.asu.edu" in url:
-        context = ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-        response = urllib.request.urlopen(url, context=context)
-    else:
-        response = urllib.request.urlopen(url)
+    response = urllib.request.urlopen(url)
     data = response.read()
     with open(dst, "wb") as fp:
         fp.write(data)


### PR DESCRIPTION
## Summary
- Remove `ssl.CERT_NONE` and `check_hostname = False` bypass for `plato.asu.edu` URLs in dataset download scripts
- The site has a valid SSL certificate — the bypass was unnecessary and flagged by SonarQube as 2 Medium-severity vulnerabilities
- Clean up unused `import ssl`

Fixes SonarQube rules `python:S4830` and `python:S5527` (the only 2 open security vulnerabilities in the report).

## Test plan
- [ ] Run `regression/get_datasets.py` and verify plato.asu.edu downloads succeed without SSL bypass
- [ ] Run `benchmarks/linear_programming/utils/get_datasets.py` and verify same