### PR TITLE
fix: add retry logic and error handling to dataset download scripts

### DIFF
--- a/benchmarks/linear_programming/utils/get_datasets.py
+++ b/benchmarks/linear_programming/utils/get_datasets.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
+import time
 import argparse
 import urllib.request
 import urllib.parse
@@ -627,14 +629,30 @@ def parse_args():
     return args
 
 
-def download(url, dst):
+def download(url, dst, max_retries=3, timeout=60):
     if os.path.exists(dst):
         return
-    print(f"Downloading {url} into {dst}...")
-    response = urllib.request.urlopen(url)
-    data = response.read()
-    with open(dst, "wb") as fp:
-        fp.write(data)
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    for attempt in range(1, max_retries + 1):
+        print(
+            f"Downloading {url} into {dst} (attempt {attempt}/{max_retries})..."
+        )
+        try:
+            response = urllib.request.urlopen(url, timeout=timeout)
+            data = response.read()
+            with open(dst, "wb") as fp:
+                fp.write(data)
+            return
+        except Exception as e:
+            if os.path.exists(dst):
+                os.remove(dst)
+            if attempt < max_retries:
+                wait = 2**attempt
+                print(f"  Failed: {e}. Retrying in {wait}s...")
+                time.sleep(wait)
+            else:
+                print(f"  Failed after {max_retries} attempts: {e}")
+                raise
 
 
 def extract(file, dir, type):
@@ -684,8 +702,7 @@ def download_dataset(name, root):
     if url == "":
         print(f"Dataset {name} doesn't have a URL. Skipping...")
         return
-    else:
-        os.mkdir(dir)
+    os.makedirs(dir, exist_ok=True)
     file = os.path.join(dir, os.path.basename(url))
     download(url, file)
     extract(file, dir, type)
@@ -707,17 +724,31 @@ def main():
         if not os.path.exists(args.instance_download_path):
             os.makedirs(args.instance_download_path)
         instance_download_path = args.instance_download_path
+
+    failed = []
+    datasets_to_download = []
     if args.LPfeasible:
-        for name in LPFeasibleMittelmannSet:
-            download_dataset(name, instance_download_path)
+        datasets_to_download.extend(LPFeasibleMittelmannSet)
     if args.datasets:
-        for name in args.datasets:
-            download_dataset(name, instance_download_path)
+        datasets_to_download.extend(args.datasets)
     if args.benchmarks:
         for bench in args.benchmarks:
-            for name in MittelmannInstances["benchmarks"][bench]:
-                download_dataset(name, instance_download_path)
-    return
+            datasets_to_download.extend(
+                MittelmannInstances["benchmarks"][bench]
+            )
+
+    for name in datasets_to_download:
+        try:
+            download_dataset(name, instance_download_path)
+        except Exception as e:
+            print(f"ERROR: Failed to download dataset '{name}': {e}")
+            failed.append(name)
+
+    if failed:
+        print(
+            f"\n{len(failed)} dataset(s) failed to download: {', '.join(failed)}"
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/benchmarks/linear_programming/utils/get_datasets.py
+++ b/benchmarks/linear_programming/utils/get_datasets.py
@@ -662,12 +662,16 @@ def extract(file, dir, type):
     if basefile.endswith(".bz2"):
         outfile = basefile.replace(".bz2", ".mps")
         unzippedfile = basefile.replace(".bz2", "")
-        subprocess.run(f"cd {dir} && bzip2 -d {basefile}", shell=True)
+        subprocess.run(
+            f"cd {dir} && bzip2 -d {basefile}", shell=True, check=True
+        )
     elif basefile.endswith(".gz"):
         outfile = basefile.replace(".gz", ".mps")
         unzippedfile = basefile.replace(".gz", "")
         subprocess.run(
-            f"cd {dir} && gunzip -c {basefile} > {unzippedfile}", shell=True
+            f"cd {dir} && gunzip -c {basefile} > {unzippedfile}",
+            shell=True,
+            check=True,
         )
     else:
         raise Exception(f"Unknown file extension found for extraction {file}")
@@ -678,11 +682,15 @@ def extract(file, dir, type):
         file = os.path.join(dir, "emps.c")
         download(url, file)
         subprocess.run(
-            f"cd {dir} && gcc -Wno-implicit-int emps.c -o emps", shell=True
+            f"cd {dir} && gcc -Wno-implicit-int emps.c -o emps",
+            shell=True,
+            check=True,
         )
         # determine output file and run emps
         subprocess.run(
-            f"cd {dir} && ./emps {unzippedfile} > {outfile}", shell=True
+            f"cd {dir} && ./emps {unzippedfile} > {outfile}",
+            shell=True,
+            check=True,
         )
         # cleanup emps and emps.c
         subprocess.run(f"rm -rf {dir}/emps*", shell=True)
@@ -733,6 +741,10 @@ def main():
         datasets_to_download.extend(args.datasets)
     if args.benchmarks:
         for bench in args.benchmarks:
+            if bench not in MittelmannInstances["benchmarks"]:
+                print(f"ERROR: Unknown benchmark '{bench}'")
+                failed.append(bench)
+                continue
             datasets_to_download.extend(
                 MittelmannInstances["benchmarks"][bench]
             )

--- a/regression/get_datasets.py
+++ b/regression/get_datasets.py
@@ -853,12 +853,16 @@ def extract(file, dir, type):
     if basefile.endswith(".bz2"):
         outfile = basefile.replace(".bz2", ".mps")
         unzippedfile = basefile.replace(".bz2", "")
-        subprocess.run(f"cd {dir} && bzip2 -d {basefile}", shell=True)
+        subprocess.run(
+            f"cd {dir} && bzip2 -d {basefile}", shell=True, check=True
+        )
     elif basefile.endswith(".gz"):
         outfile = basefile.replace(".gz", ".mps")
         unzippedfile = basefile.replace(".gz", "")
         subprocess.run(
-            f"cd {dir} && gunzip -c {basefile} > {unzippedfile}", shell=True
+            f"cd {dir} && gunzip -c {basefile} > {unzippedfile}",
+            shell=True,
+            check=True,
         )
         subprocess.run(f"cd {dir} && rm -rf {basefile}", shell=True)
     else:
@@ -870,11 +874,15 @@ def extract(file, dir, type):
         file = os.path.join(dir, "emps.c")
         download(url, file)
         subprocess.run(
-            f"cd {dir} && gcc -Wno-implicit-int emps.c -o emps", shell=True
+            f"cd {dir} && gcc -Wno-implicit-int emps.c -o emps",
+            shell=True,
+            check=True,
         )
         # determine output file and run emps
         subprocess.run(
-            f"cd {dir} && ./emps {unzippedfile} > {outfile}", shell=True
+            f"cd {dir} && ./emps {unzippedfile} > {outfile}",
+            shell=True,
+            check=True,
         )
         subprocess.run(f"cd {dir} && rm -rf {unzippedfile}", shell=True)
         # cleanup emps and emps.c

--- a/regression/get_datasets.py
+++ b/regression/get_datasets.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import time
 import urllib.request
 import urllib.parse
 import subprocess
@@ -819,14 +820,30 @@ MittelmannInstances = {
 }
 
 
-def download(url, dst):
+def download(url, dst, max_retries=3, timeout=60):
     if os.path.exists(dst):
         return
-    print(f"Downloading {url} into {dst}...")
-    response = urllib.request.urlopen(url)
-    data = response.read()
-    with open(dst, "wb") as fp:
-        fp.write(data)
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    for attempt in range(1, max_retries + 1):
+        print(
+            f"Downloading {url} into {dst} (attempt {attempt}/{max_retries})..."
+        )
+        try:
+            response = urllib.request.urlopen(url, timeout=timeout)
+            data = response.read()
+            with open(dst, "wb") as fp:
+                fp.write(data)
+            return
+        except Exception as e:
+            if os.path.exists(dst):
+                os.remove(dst)
+            if attempt < max_retries:
+                wait = 2**attempt
+                print(f"  Failed: {e}. Retrying in {wait}s...")
+                time.sleep(wait)
+            else:
+                print(f"  Failed after {max_retries} attempts: {e}")
+                raise
 
 
 def extract(file, dir, type):
@@ -899,9 +916,24 @@ def download_mip_dataset(name, dir):
 datasets_path = sys.argv[1]
 dataset_type = sys.argv[2]
 
+failed = []
 if dataset_type == "lp":
     for name in LPFeasibleMittelmannSet:
-        download_lp_dataset(name, datasets_path)
+        try:
+            download_lp_dataset(name, datasets_path)
+        except Exception as e:
+            print(f"ERROR: Failed to download LP dataset '{name}': {e}")
+            failed.append(name)
 elif dataset_type == "mip":
     for name in MiplibInstances:
-        download_mip_dataset(name, datasets_path)
+        try:
+            download_mip_dataset(name, datasets_path)
+        except Exception as e:
+            print(f"ERROR: Failed to download MIP dataset '{name}': {e}")
+            failed.append(name)
+
+if failed:
+    print(
+        f"\n{len(failed)} dataset(s) failed to download: {', '.join(failed)}"
+    )
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- Add retry with exponential backoff (3 attempts) to `download()` in both dataset scripts
- Add 60s connection timeout to prevent hanging on unreachable hosts
- Clean up partial files on download failure
- Continue downloading remaining datasets when one fails — report all failures at the end with non-zero exit code
- Remove insecure SSL verification bypass for plato.asu.edu (site has valid cert, fixes SonarQube `python:S4830` and `python:S5527`)

### Before
A single unreachable host (e.g. `old.sztaki.hu`) crashes the entire download batch — no other datasets get downloaded.

### After
Failed downloads are retried 3 times with backoff, then skipped. All other datasets continue downloading. Failures are summarized at the end.

## Test plan
- [ ] Run `bash datasets/linear_programming/download_pdlp_test_dataset.sh` — verify plato.asu.edu downloads succeed and unreachable hosts are retried then skipped
- [ ] Run `python regression/get_datasets.py <dir> lp` — verify retry and summary behavior
- [ ] Verify non-zero exit code when downloads fail