### PR TITLE
ci: bump C++ test timeout from 40m to 50m

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -52,7 +52,7 @@ set +e
 export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 
 rapids-logger "Run gtests"
-timeout 40m ./ci/run_ctests.sh
+timeout 50m ./ci/run_ctests.sh
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
## Summary
- Increase the outer wall-clock timeout around \`./ci/run_ctests.sh\` in \`ci/test_cpp.sh\` from 40 minutes to 50 minutes.
- Gives ctest an extra 10 minutes of headroom so occasional slow MILP/LP tests do not hit the outer \`timeout\` and fail CI.

## Test plan
- [ ] CI \`test_cpp\` job still runs to completion within the new 50m window
- [ ] No change in which tests are selected or how they are executed — only the ceiling changed