### PR TITLE
docs(readme): use py3.13 docker tags (py3.14 not supported)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ docker pull nvidia/cuopt:latest-cuda12.9-py3.13
 docker pull nvidia/cuopt:latest-cuda13.0-py3.13
 ```
 
-Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py3.13`` or ``<version>-cuda13.0-py3.13`` tag. For example, to use cuOpt 25.10.0, you can use the ``25.10.0-cuda12.9-py3.13`` or ``25.10.0-cuda13.0-py3.13`` tag. Please refer to `cuOpt dockerhub page <https://hub.docker.com/r/nvidia/cuopt/tags>`_ for the list of available tags.
+Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py3.13`` or ``<version>-cuda13.0-py3.13`` tag. For example, to use cuOpt 25.10.0, you can use the ``25.10.0-cuda12.9-py3.13`` or ``25.10.0-cuda13.0-py3.13`` tag. Please refer to [cuOpt dockerhub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the list of available tags.
 
 More information about the cuOpt container can be found [here](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-server/quick-start.html#container-from-docker-hub).
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Users can pull the cuOpt container from the NVIDIA container registry.
 
 ```bash
 # For CUDA 12.x
-docker pull nvidia/cuopt:latest-cuda12.9-py3.14
+docker pull nvidia/cuopt:latest-cuda12.9-py3.13
 
 # For CUDA 13.x
-docker pull nvidia/cuopt:latest-cuda13.0-py3.14
+docker pull nvidia/cuopt:latest-cuda13.0-py3.13
 ```
 
-Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py3.14`` or ``<version>-cuda13.0-py3.14`` tag. For example, to use cuOpt 25.10.0, you can use the ``25.10.0-cuda12.9-py3.13`` or ``25.10.0-cuda13.0-py3.13`` tag. Please refer to `cuOpt dockerhub page <https://hub.docker.com/r/nvidia/cuopt/tags>`_ for the list of available tags.
+Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cuda12.9-py3.13`` or ``<version>-cuda13.0-py3.13`` tag. For example, to use cuOpt 25.10.0, you can use the ``25.10.0-cuda12.9-py3.13`` or ``25.10.0-cuda13.0-py3.13`` tag. Please refer to `cuOpt dockerhub page <https://hub.docker.com/r/nvidia/cuopt/tags>`_ for the list of available tags.
 
 More information about the cuOpt container can be found [here](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-server/quick-start.html#container-from-docker-hub).
 


### PR DESCRIPTION
## Summary
- README's `docker pull` commands reference `py3.14` tags, but Python 3.14 is not currently supported
- Updates the two `docker pull` snippets and the accompanying `<version>-cuda*-py3.14` note to `py3.13`, matching the worked example immediately after it (`25.10.0-cuda12.9-py3.13`)

## Test plan
- [ ] Verify the updated `docker pull nvidia/cuopt:latest-cuda12.9-py3.13` and `latest-cuda13.0-py3.13` tags exist on [Docker Hub](https://hub.docker.com/r/nvidia/cuopt/tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)