### PR TITLE
Fixed lower bound in single thread mode

### DIFF
--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -299,10 +299,11 @@ branch_and_bound_t<i_t, f_t>::branch_and_bound_t(
 template <typename i_t, typename f_t>
 f_t branch_and_bound_t<i_t, f_t>::get_lower_bound()
 {
-  f_t lower_bound      = lower_bound_ceiling_.load();
-  f_t heap_lower_bound = node_queue_.get_lower_bound();
-  lower_bound          = std::min(heap_lower_bound, lower_bound);
-  lower_bound          = std::min(worker_pool_.get_lower_bound(), lower_bound);
+  f_t lower_bound        = lower_bound_ceiling_.load();
+  f_t heap_lower_bound   = node_queue_.get_lower_bound();
+  f_t worker_lower_bound = worker_pool_.get_lower_bound();
+  lower_bound            = std::min(heap_lower_bound, lower_bound);
+  lower_bound            = std::min(worker_lower_bound, lower_bound);
 
   if (std::isfinite(lower_bound)) {
     return lower_bound;
@@ -1800,7 +1801,8 @@ void branch_and_bound_t<i_t, f_t>::run_scheduler()
 template <typename i_t, typename f_t>
 void branch_and_bound_t<i_t, f_t>::single_threaded_solve()
 {
-  branch_and_bound_worker_t<i_t, f_t> worker(0, original_lp_, Arow_, var_types_, settings_);
+  worker_pool_.init(1, original_lp_, Arow_, var_types_, settings_);
+  branch_and_bound_worker_t<i_t, f_t>* worker = worker_pool_.get_idle_worker();
 
   f_t lower_bound = get_lower_bound();
   f_t abs_gap     = compute_user_abs_gap(original_lp_, upper_bound_.load(), lower_bound);
@@ -1808,7 +1810,6 @@ void branch_and_bound_t<i_t, f_t>::single_threaded_solve()
 
   while (solver_status_ == mip_status_t::UNSET && abs_gap > settings_.absolute_mip_gap_tol &&
          rel_gap > settings_.relative_mip_gap_tol && node_queue_.best_first_queue_size() > 0) {
-    bool launched_any_task = false;
     repair_heuristic_solutions();
 
     f_t now = toc(exploration_stats_.start_time);
@@ -1844,8 +1845,8 @@ void branch_and_bound_t<i_t, f_t>::single_threaded_solve()
       continue;
     }
 
-    worker.init_best_first(start_node.value(), original_lp_);
-    plunge_with(&worker);
+    worker->init_best_first(start_node.value(), original_lp_);
+    plunge_with(worker);
 
     lower_bound = get_lower_bound();
     abs_gap     = compute_user_abs_gap(original_lp_, upper_bound_.load(), lower_bound);

--- a/cpp/tests/mip/miplib_test.cu
+++ b/cpp/tests/mip/miplib_test.cu
@@ -70,4 +70,24 @@ TEST(mip_solve, run_small_tests)
   }
 }
 
+//
+TEST(mip_solve, low_thread_count_test)
+{
+  mip_solver_settings_t<int, double> settings;
+  settings.num_cpu_threads = 1;
+  settings.time_limit      = 30;
+
+  const raft::handle_t handle_{};
+
+  auto path = make_path_absolute("mip/dominating_set.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, false);
+  handle_.sync_stream();
+
+  mip_solution_t<int, double> solution = solve_mip(&handle_, problem, settings);
+  EXPECT_EQ(solution.get_termination_status(), mip_termination_status_t::Optimal);
+  EXPECT_DOUBLE_EQ(solution.get_objective_value(), 3.0);
+  test_variable_bounds(problem, solution.get_solution(), settings);
+}
+
 }  // namespace cuopt::linear_programming::test

--- a/cpp/tests/mip/miplib_test.cu
+++ b/cpp/tests/mip/miplib_test.cu
@@ -70,7 +70,7 @@ TEST(mip_solve, run_small_tests)
   }
 }
 
-//
+// See https://github.com/NVIDIA/cuopt/pull/1111
 TEST(mip_solve, low_thread_count_test)
 {
   mip_solver_settings_t<int, double> settings;

--- a/datasets/mip/dominating_set.mps
+++ b/datasets/mip/dominating_set.mps
@@ -1,0 +1,90 @@
+NAME        dominating_set
+ROWS
+ N  obj     
+ G  c0      
+ G  c1      
+ G  c2      
+ G  c3      
+ G  c4      
+ G  c5      
+ G  c6      
+ G  c7      
+ G  c8      
+COLUMNS
+    MARK0000  'MARKER'                 'INTORG'
+    x0        obj       1
+    x0        c0        1
+    x0        c1        1
+    x0        c2        1
+    x0        c3        1
+    x0        c6        1
+    x1        obj       1
+    x1        c0        1
+    x1        c1        1
+    x1        c2        1
+    x1        c4        1
+    x1        c7        1
+    x2        obj       1
+    x2        c0        1
+    x2        c1        1
+    x2        c2        1
+    x2        c5        1
+    x2        c8        1
+    x3        obj       1
+    x3        c0        1
+    x3        c3        1
+    x3        c4        1
+    x3        c5        1
+    x3        c6        1
+    x4        obj       1
+    x4        c1        1
+    x4        c3        1
+    x4        c4        1
+    x4        c5        1
+    x4        c7        1
+    x5        obj       1
+    x5        c2        1
+    x5        c3        1
+    x5        c4        1
+    x5        c5        1
+    x5        c8        1
+    x6        obj       1
+    x6        c0        1
+    x6        c3        1
+    x6        c6        1
+    x6        c7        1
+    x6        c8        1
+    x7        obj       1
+    x7        c1        1
+    x7        c4        1
+    x7        c6        1
+    x7        c7        1
+    x7        c8        1
+    x8        obj       1
+    x8        c2        1
+    x8        c5        1
+    x8        c6        1
+    x8        c7        1
+    x8        c8        1
+    MARK0001  'MARKER'                 'INTEND'
+RHS
+    RHS_V     c0        1
+    RHS_V     c1        1
+    RHS_V     c2        1
+    RHS_V     c3        1
+    RHS_V     c4        1
+    RHS_V     c5        1
+    RHS_V     c6        1
+    RHS_V     c7        1
+    RHS_V     c8        1
+BOUNDS
+ BV BOUND     x0      
+ BV BOUND     x1      
+ BV BOUND     x2      
+ BV BOUND     x3      
+ BV BOUND     x4      
+ BV BOUND     x5      
+ BV BOUND     x6      
+ BV BOUND     x7      
+ BV BOUND     x8      
+ENDATA


### PR DESCRIPTION
This PR fixes the incorrect computation of the lower bound when running with just a single thread. In the `single_threaded_solve`, we were creating a separated worker instance from the pool, such that its lower bounds was never consider when computing the global lower bound. This PR  simply change the routine to use a worker from the pool.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
