### PR TITLE
Enable SonarQube analysis in nightly test pipeline

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -4,9 +4,6 @@
 name: SonarQube Analysis
 
 on:
-  push:
-    branches:
-      - "enable-sonarqube-nightly"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -4,6 +4,9 @@
 name: SonarQube Analysis
 
 on:
+  push:
+    branches:
+      - "enable-sonarqube-nightly"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: SonarQube Analysis
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to analyze (default: current branch)"
+        required: false
+        type: string
+
+jobs:
+  sonarqube-analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run SonarQube analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ci/run_sonarqube.sh "${{ inputs.branch || github.ref_name }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,3 +99,16 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: ci/test_notebooks.sh
+  sonarqube-analysis:
+    if: inputs.build_type == 'nightly'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+      - name: Run SonarQube analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ci/run_sonarqube.sh "${{ inputs.branch }}"

--- a/ci/run_sonarqube.sh
+++ b/ci/run_sonarqube.sh
@@ -20,13 +20,14 @@ SONAR_SCANNER_DIR="/tmp/sonar-scanner"
 mkdir -p "${SONAR_SCANNER_DIR}"
 curl -sSLo /tmp/sonar-scanner.zip \
   "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux-x64.zip"
-unzip -q /tmp/sonar-scanner.zip -d "${SONAR_SCANNER_DIR}"
+unzip -qo /tmp/sonar-scanner.zip -d "${SONAR_SCANNER_DIR}"
 SONAR_SCANNER_BIN="${SONAR_SCANNER_DIR}/sonar-scanner-${SONAR_SCANNER_VERSION}-linux-x64/bin/sonar-scanner"
 rm /tmp/sonar-scanner.zip
 
 echo "Running SonarQube analysis for branch: ${BRANCH}"
 
 "${SONAR_SCANNER_BIN}" \
-  -Dsonar.branch.name="${BRANCH}"
+  -Dsonar.branch.name="${BRANCH}" \
+  -Dsonar.scanner.socketTimeout=300
 
 echo "SonarQube analysis completed successfully"

--- a/ci/run_sonarqube.sh
+++ b/ci/run_sonarqube.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SONAR_SCANNER_VERSION="6.2.1.4610"
+
+if [ -z "${SONAR_TOKEN:-}" ]; then
+  echo "ERROR: SONAR_TOKEN environment variable is not set"
+  exit 1
+fi
+
+BRANCH="${1:-main}"
+
+# Install sonar-scanner CLI
+echo "Installing sonar-scanner ${SONAR_SCANNER_VERSION}..."
+SONAR_SCANNER_DIR="/tmp/sonar-scanner"
+mkdir -p "${SONAR_SCANNER_DIR}"
+curl -sSLo /tmp/sonar-scanner.zip \
+  "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux-x64.zip"
+unzip -q /tmp/sonar-scanner.zip -d "${SONAR_SCANNER_DIR}"
+SONAR_SCANNER_BIN="${SONAR_SCANNER_DIR}/sonar-scanner-${SONAR_SCANNER_VERSION}-linux-x64/bin/sonar-scanner"
+rm /tmp/sonar-scanner.zip
+
+echo "Running SonarQube analysis for branch: ${BRANCH}"
+
+"${SONAR_SCANNER_BIN}" \
+  -Dsonar.branch.name="${BRANCH}"
+
+echo "SonarQube analysis completed successfully"

--- a/sonarqube/sonar-branches.txt
+++ b/sonarqube/sonar-branches.txt
@@ -5,7 +5,7 @@
 
 # Main development branches
 main
-release/26.04
+release/26.06
 
 # Add release branches as needed
 # release/v1.0


### PR DESCRIPTION
## Summary
- Add `sonarqube-analysis` job to nightly `test.yaml` (source-only scan on `ubuntu-latest`)
- Add standalone `sonarqube.yaml` workflow for on-demand manual testing
- Create `ci/run_sonarqube.sh` to download sonar-scanner and run analysis

### Prerequisite
- `SONAR_TOKEN` secret must be configured in repo settings

## Test plan
- [ ] Set `SONAR_TOKEN` secret in repo settings
- [ ] Trigger `sonarqube.yaml` manually from Actions tab to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)