### PR TITLE
test(c_api): skip flaky TimeLimitTestFixture MIP case (#1135)

### DIFF
--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -47,6 +47,14 @@ TEST_P(TimeLimitTestFixture, time_limit)
   std::string filename                    = rapidsDatasetRootDir + std::get<0>(GetParam());
   double target_solve_time                = std::get<1>(GetParam());
   int method                              = std::get<2>(GetParam());
+
+  // The MIP case overshoots the 3s tolerance on CPU-thread-constrained CI runners
+  // because solve_time includes Papilo presolve and post-B&B serial wind-down.
+  // Tracked in https://github.com/NVIDIA/cuopt/issues/1135.
+  if (filename.find("/mip/") != std::string::npos) {
+    GTEST_SKIP() << "Disabled pending NVIDIA/cuopt#1135";
+  }
+
   int termination_status;
   double solve_time = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ(solve_mps_file(filename.c_str(),

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -48,10 +48,10 @@ TEST_P(TimeLimitTestFixture, time_limit)
   double target_solve_time                = std::get<1>(GetParam());
   int method                              = std::get<2>(GetParam());
 
-  // The MIP case overshoots the 3s tolerance on CPU-thread-constrained CI runners
+  // supportcase22.mps overshoots the 3s tolerance on CPU-thread-constrained CI runners
   // because solve_time includes Papilo presolve and post-B&B serial wind-down.
   // Tracked in https://github.com/NVIDIA/cuopt/issues/1135.
-  if (filename.find("/mip/") != std::string::npos) {
+  if (std::get<0>(GetParam()) == "/mip/supportcase22.mps") {
     GTEST_SKIP() << "Disabled pending NVIDIA/cuopt#1135";
   }
 


### PR DESCRIPTION
## Summary

- Skip the `c_api/TimeLimitTestFixture.time_limit/2` parametric instance (`/mip/supportcase22.mps`, 15s, `CUOPT_METHOD_DUAL_SIMPLEX`) via `GTEST_SKIP()`.
- LP cases `/0` and `/1` remain enabled.

## Why

The MIP case intermittently overshoots the 3s `excess_allowed_time` tolerance on CPU-thread-constrained CI runners. `cuOptGetSolveTime()` for MIP returns `mip_solution_t::get_total_solve_time()`, which is set in `cpp/src/mip_heuristics/solver.cu:489` from a timer started in `cpp/src/mip_heuristics/solve.cu:306` — *before* Papilo presolve. So `solve_time` includes Papilo presolve (OpenMP-parallel) and the post-B&B serial wind-down (`branch_and_bound_status_future.get()`, `compute_feasibility`, `test_variable_bounds`), neither of which is bounded by the user's `time_limit` setting.

On a 12-thread-visible CI runner, observed `solve_time = 18.398s` vs the 18s bar (15s + 3s tolerance). Solver itself respected the limit (`Explored 0 nodes in 15.01s`).

Full investigation and proposed fixes (measure inside the time-limited region only, or per-case tolerances) are in the issue.

Tracking: NVIDIA/cuopt#1135.

## Test plan

- [x] Pre-commit clean (`clang-format`, `verify-copyright`, etc.)
- [x] Local rebuild of `C_API_TEST` succeeds
- [x] Verified `/2` is reported as `[ SKIPPED ] Disabled pending NVIDIA/cuopt#1135`; `/0` and `/1` are unchanged in behavior
- [ ] CI green