### PR TITLE
ci: refine CodeRabbit review guide to match cuOpt idioms

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -81,43 +81,18 @@ reviews:
 
     - path: "cpp/src/**/*.{cu,cuh}"
       instructions: |
-        CUDA source files. Apply cuOpt's RAPIDS idioms:
-        - CUDA errors must be checked with RAFT_CUDA_TRY (251 existing uses); flag bare cuda* calls
-        - Prefer rmm::device_uvector / rmm::device_buffer over raw cudaMalloc/cudaFree
-          (only ~3 files use raw allocators legitimately — pinned-host allocators)
-        - Streams should come from raft::handle_t::get_stream(); flag ad-hoc cudaStreamCreate
-          unless no handle is in scope (and then it must be paired with cudaStreamDestroy)
-        - Prefer thrust::/cuda::std:: (CCCL) over hand-rolled reductions, scans, sorts, transforms
-        - Watch for default-stream reliance in code that must run concurrently
-
-        DO NOT comment on formatting (clang-format handles it) or exception use
-        (cuOpt uses exceptions as its canonical error mechanism; this deviates
-        from Google C++ intentionally).
+        CUDA source files. Apply "CUDA / GPU — cuOpt idioms" from
+        .github/.coderabbit_review_guide.md. Do NOT comment on formatting
+        (clang-format handles it) or exception use (cuOpt uses exceptions
+        as its canonical error mechanism).
 
     - path: "cpp/src/**/*.{cpp,hpp,h}"
       instructions: |
-        C++ host code. cuOpt has its own established style — match nearby code.
-        Conventions (do NOT comment on these as if they were issues):
-          - snake_case for functions/variables; snake_case_t with _t suffix
-            for types/classes/enums (e.g. logic_error, error_type_t)
-          - Trailing underscore on private members (error_type_)
-          - Project macros: CUOPT_ prefix, SCREAMING_SNAKE_CASE
-          - Exceptions are used: throw + cuopt_expects / CUOPT_EXPECTS from
-            cpp/include/cuopt/error.hpp
-          - Column limit is 100; formatting handled by clang-format
-
-        Cite the Google C++ Style Guide ONLY for these named language-level
-        practices that cuOpt actually follows:
-          - Header self-containment, Include What You Use, avoid fwd decls
-          - explicit on single-arg constructors
-          - override/final on virtual methods
-          - std::unique_ptr for owning pointers; no raw owning pointers
-          - const/constexpr correctness
-          - C++-style casts; avoid dynamic_cast (prefer virtual dispatch)
-          - No `using namespace` at file scope
-
-        Do NOT cite Google for naming, exception use, or column limit —
-        cuOpt's convention wins there. Do not flag formatting.
+        C++ host code. Follow "C++ — cuOpt conventions" and "C++ —
+        language-level practices we follow from Google C++" in
+        .github/.coderabbit_review_guide.md. Match nearby code; cuOpt's
+        naming, exception use, and column limit override Google where they
+        disagree. Do not flag formatting.
 
     - path: "cpp/src/grpc/**"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,15 +29,22 @@ reviews:
 
   # Exclude paths CodeRabbit should not review.
   # Formatting/lint/style for these is already handled (or not applicable).
+  # datasets/ is NOT fully excluded — shell scripts there download test data
+  # and are worth reviewing; only the bulk data files are filtered out.
   path_filters:
     - "!thirdparty/**"
-    - "!datasets/**"
-    - "!regression/**"
     - "!notebooks/**"
     - "!docs/**/_build/**"
     - "!**/*.mps"
     - "!**/*.qps"
     - "!**/*.lp"
+    - "!datasets/**/*.json"
+    - "!datasets/**/*.yaml"
+    - "!datasets/**/*.yml"
+    - "!datasets/**/*.txt"
+    - "!regression/**/*.json"
+    - "!regression/**/*.csv"
+    - "!regression/**/*.html"
 
   # Path-specific review instructions.
   # Keep each block narrow — the main review guide is in
@@ -170,6 +177,63 @@ reviews:
         - Edge cases: empty, infeasible, unbounded, degenerate problems
         - No leaked GPU state across tests
         - Regression coverage for fixed bugs
+
+    - path: "**/CMakeLists.txt"
+      instructions: |
+        Flag any new entry in add_library / add_executable / target_sources /
+        add_subdirectory / install(FILES ...) that references a source, header,
+        or directory not present in this PR or in the base branch — this is the
+        most common place a forgotten `git add` surfaces. See Common Bug
+        Patterns §7 in the review guide. The right ask is "did you mean to
+        include `<path>` in this PR?" rather than a generic style comment.
+
+    - path: "**/*.cmake"
+      instructions: |
+        Same as CMakeLists.txt: cross-check any added file-list entries against
+        the PR contents (Common Bug Patterns §7).
+
+    - path: ".github/workflows/**"
+      instructions: |
+        GitHub Actions workflows. Primary concern is Common Bug Patterns §7:
+        any `run:` step invoking `ci/*.sh`, `python ci/*.py`, or a repo-local
+        binary must reference a file present in the PR or the base branch.
+        Also check for:
+        - Referenced composite actions (`uses: ./.github/actions/<name>`) that don't exist
+        - `needs:` dependencies on jobs that were renamed or removed
+        - Secrets / environment variables newly referenced without being documented
+        Do not flag style of YAML formatting.
+
+    - path: "ci/**/*.sh"
+      instructions: |
+        CI shell scripts. Primary concern is Common Bug Patterns §7:
+        - `source` / `.` lines pointing at helper scripts not in the PR or tree
+        - `bash path/to/foo.sh` / direct script invocations referencing missing files
+        - `RAPIDS_DATASET_ROOT_DIR`-relative paths not produced by an in-tree script
+        Also: `set -euo pipefail` hygiene for new scripts, proper quoting on
+        interpolated paths. Do not re-raise shellcheck warnings (pre-commit
+        runs shellcheck at --severity=warning).
+
+    - path: "datasets/**/*.sh"
+      instructions: |
+        Dataset download/setup scripts. Same as ci/**/*.sh, with emphasis on:
+        - URLs reachable and versioned (not pinned to `latest`)
+        - Referenced helper scripts exist in the PR or tree (Common Bug Patterns §7)
+        - Exit on failure; no silent download errors
+
+    - path: "**/Dockerfile*"
+      instructions: |
+        Dockerfiles. Primary concern is Common Bug Patterns §7: `COPY` / `ADD`
+        paths must exist in the build context at the referenced location.
+        Also check for:
+        - Pinned base image tags (not `:latest`)
+        - Multi-stage builds don't leak secrets
+        - No credentials baked into layers
+
+    - path: "helmchart/**"
+      instructions: |
+        Helm charts. Same as CMakeLists.txt philosophy: new references to
+        ConfigMaps, Secrets, values keys, or template files must exist in
+        this PR (Common Bug Patterns §7). Do not flag chart style nits.
 
 knowledge_base:
   opt_out: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,33 +27,154 @@ reviews:
   request_changes_workflow: false
   review_status: false
 
-  # Path-specific review instructions
+  # Exclude paths CodeRabbit should not review.
+  # Formatting/lint/style for these is already handled (or not applicable).
+  path_filters:
+    - "!thirdparty/**"
+    - "!datasets/**"
+    - "!regression/**"
+    - "!notebooks/**"
+    - "!docs/**/_build/**"
+    - "!**/*.mps"
+    - "!**/*.qps"
+    - "!**/*.lp"
+
+  # Path-specific review instructions.
+  # Keep each block narrow — the main review guide is in
+  # .github/.coderabbit_review_guide.md (see knowledge_base below).
   path_instructions:
     - path: "docs/**/*"
       instructions: |
         For documentation changes, focus on:
-        - Accuracy: Verify code examples compile and run correctly
-        - Completeness: Check if API changes (parameters, return values, errors) are documented
-        - Clarity: Flag confusing explanations, missing prerequisites, or unclear examples
-        - Consistency: Version numbers, parameter types, and terminology match code
-        - Examples: Suggest adding examples for complex features or new APIs
-        - Missing docs: If PR changes public APIs without updating docs, flag as HIGH priority
+        - Accuracy: verify code examples compile and run correctly
+        - Completeness: check if API changes (parameters, return values, errors) are documented
+        - Clarity: flag confusing explanations, missing prerequisites, unclear examples
+        - Consistency: version numbers, parameter types, and terminology match code
+        - Missing docs: if the PR changes public APIs without updating docs, flag as HIGH
 
-        When code changes affect docs:
-        - Suggest specific doc files that need updates (e.g., docs/cuopt/api.rst)
-        - Identify outdated information contradicting the code changes
-        - Recommend documenting performance characteristics, GPU requirements, or numerical tolerances
+        When code changes affect docs, suggest specific files (e.g. docs/cuopt/source/*.rst)
+        and recommend documenting performance characteristics, GPU requirements, or tolerances.
 
     - path: "cpp/include/cuopt/**/*"
       instructions: |
-        For public header files (C++ API):
-        - Check if new public functions/classes have documentation comments (Doxygen format)
+        Public C++ headers:
+        - New public functions/classes need Doxygen-style documentation
         - Flag API changes that may need corresponding docs/ updates
         - Verify parameter descriptions match actual types/behavior
-        - Suggest documenting thread-safety, GPU requirements, and numerical behavior
-        - For breaking changes, recommend updating docs and migration guides
+        - Suggest documenting thread-safety, GPU requirements, numerical behavior
+        - For breaking changes, recommend migration notes
+
+    - path: "cpp/include/cuopt/linear_programming/cuopt_c.h"
+      instructions: |
+        This is the C ABI surface. Flag ANY change to struct layout, function
+        signatures, enum values, or typedef shape as potentially ABI-breaking.
+        Ask the author to confirm the change is intentional and documented,
+        since there is no formal ABI-versioning macro today. Do not suggest
+        adding one unless the PR is specifically about API stability.
+
+    - path: "cpp/src/**/*.{cu,cuh}"
+      instructions: |
+        CUDA source files. Apply cuOpt's RAPIDS idioms:
+        - CUDA errors must be checked with RAFT_CUDA_TRY (251 existing uses); flag bare cuda* calls
+        - Prefer rmm::device_uvector / rmm::device_buffer over raw cudaMalloc/cudaFree
+          (only ~3 files use raw allocators legitimately — pinned-host allocators)
+        - Streams should come from raft::handle_t::get_stream(); flag ad-hoc cudaStreamCreate
+          unless no handle is in scope (and then it must be paired with cudaStreamDestroy)
+        - Prefer thrust::/cuda::std:: (CCCL) over hand-rolled reductions, scans, sorts, transforms
+        - Watch for default-stream reliance in code that must run concurrently
+
+        DO NOT comment on formatting (clang-format handles it) or exception use
+        (cuOpt uses exceptions as its canonical error mechanism; this deviates
+        from Google C++ intentionally).
+
+    - path: "cpp/src/**/*.{cpp,hpp,h}"
+      instructions: |
+        C++ host code. Reference the Google C++ Style Guide
+        (https://google.github.io/styleguide/cppguide.html) by rule name
+        for substantive issues. Note cuOpt deviations: exceptions ARE used
+        (see cpp/include/cuopt/error.hpp — cuopt_expects / CUOPT_EXPECTS
+        macros throw cuopt::logic_error); column limit is 100, not 80.
+
+        Focus on:
+        - Header self-containment, include-what-you-use
+        - explicit on single-arg constructors
+        - override/final on virtual methods
+        - std::unique_ptr for owning pointers; avoid raw owning pointers
+        - const/constexpr correctness
+        - C++-style casts; avoid dynamic_cast in favor of virtual dispatch
+
+        Do not flag exception use or formatting.
+
+    - path: "cpp/src/grpc/**"
+      instructions: |
+        gRPC server C++ code. In addition to cpp/src rules:
+        - Input validation on all request fields reaching the solver
+        - Size limits on problem data to prevent resource exhaustion
+        - No credential/internal-path leakage in error messages or logs
+        - Safe deserialization of problem payloads
+        - Thread-safety on shared state across RPCs
+
+    - path: "cpp/tests/**"
+      instructions: |
+        C++ tests (gtest). Focus on:
+        - Numerical correctness validation (not just "runs without error")
+        - Edge cases: empty, infeasible, unbounded, degenerate, singleton problems
+        - Test isolation — no leaked GPU state or global mutation across tests
+        - Flakiness: GPU timing races, uninitialized memory, non-deterministic order
+        - When a bug fix lands, a regression test should cover the specific case
+
+        Do not require benchmarks here — benchmarks live in benchmarks/ and regression/.
+
+    - path: "python/**/*.py"
+      instructions: |
+        Python code. ruff (E,F,W ignoring E501), ruff-format, and pydocstyle
+        handle formatting, imports, and docstring format. Focus on what they
+        do NOT cover:
+        - Type hints on NEW public functions/classes (do not require them on existing code;
+          there is no mypy config and the codebase is mixed)
+        - Signature changes on public APIs must emit DeprecationWarning with a
+          removal version before breaking (see the pattern in
+          python/cuopt/cuopt/linear_programming/problem.py around the deprecated helpers)
+        - Docstring CONTENT on new public APIs — params, returns, raises — even
+          when pydocstyle format rules pass
+        - Error messages that expose internals vs. user-actionable messages
+
+        Do not re-raise ruff/pydocstyle-covered issues.
+
+    - path: "python/**/*.pyx"
+      instructions: |
+        Cython implementation files:
+        - C++ calls that may throw must use `except +` on the cdef declaration
+        - Use `nogil` on blocking C calls unless the GIL is needed
+        - Memoryview lifetimes: the Python object owning the buffer must outlive the view
+        - Prefer cpdef only when the function should be callable from Python
+
+    - path: "python/**/*.pxd"
+      instructions: |
+        Cython declaration files. Check that C++ signatures match their .hpp
+        counterparts (argument types, const-qualification, throw-specification).
+
+    - path: "python/cuopt_server/**"
+      instructions: |
+        Python server code. In addition to python/**/*.py rules:
+        - Input validation on all fields from the REST payload
+        - Size/shape limits on problem data
+        - No credential or internal-path leakage in error responses or logs
+        - Safe deserialization (no pickle on untrusted input)
+        - Rate limiting considerations on expensive endpoints
+
+    - path: "python/**/tests/**"
+      instructions: |
+        Python tests (pytest). Focus on:
+        - Numerical correctness validation
+        - Edge cases: empty, infeasible, unbounded, degenerate problems
+        - No leaked GPU state across tests
+        - Regression coverage for fixed bugs
+
 knowledge_base:
   opt_out: false
   code_guidelines:
     filePatterns:
       - ".github/.coderabbit_review_guide.md"
+      - "CONTRIBUTING.md"
+      - "CONVENTIONS.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -132,6 +132,16 @@ reviews:
 
         Do not require benchmarks here — benchmarks live in benchmarks/ and regression/.
 
+        IMPORTANT — dataset references: tests resolve problem data via
+        RAPIDS_DATASET_ROOT_DIR (see cpp/tests/utilities/common_utils.hpp,
+        `get_rdrd_or_default()`). Most datasets are downloaded at test time
+        by datasets/get_test_data.sh, datasets/linear_programming/download_pdlp_test_dataset.sh,
+        or datasets/mip/download_miplib_test_dataset.sh — they are NOT committed.
+        Do NOT flag a test for referencing a dataset path that isn't in the tree
+        UNLESS the filename does not appear in any download script (in which
+        case the download script likely needs updating too). See Common Bug
+        Patterns §7 "When NOT to flag" in the review guide.
+
     - path: "python/**/*.py"
       instructions: |
         Python code. ruff (E,F,W ignoring E501), ruff-format, and pydocstyle
@@ -177,6 +187,15 @@ reviews:
         - Edge cases: empty, infeasible, unbounded, degenerate problems
         - No leaked GPU state across tests
         - Regression coverage for fixed bugs
+
+        IMPORTANT — dataset references: tests resolve problem data via
+        os.getenv("RAPIDS_DATASET_ROOT_DIR"). Most datasets are downloaded at
+        test time by scripts under datasets/ (get_test_data.sh,
+        linear_programming/download_pdlp_test_dataset.sh,
+        mip/download_miplib_test_dataset.sh) — they are NOT committed.
+        Do NOT flag a test for referencing a dataset path that isn't in the tree
+        UNLESS the filename does not appear in any download script. See Common
+        Bug Patterns §7 "When NOT to flag" in the review guide.
 
     - path: "**/CMakeLists.txt"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -96,21 +96,28 @@ reviews:
 
     - path: "cpp/src/**/*.{cpp,hpp,h}"
       instructions: |
-        C++ host code. Reference the Google C++ Style Guide
-        (https://google.github.io/styleguide/cppguide.html) by rule name
-        for substantive issues. Note cuOpt deviations: exceptions ARE used
-        (see cpp/include/cuopt/error.hpp — cuopt_expects / CUOPT_EXPECTS
-        macros throw cuopt::logic_error); column limit is 100, not 80.
+        C++ host code. cuOpt has its own established style — match nearby code.
+        Conventions (do NOT comment on these as if they were issues):
+          - snake_case for functions/variables; snake_case_t with _t suffix
+            for types/classes/enums (e.g. logic_error, error_type_t)
+          - Trailing underscore on private members (error_type_)
+          - Project macros: CUOPT_ prefix, SCREAMING_SNAKE_CASE
+          - Exceptions are used: throw + cuopt_expects / CUOPT_EXPECTS from
+            cpp/include/cuopt/error.hpp
+          - Column limit is 100; formatting handled by clang-format
 
-        Focus on:
-        - Header self-containment, include-what-you-use
-        - explicit on single-arg constructors
-        - override/final on virtual methods
-        - std::unique_ptr for owning pointers; avoid raw owning pointers
-        - const/constexpr correctness
-        - C++-style casts; avoid dynamic_cast in favor of virtual dispatch
+        Cite the Google C++ Style Guide ONLY for these named language-level
+        practices that cuOpt actually follows:
+          - Header self-containment, Include What You Use, avoid fwd decls
+          - explicit on single-arg constructors
+          - override/final on virtual methods
+          - std::unique_ptr for owning pointers; no raw owning pointers
+          - const/constexpr correctness
+          - C++-style casts; avoid dynamic_cast (prefer virtual dispatch)
+          - No `using namespace` at file scope
 
-        Do not flag exception use or formatting.
+        Do NOT cite Google for naming, exception use, or column limit —
+        cuOpt's convention wins there. Do not flag formatting.
 
     - path: "cpp/src/grpc/**"
       instructions: |

--- a/.github/.coderabbit_review_guide.md
+++ b/.github/.coderabbit_review_guide.md
@@ -228,7 +228,6 @@ The PR compiles locally because the author has extra files in their working tree
 - Shell scripts sourcing other scripts (`source ci/utils/helper.sh`, `. ./foo.sh`) that are not in the PR or base tree
 - `Dockerfile` `COPY` / `ADD` referencing files or directories not in the build context of the PR
 - `helmchart/` templates referencing config maps, secrets, or values not in the PR
-- Tests invoking `datasets/*.sh` download scripts that don't exist, or using `RAPIDS_DATASET_ROOT_DIR`-relative paths not produced by an existing script
 - Docs / Sphinx `.. include::` / `.. literalinclude::` / `toctree::` referencing files not in the PR
 
 **Dependency red flags**:
@@ -236,6 +235,26 @@ The PR compiles locally because the author has extra files in their working tree
 - `requirements*.txt` / pyproject `dependencies` referencing a local-path wheel or directory not in the PR
 
 **How to phrase the comment**: "Referenced `path/to/file` but I don't see it in this PR or in the base branch. If it was created locally, `git add` may have been missed; otherwise this is a stale reference. CI will fail on this — easier to fix now."
+
+**When NOT to flag — runtime-downloaded datasets**:
+
+Most problem data files (MPS, QPS, LP, MIPLIB instances, PDLP test sets) are **not committed**. They are downloaded at test time by scripts under `datasets/`:
+
+- `datasets/get_test_data.sh` — routing + general test data
+- `datasets/linear_programming/download_pdlp_test_dataset.sh` — LP/PDLP instances
+- `datasets/mip/download_miplib_test_dataset.sh` — MIPLIB instances
+
+Tests reference these paths via the `RAPIDS_DATASET_ROOT_DIR` environment variable (C++ tests: `cpp/tests/utilities/common_utils.hpp` → `get_rdrd_or_default()`; Python tests: `os.getenv("RAPIDS_DATASET_ROOT_DIR")`). The CI scripts under `ci/` run the download scripts before invoking ctest/pytest.
+
+**Do NOT flag** a test that:
+- References a path via `RAPIDS_DATASET_ROOT_DIR`, `get_rdrd_or_default()`, or a path relative to the datasets root
+- References a filename that matches instances listed in one of the download scripts above
+- References data under `datasets/<subdir>/` that is gitignored (only scripts and a few reference/config files are tracked under `datasets/`)
+
+**DO flag** when:
+- The PR adds a test referencing a NEW dataset filename that does **not** appear in any `datasets/**/download_*.sh` script — the download script likely also needs updating, or the author forgot to commit a new dataset-fetch step
+- The PR removes or renames an entry in a download script but a test still references the old name
+- The PR references a dataset path with a typo not matching any download-script entry
 
 ---
 

--- a/.github/.coderabbit_review_guide.md
+++ b/.github/.coderabbit_review_guide.md
@@ -1,468 +1,307 @@
-# AI Code Review Guidelines for CodeRabbit - cuOpt
+# AI Code Review Guidelines for CodeRabbit — cuOpt
 
-**Role**: Act as a principal engineer with 10+ years experience in GPU computing, numerical optimization, and high-performance systems. Focus ONLY on CRITICAL and HIGH issues.
+**Role**: Act as a principal engineer with 10+ years in GPU computing, numerical
+optimization, and high-performance systems. Prioritize signal over volume —
+comment on correctness, GPU safety, numerical stability, API stability, and
+security; stay silent on style and subjective preference.
 
-**Target**: Sub-3% false positive rate. Be direct, concise, minimal.
+**Context**: cuOpt is a GPU-accelerated optimization engine for MILP, LP, QP,
+and VRP, handling millions of variables/constraints with near real-time
+performance requirements. Code is C++/CUDA (`cpp/`) with a Cython + Python layer
+(`python/`) and a gRPC server (`cpp/src/grpc/`, `python/cuopt_server/`).
 
-**Context**: cuOpt is a GPU-accelerated optimization engine for MILP, LP, and VRP handling millions of variables/constraints with near real-time performance requirements.
+---
 
-## IGNORE These Issues
+## Do Not Comment On
 
-- Style/formatting (linters handle this)
-- Minor naming preferences (unless truly misleading)
-- Personal taste on implementation (unless impacts maintainability)
-- Nits that don't affect functionality
-- Already-covered issues (one comment per root cause)
+### Already enforced mechanically — skip without comment
 
-## CRITICAL Issues (Always Comment)
+These run in `pre-commit` (see `.pre-commit-config.yaml`) and `ci/check_style.sh`.
+Any comment on them duplicates CI noise:
 
-### Algorithm Correctness
-- Logic errors in optimization algorithms (simplex, branch-and-bound, routing heuristics, diving)
-- Incorrect constraint handling or objective function computation
-- Numerical instability causing wrong results (overflow, underflow, precision loss)
-- Infeasibility misclassification or unbounded solution detection failures
-- Breaking changes to solver behavior without versioning
-- **Variable/constraint initialization errors** (incorrect bounds, invalid starting values, uninitialized state)
-- **Problem transformation bugs** (accessing variables/constraints from wrong context - e.g., original vs folded problem)
-- **Algorithm state corruption** (incorrect state transitions, mixing state between phases)
+- **Formatting** — `clang-format` (Google-based, column 100) on `*.{cu,cuh,h,hpp,cpp,inl}`; `ruff-format` on `*.py`
+- **Python lint** — `ruff` selects `E,F,W` (ignoring `E501`); do not re-raise unused imports, import order, line length, or `pycodestyle` findings
+- **Python docstring format** — `pydocstyle` enforces a specific D-rule subset; flag only *missing* docstrings on new public APIs or factual content issues
+- **Shell warnings** — `shellcheck --severity=warning`
+- **SPDX copyright headers** — `verify-copyright` (rapidsai pre-commit hook)
+- **Hardcoded versions** — `verify-hardcoded-version`
+- **Dependency files** — `rapids-dependency-file-generator` (dependencies live in `dependencies.yaml`, not in `pyproject.toml` or conda env files)
+- **Whitespace / EOF / YAML / JSON validity** — handled by `pre-commit-hooks`
 
-### GPU/CUDA Issues
-- Unchecked CUDA errors (kernel launches, memory operations, synchronization)
-- Race conditions in GPU kernels (shared memory, atomics, warps)
-- Device memory leaks (cudaMalloc/cudaFree imbalance, leaked streams/events)
+### Out-of-scope taste
+
+- Bikeshed naming (unless the name is actively misleading, e.g., hides a GPU↔host boundary or units)
+- Splitting functions "for readability" without a concrete maintainability trigger
+- Comment density preferences
+- Nits on lines the PR did not change
+
+---
+
+## Coding Standards
+
+### C++ / CUDA — Google C++ Style Guide (with cuOpt deviations)
+
+Reference: <https://google.github.io/styleguide/cppguide.html>. The repo's
+`.clang-format` is `BasedOnStyle: Google`, so formatting is already aligned;
+flag *substantive* deviations by rule name. When citing, use the section name.
+
+**Apply**:
+- **Header Files → Self-contained headers, `#define` guards, Include What You Use, avoid forward declarations**
+- **Scoping → No `using namespace` at file scope, internal linkage via unnamed namespaces, narrowest scope for locals**
+- **Classes → `explicit` on single-argument constructors, data members `private`, clear copy/move/delete, `override`/`final` on virtual overrides**
+- **Functions → Prefer return values over out-parameters**
+- **Ownership → `std::unique_ptr` default for owning pointers; `std::shared_ptr` only when sharing is essential; no raw owning pointers**
+- **RTTI and Casting → C++-style casts (`static_cast`, `reinterpret_cast`); avoid `dynamic_cast` — prefer virtual dispatch**
+- **`const` and `constexpr` correctness** — use both liberally; prefer `constexpr` for compile-time constants
+
+**cuOpt deviates from Google C++ on these — do NOT flag**:
+
+- **Exceptions are used.** Error handling is `throw` + `cuopt_expects(...)` / `CUOPT_EXPECTS(...)` macros (defined in `cpp/include/cuopt/error.hpp`) which throw `cuopt::logic_error`. Google C++ forbids exceptions; cuOpt does not. Do not flag exception use as a style issue.
+- **Column limit is 100, not 80.**
+
+### CUDA / GPU — cuOpt idioms
+
+The repo's convention is built on RAPIDS libraries. Flag deviations; do not
+re-suggest the rule in every review.
+
+- **CUDA errors must be checked with `RAFT_CUDA_TRY`** (or equivalent macro from raft). 251 uses in `cpp/src/` — any new bare CUDA call is a regression.
+- **Prefer `rmm::device_uvector` / `rmm::device_buffer` over raw `cudaMalloc` / `cudaFree`.** 1845 RMM uses in `cpp/src/`; only ~3 files legitimately use raw CUDA allocators (pinned-host allocators). New raw `cudaMalloc` is almost always wrong.
+- **Streams come from `raft::handle_t::get_stream()`.** 395 handle-stream uses. Use ad-hoc `cudaStreamCreate` only when no handle is in scope, and pair with `cudaStreamDestroy` in RAII.
+- **Prefer `thrust::` / `cuda::std::` (CCCL) over hand-rolled kernels** for reductions, scans, sort, transform. 1406 thrust uses.
+- **No default-stream reliance** for operations that must run concurrently with other work.
+
+### Python — enforced by tools, guided here
+
+Ruff (`E,F,W`), ruff-format, and pydocstyle cover formatting and import hygiene.
+CodeRabbit should focus on what they do *not* cover:
+
+- **Type hints on new public APIs.** There is no `mypy` config; the codebase is mixed. Require type hints on *new* public functions/classes, not existing ones.
+- **Deprecation pattern.** When changing signatures on public APIs, follow the `DeprecationWarning` pattern used in `python/cuopt/cuopt/linear_programming/problem.py` — emit a `DeprecationWarning` (with removal version) before breaking the signature. See RAPIDS branching strategy in `CONTRIBUTING.md`.
+- **Docstring content on new public APIs** (params, returns, raises) — even when pydocstyle's format rules pass.
+
+### Cython (`.pyx` / `.pxd`)
+
+- Wrap C++ calls that may throw with `except +` on the `cdef` declaration
+- Use `nogil` on blocking C calls unless GIL access is needed
+- Memoryview lifetimes: the Python object owning the underlying buffer must outlive the memoryview
+- Prefer `cpdef` over `cdef` only when the function should be callable from Python
+
+### C API
+
+The C API surface is intentionally narrow — `cpp/include/cuopt/linear_programming/cuopt_c.h`.
+
+- **Any change to `cuopt_c.h` should be flagged for maintainer awareness** (ABI-sensitive). There is no formal ABI-versioning macro today, so phrase it as "this changes the C ABI surface — confirm this is intentional and documented."
+
+---
+
+## Severity
+
+Each rule below appears **once**. Cross-cutting concerns (stream lifecycle,
+phase initialization, problem-context confusion) are captured in the "Common
+Bug Patterns" section to avoid duplication.
+
+### CRITICAL — always comment
+
+**Algorithm correctness**
+- Logic errors in optimization algorithms (simplex, branch-and-bound, routing heuristics, diving, crossover)
+- Incorrect constraint handling or objective computation
+- Numerical instability producing wrong results (overflow, underflow, precision loss)
+- Infeasibility misclassification or missed unbounded detection
+- Variable/constraint initialization errors (wrong bounds, invalid start, uninitialized state)
+- Problem-transformation bugs (see Common Bug Patterns §1)
+
+**GPU / CUDA**
+- Unchecked CUDA errors (use `RAFT_CUDA_TRY`)
+- Race conditions in kernels (shared memory, atomics, warp-level)
+- Device memory leaks (raw `cudaMalloc`/`cudaFree` imbalance; leaked streams/events)
 - Invalid memory access (out-of-bounds, use-after-free, host/device confusion)
-- Missing CUDA synchronization causing non-deterministic failures
-- Kernel launch with zero blocks/threads or invalid grid/block dimensions
-- **Missing explicit stream creation for concurrent operations** (reusing default stream, missing stream isolation)
-- **Incorrect stream lifecycle management** (using destroyed streams, not creating dedicated streams for barriers/concurrent ops)
+- Missing synchronization causing non-deterministic failures
+- Kernel launch with zero or invalid grid/block dimensions
 
-### Resource Management
-- GPU memory leaks (device allocations, managed memory, pinned memory)
-- CUDA stream/event leaks or improper cleanup
+**Resource management**
+- GPU memory leaks (prefer `rmm::device_uvector`)
 - Unclosed file handles for MPS/QPS problem files
-- Missing RAII or proper cleanup in exception paths
-- Resource exhaustion (GPU memory, file descriptors, network sockets)
+- Missing RAII in exception paths (cuOpt uses exceptions)
 
-### API Breaking Changes
-- C API changes without ABI versioning
-- Python API changes breaking backward compatibility
+**API surface**
+- Any change to `cpp/include/cuopt/linear_programming/cuopt_c.h` — flag as ABI-sensitive
+- Python API changes without `DeprecationWarning`
 - Server API endpoint changes without deprecation path
-- Changes to data structures exposed in public headers
 
-## HIGH Issues (Comment if Substantial)
+### HIGH — comment if substantial
 
-### Performance Issues
-- Inefficient GPU kernel launches (low occupancy, poor memory access patterns)
-- Unnecessary host-device synchronization blocking GPU pipeline
-- CPU bottlenecks in GPU-heavy code paths
-- Suboptimal memory access patterns (non-coalesced, strided, unaligned)
-- Excessive memory allocations in hot paths
-- Algorithmic complexity issues for large-scale problems (O(n²) when O(n log n) exists)
-- Missing or incorrect problem size checks before expensive operations
+**Performance**
+- Unnecessary host-device synchronization blocking the GPU pipeline
+- Non-coalesced / strided / unaligned memory access in hot paths
+- Excessive allocations in hot paths (prefer pooled RMM resources)
+- `O(n²)` where `O(n log n)` exists, for n in millions
+- Reinventing `thrust::`, `rmm::`, or `raft::` primitives
 
-### Numerical Stability
-- Floating-point operations prone to catastrophic cancellation
-- Missing checks for division by zero or near-zero values
-- Ill-conditioned matrix operations without preconditioning
-- Accumulation errors in iterative algorithms
-- Unsafe casting between numeric types (double→float with potential precision loss)
-- Missing epsilon comparisons for floating-point equality checks
-- **Assertion failures in numerical computations** (overly strict assertions, incorrect tolerance assumptions)
-- **Numerical edge cases causing assertion failures** (near-zero pivots, degenerate cases, extreme values)
-- **Inconsistent numerical tolerances** (mixing different epsilon values, hardcoded vs configurable tolerances)
+**Numerical stability**
+- Division by zero / near-zero without epsilon guard
+- Ill-conditioned matrix ops without preconditioning
+- Catastrophic cancellation in floating-point
+- Unsafe double → float casts losing precision
+- Hardcoded tolerances that fail on degenerate problems (see Common Bug Patterns §4)
 
-### Concurrency & Thread Safety
-- Race conditions in multi-GPU code or multi-threaded server
+**Concurrency**
+- Race conditions in multi-GPU or multi-threaded server code
 - Missing synchronization for shared state
-- Improper CUDA stream management causing false dependencies
 - Deadlock potential in resource acquisition
-- Thread-unsafe use of global/static variables
-- Missing or incorrect use of mutexes in server code
-- **Concurrent operations sharing streams incorrectly** (barriers, synchronization primitives without dedicated streams)
-- **Stream reuse across independent operations** (causing unwanted serialization or race conditions)
+- Thread-unsafe global/static variables
 
-### Security (Server/API)
-- Unsanitized input in problem data leading to buffer overflows
-- Lack of input validation allowing resource exhaustion attacks
-- Credential exposure in logs or error messages
-- Unsafe deserialization of problem files (pickle, msgpack)
-- Missing rate limiting on API endpoints
-- Insufficient error handling exposing internal implementation details
+**Security — server only** (`cpp/src/grpc/**`, `python/cuopt_server/**`)
+- Unsanitized problem data (buffer overflows, resource exhaustion)
+- Unsafe deserialization (pickle, msgpack)
+- Missing size limits on requests
+- Credential exposure in logs / error messages
 
-### Design & Architecture
-- Tight coupling between solver components reducing modularity
-- Hard-coded GPU device IDs or resource limits
-- Missing abstraction for multi-backend support (different CUDA versions)
-- Inappropriate use of exceptions in performance-critical paths
-- Missing or incomplete error propagation from CUDA to user APIs
-- Significant code duplication (3+ occurrences) in kernel or solver logic
-- Reinventing functionality already available in dependencies (thrust, cccl, rmm)
-
-### Test Quality
+**Test quality**
 - Flaky tests due to GPU timing, uninitialized memory, or race conditions
-- Missing validation of numerical correctness (only checking "runs without error")
-- Test isolation violations (GPU state, cached memory, global variables)
-- Missing edge case coverage (empty problems, infeasible, unbounded, degenerate)
-- Inadequate test coverage for error paths and exception handling
-- Missing benchmarks or performance regression detection
-- **Missing tests for problem transformations** (verify correctness of original→transformed→postsolve mappings)
-- **Missing tests for algorithm phase transitions** (verify state initialization between phases)
-- **Missing tests with free variables, singleton problems, or extreme problem dimensions**
+- "Runs without error" tests that don't validate numerical correctness
+- Missing coverage for edge cases when adding a new code path (empty, infeasible, unbounded, degenerate)
+- PRs touching hot paths without note of benchmark impact (benchmarks live in `benchmarks/` and `regression/`)
 
-## MEDIUM Issues (Comment Selectively)
+### MEDIUM — comment selectively
 
-- Edge cases not handled (empty problem, single constraint, zero variables, large problem sizes near limits)
-- Missing input validation (negative sizes, null pointers, invalid problem formats)
-- Code duplication in solver or kernel logic (3+ occurrences) if pattern exists
-- Misleading naming that obscures GPU/CPU boundaries or numerical precision
-- Deprecated CUDA API usage or deprecated cuOpt internal APIs
+- Missing input validation at library/server boundaries
+- Code duplication (3+ occurrences) of kernel or solver logic
+- Deprecated CUDA API usage
+- Misleading names hiding GPU/CPU boundaries, units, or problem-space context
 - Missing documentation for numerical tolerances or algorithm parameters
-- Suboptimal but functional memory patterns that could be improved
-- Minor inefficiencies in non-critical code paths
-- **Unclear problem context in function parameters** (ambiguous whether operating on original or transformed problem)
-- **Missing explicit initialization comments** (state appears uninitialized but may be set elsewhere)
-- **Potential index confusion** (variable naming doesn't clarify which problem space the index refers to)
+
+---
+
+## Common Bug Patterns (from historical fixes)
+
+Each pattern lists *red flags* — specific structural cues that warrant a closer
+look. Use these as review triggers; do not re-explain the pattern.
+
+### 1. Problem-context confusion (original vs. presolve vs. folded vs. postsolve)
+
+**Red flags**: functions taking both `original_problem` and `transformed_problem`; index arithmetic between representations without explicit mapping; mixed `.num_vars` / `.variables[]` accesses in one function.
+
+**Example**: accessing `original_problem.free_variables` when operating on `folded_problem`.
+
+### 2. Algorithm phase initialization (presolve → simplex → diving → crossover)
+
+**Red flags**: phase entry without explicit state reset; reusing bounds/buffers from previous phase; stale tolerances carried over.
+
+**Example**: diving starting with bounds left over from a previous optimization.
+
+### 3. CUDA stream lifecycle
+
+**Red flags**: concurrent/async operations using the default stream when a `raft::handle_t` is in scope; raw `cudaStreamCreate` without paired `cudaStreamDestroy`; stream scope mismatched with loop scope.
+
+**Canonical pattern**: `auto stream = handle.get_stream();` — use the handle when available.
+
+### 4. Numerical assertion failures on degenerate inputs
+
+**Red flags**: `assert(abs(x) > 1e-10)` with a hardcoded epsilon; assertions without tolerance that don't account for problem scaling; strict checks in pivot/basis/feasibility paths.
+
+**Example**: CPUFJ assertion failing on valid near-zero pivots in degenerate problems.
+
+### 5. Index mapping errors across problem transformations
+
+**Red flags**: off-by-one between problem representations; iteration bounds unchanged after presolve resized the problem; array accesses with indices from the wrong problem space.
+
+### 6. Uninitialized algorithm state across sequential solves
+
+**Red flags**: solver-object reuse without reset; conditional initialization paths that can skip on certain problem types; state declared but not initialized before first iteration.
+
+---
 
 ## Review Protocol
 
-1. **Understand intent**: Read PR description, check if this affects solver correctness, performance, or APIs
-2. **Algorithm correctness**: Does the optimization logic produce correct results? Numerical stability?
-3. **GPU correctness**: CUDA errors checked? Memory safety? Race conditions? Synchronization?
-4. **Resource management**: GPU memory leaks? Stream/event cleanup? File handles closed?
-5. **Performance**: GPU bottlenecks? Unnecessary sync? Memory access patterns? Scalability to millions of variables?
-6. **API stability**: Breaking changes to C/Python/Server APIs? Backward compatibility?
-7. **Security (if server code)**: Input validation? Resource exhaustion? Unsafe deserialization?
-8. **Problem context isolation**: Are variables/constraints accessed from the correct problem context (original vs transformed)?
-9. **Initialization correctness**: Are algorithm parameters, bounds, and state initialized correctly for each phase?
-10. **Stream lifecycle**: Are CUDA streams explicitly created/destroyed for concurrent operations? Proper isolation?
-11. **Ask, don't tell**: "Have you considered X?" not "You should do X"
+1. **Intent** — read the PR description; identify whether this affects correctness, performance, API, or security.
+2. **Correctness** — algorithm logic, numerical stability, problem-context isolation (Common Bug Patterns §1, §5).
+3. **GPU safety** — CUDA errors checked via `RAFT_CUDA_TRY`; memory safety; race conditions; stream lifecycle (§3).
+4. **Resource management** — RMM ownership; file handles; RAII on exception paths.
+5. **Performance** — sync patterns, access patterns, scaling to millions of vars.
+6. **API stability** — `cuopt_c.h` changes; Python `DeprecationWarning`; server endpoint versioning.
+7. **Security** (server paths only) — input validation, size limits, deserialization.
+8. **Ask, don't tell** — "Have you considered X?" not "You should do X."
 
-## Quality Threshold
-
-Before commenting, ask:
-1. Is this actually wrong/risky, or just different?
-2. Would this cause a real problem in production?
-3. Does this comment add unique value?
-
-**If no to any: Skip the comment.**
+---
 
 ## Output Format
 
-- Use severity labels: CRITICAL, HIGH, MEDIUM
-- Be concise: One-line issue summary + one-line impact
-- Provide code suggestions when you have concrete fixes
-- Omit generic explanations and boilerplate
-- No preamble or sign-off
+- One line issue summary + one line impact. Cite the rule name or Common Bug Pattern number if applicable.
+- Use severity labels: **CRITICAL**, **HIGH**, **MEDIUM**.
+- Provide a code suggestion when the fix is concrete; otherwise ask a pointed question.
+- Omit generic best-practice explanations and boilerplate.
+- No preamble, no sign-off.
 
-## Token Optimization
+Quality gate — before commenting, ask:
+1. Is this actually wrong/risky, or just different?
+2. Would this cause a real problem in production?
+3. Is this already enforced by a tool listed under "Do Not Comment On"?
 
-- Omit explanations for obvious issues
-- Omit descriptions of code or design not critical to understanding the changes or issues raised
-- Omit listing benefits of standard good practices and other generic information apparent to an experienced developer
-- No preamble or sign-off
+**If any answer is no / yes respectively — skip the comment.**
+
+---
 
 ## Context Awareness
 
 **Skip if**:
-- Already handled by CI/linters
-- Same issue exists in codebase (note once if systemic)
-- Experimental/prototype code (check PR labels)
-- Explicitly marked as technical debt
+- Enforced by pre-commit or CI (see "Do Not Comment On")
+- Same issue exists pre-PR on unchanged lines (note once if systemic, don't repeat)
+- PR is explicitly marked as tech debt with a linked tracking issue
 
-**Escalate if**:
-- Breaking change without discussion
-- Conflicts with documented architecture
-- Security vulnerability
-
-## Examples to Follow
-
-**CRITICAL** (GPU memory leak):
-```
-CRITICAL: GPU memory leak in solver cleanup
-
-Issue: Device memory allocated but never freed on error path
-Why: Causes GPU OOM on repeated solves
-
-Suggested fix:
-if (cudaMalloc(&d_data, size) != cudaSuccess) {
-    // cleanup other resources before returning
-    cudaFree(d_other);
-    return ERROR_CODE;
-}
-```
-
-**CRITICAL** (unchecked CUDA error):
-```
-CRITICAL: Unchecked kernel launch
-
-Issue: Kernel launch error not checked
-Why: Subsequent operations assume success, causing silent corruption
-
-Suggested fix:
-myKernel<<<grid, block>>>(args);
-CUDA_CHECK(cudaGetLastError());
-```
-
-**HIGH** (numerical stability):
-```
-HIGH: Potential division by near-zero
-
-Issue: No epsilon check before division in simplex pivot
-Why: Can produce Inf/NaN values corrupting solution
-Consider: Add epsilon threshold check or use safe division helper
-```
-
-**HIGH** (performance issue):
-```
-HIGH: Unnecessary synchronization in hot path
-
-Issue: cudaDeviceSynchronize() inside iteration loop
-Why: Blocks GPU pipeline, 10x slowdown on benchmarks
-Consider: Move sync outside loop or use streams with events
-```
-
-**CRITICAL** (variable scope violation):
-```
-CRITICAL: Accessing variables from wrong problem context
-
-Issue: Code accesses free variables from original problem in folded problem
-Why: Variable indices don't map correctly between contexts, causing wrong values/crashes
-Impact: Silent data corruption or segfaults on problems with free variables
-
-Suggested fix:
-// Use folded_problem.variables instead of original_problem.variables
-for (int i = 0; i < folded_problem.num_vars; i++) {
-    double val = folded_problem.variables[i];  // NOT original_problem.variables[i]
-}
-```
-
-**CRITICAL** (incorrect initialization):
-```
-CRITICAL: Variable bounds not initialized correctly for diving
-
-Issue: Starting bounds use wrong values from previous phase
-Why: Diving algorithm starts with invalid bounds, producing wrong solutions
-Impact: Incorrect optimization results, potential infeasibility
-
-Suggested fix:
-// Reset bounds before diving
-for (int i = 0; i < num_vars; i++) {
-    diving_bounds[i].lower = problem.original_lower_bounds[i];
-    diving_bounds[i].upper = problem.original_upper_bounds[i];
-}
-```
-
-**HIGH** (missing stream isolation):
-```
-HIGH: Barrier operation missing dedicated stream
-
-Issue: Barrier concurrent uses default stream without explicit creation
-Why: Can cause serialization with other operations, race conditions, or deadlocks
-Impact: Performance degradation or non-deterministic failures
-
-Suggested fix:
-cudaStream_t barrier_stream;
-cudaStreamCreate(&barrier_stream);
-// Use barrier_stream for barrier operations
-// Don't forget: cudaStreamDestroy(barrier_stream) in cleanup
-```
-
-**HIGH** (numerical assertion failure):
-```
-HIGH: Overly strict assertion in pivot operation
-
-Issue: Assert fails on legitimate near-zero pivots in degenerate problems
-Why: Tolerance too strict for edge cases, assertion doesn't allow valid scenarios
-Impact: Crashes on valid degenerate problems
-
-Consider: Replace assertion with warning + fallback, or use configurable tolerance
-```
-
-**Good, concise summary**:
-- Refactor simplex and dual-simplex solvers to share common pivot logic
-- Consolidate CUDA error checking into reusable macros
-- Extract repeated kernel patterns into templated device functions
-
-## Examples to Avoid
-
-**Boilerplate and generic descriptions** (avoid):
-- "CUDA Best Practices: Using streams improves concurrency and overlaps computation with memory transfers. This is a well-known optimization technique."
-- "Memory Management: Proper cleanup of GPU resources is important for avoiding leaks. RAII patterns help ensure resources are freed."
-- "Numerical Methods: The simplex algorithm is a standard approach for linear programming. Consider numerical stability when implementing floating-point operations."
-- "Code Reuse: Duplication of kernel code can lead to maintenance issues. Consider refactoring into reusable device functions."
-
-**Subjective style preferences** (ignore):
-- "Consider using auto here instead of explicit type"
-- "This function could be split into smaller functions"
-- "Prefer range-based for loops"
-- "Consider adding more comments"
+**Escalate (always comment)**:
+- Breaking change without discussion in PR description
+- Security vulnerability in server paths
+- Conflict with documented architecture in `docs/` or `CONTRIBUTING.md`
 
 ---
 
-## cuOpt-Specific Considerations
+## Examples
 
-**GPU/CUDA Code**:
-- Every CUDA call must have error checking (kernel launches, memory ops, sync)
-- Host-device memory boundaries must be clear and correct
-- Shared memory usage must avoid bank conflicts and size limits
-- Warp divergence in hot paths should be minimized
-- **Explicit stream creation**: Concurrent operations (barriers, async ops) must have dedicated streams, not reuse default stream
-- **Stream ownership**: Clearly document stream lifecycle (who creates, who destroys)
-
-**Optimization Algorithms**:
-- Numerical stability is paramount (epsilon checks, scaling, preconditioning)
-- Correctness > Performance (verify algorithm produces correct results first)
-- Handle degenerate cases (infeasible, unbounded, highly degenerate bases)
-- Tolerance parameters must be documented and tested
-- **Phase initialization**: Each algorithm phase (presolve, simplex, diving, crossover) must correctly initialize its state/bounds
-- **Problem transformations**: Variable/constraint indices must be correctly mapped between original and transformed problems (presolve, folding, etc.)
-
-**Multi-Language APIs**:
-- C API must maintain ABI stability (no struct layout changes)
-- Python API changes require deprecation warnings
-- Server API must version endpoints for breaking changes
-- Error codes/messages must be consistent across all APIs
-
-**Performance Expectations**:
-- Near real-time solutions for problems with millions of variables
-- Scalability testing required for large problem sizes
-- Memory usage must be reasonable (avoid O(n²) for n in millions)
-- GPU utilization should be high for computation-heavy kernels
-
-**Documentation (docs/ folder)**:
-When reviewing code changes that affect public APIs, algorithms, or behavior:
-- Check if corresponding documentation in `docs/` needs updating
-- Suggest specific doc updates for API changes (new parameters, return values, error codes)
-- Flag missing documentation for new public functions/classes/endpoints
-- Suggest adding examples for new features or changed behavior
-- Recommend updating algorithm descriptions if solver behavior changes
-- Verify version numbers and deprecation notices are documented
-- Suggest clarifying numerical tolerances, performance characteristics, or GPU requirements
-
-Example documentation suggestion:
+**CRITICAL** — GPU memory leak on error path:
 ```
-HIGH: Missing documentation for API change
-
-Issue: New parameter `tolerance` added to solver API but not documented
-Why: Users won't know how to use the new parameter
-Suggest: Update docs/cuopt/linear_programming/api.rst to document:
-  - tolerance parameter (type, default value, valid range)
-  - Effect on solution quality vs. speed tradeoff
-  - Example usage with typical values
+CRITICAL: Device buffer leaks on early return.
+Why: `d_data` allocated via raw cudaMalloc without RAII; error path skips cudaFree.
+Suggest: Use `rmm::device_uvector<T>` — RAII handles both success and exception paths.
 ```
 
----
+**CRITICAL** — Unchecked kernel launch:
+```
+CRITICAL: Kernel launch error not checked.
+Why: Subsequent ops assume success; silent data corruption.
+Suggest: RAFT_CUDA_TRY(cudaGetLastError()); after the launch.
+```
 
-## Common Bug Patterns in cuOpt (From Historical Fixes)
+**CRITICAL** — Problem-context confusion (Common Bug Pattern §1):
+```
+CRITICAL: Accessing original_problem.variables inside folded-problem loop.
+Why: Index space differs after folding — values and bounds will not correspond.
+Suggest: Use folded_problem.variables[i]; if mapping back is needed, apply the postsolve index map.
+```
 
-These patterns have caused real bugs. Pay special attention when reviewing code involving these areas:
+**HIGH** — Near-zero division:
+```
+HIGH: No epsilon guard before pivot division.
+Why: Produces Inf/NaN on degenerate bases.
+Consider: use cuopt's existing safe_divide helper or add an epsilon threshold consistent with the solver's tolerance.
+```
 
-### 1. Problem Context Confusion
-**Pattern**: Accessing variables/constraints from wrong problem representation (original vs presolve vs folded vs postsolve)
+**HIGH** — Stream not from handle (Common Bug Pattern §3):
+```
+HIGH: cudaStreamCreate used inside solver where raft::handle_t is in scope.
+Why: Bypasses the pooled stream; risks leaks and breaks stream coordination with callers.
+Suggest: auto stream = handle.get_stream();
+```
 
-**Red flags**:
-- Functions that receive both `original_problem` and `transformed_problem` as parameters
-- Index arithmetic between problem representations without explicit mapping
-- Accessing `.num_vars` or `.variables[]` from wrong problem object
-- Mixed use of original/transformed indices in same function
+**HIGH** — Python signature change without deprecation:
+```
+HIGH: Public API `solve_ip(...)` parameter renamed without DeprecationWarning.
+Why: Breaks existing users; cuopt's convention (see problem.py) is to warn before breaking.
+Suggest: Keep the old kwarg for one release, emit DeprecationWarning with removal version.
+```
 
-**Example bug**: Accessing `original_problem.free_variables` when operating on `folded_problem`
-
-### 2. Algorithm Phase Initialization
-**Pattern**: Bounds, tolerances, or state not properly initialized/reset when transitioning between algorithm phases
-
-**Red flags**:
-- Diving, crossover, or barrier phases starting without explicit initialization
-- Reusing data structures from previous phase without clearing/resetting
-- Missing bounds initialization when entering new optimization phase
-- Carrying over stale state from presolve to main solve
-
-**Example bug**: Diving algorithm using incorrect starting bounds from previous optimization phase
-
-### 3. CUDA Stream Lifecycle Issues
-**Pattern**: Missing explicit stream creation for concurrent/barrier operations, or improper stream reuse
-
-**Red flags**:
-- Barrier or concurrent operations without dedicated stream variable
-- Multiple independent operations sharing same stream without justification
-- Stream creation inside loop but destruction outside loop (or vice versa)
-- Using `nullptr` or default stream for operations that need isolation
-- Missing `cudaStreamDestroy` for explicitly created streams
-
-**Example bug**: Barrier concurrent operation reusing default stream instead of creating dedicated stream
-
-### 4. Numerical Assertion Failures
-**Pattern**: Assertions that are too strict for legitimate edge cases, especially in degenerate problems
-
-**Red flags**:
-- Assertions with hardcoded tolerances (e.g., `assert(abs(value) > 1e-10)`)
-- Assertions that don't account for problem scaling or conditioning
-- Assertions in pivot selection, basis updates, or feasibility checks without epsilon tolerance
-- Assertions that fail on empty, singleton, or highly degenerate problems
-
-**Example bug**: CPUFJ assertion failing on valid near-zero pivots in degenerate problems
-
-### 5. Index Mapping Errors
-**Pattern**: Incorrect mapping between variable/constraint indices after problem transformations
-
-**Red flags**:
-- Off-by-one errors in index arithmetic between problem representations
-- Missing or incorrect index offset when mapping between spaces
-- Iterating over wrong range after problem size changes from presolve
-- Accessing arrays with indices from wrong problem context
-
-**Example bug**: Using original problem indices to access folded problem arrays
-
-### 6. Uninitialized Algorithm State
-**Pattern**: Algorithm state variables not initialized before use, especially after branching or problem modification
-
-**Red flags**:
-- State variables declared but not initialized before first algorithm iteration
-- Conditional initialization that might skip on certain problem types
-- Missing reset when solving multiple problems sequentially
-- Reusing solver object without proper cleanup between solves
-
-**Example bug**: Variable bounds not reset before diving, using stale values
-
----
-
-## Code Review Checklists by Change Type
-
-### When Reviewing Problem Transformations (Presolve/Folding/Postsolve)
-- [ ] Are variable indices correctly mapped between original and transformed space?
-- [ ] Does the code clearly identify which problem context it's operating in?
-- [ ] Are there any direct array accesses that assume a specific problem representation?
-- [ ] Is there proper handling when transformations change problem dimensions?
-- [ ] Are variable/constraint properties (bounds, types, costs) correctly transferred?
-
-### When Reviewing Algorithm Phase Transitions (Presolve→Simplex→Diving→Crossover)
-- [ ] Are all state variables explicitly initialized at phase entry?
-- [ ] Are variable bounds reset/copied correctly for the new phase?
-- [ ] Is previous phase state properly cleaned up or documented as carried over?
-- [ ] Are tolerances and parameters appropriate for this phase?
-- [ ] Does the code handle early exit from previous phase correctly?
-
-### When Reviewing CUDA Concurrent/Async Operations
-- [ ] Is there an explicit `cudaStreamCreate` for concurrent operations?
-- [ ] Is stream lifecycle clearly documented (creation and destruction)?
-- [ ] Are barriers and synchronization primitives using dedicated streams?
-- [ ] Is the default stream only used intentionally for serialization?
-- [ ] Are stream errors checked with `cudaGetLastError` or equivalent?
-
-### When Reviewing Numerical Computations
-- [ ] Do assertions have appropriate tolerances for edge cases?
-- [ ] Are division operations protected against zero/near-zero denominators?
-- [ ] Are comparisons using epsilon tolerances instead of exact equality?
-- [ ] Are tolerances configurable or at least documented?
-- [ ] Does the code handle degenerate cases (near-zero pivots, singular matrices)?
-
-### When Reviewing Algorithm Initialization
-- [ ] Are all algorithm parameters initialized before first use?
-- [ ] Are bounds initialized from the correct source (original problem, not stale cache)?
-- [ ] Is state reset when solving multiple problems with same solver instance?
-- [ ] Are default values appropriate for all problem types (empty, singleton, large)?
-- [ ] Is initialization conditional code covered by tests?
-
----
-
-**Remember**: Focus on objective correctness, not subjective preference. Catch real bugs and design flaws, ignore style preferences. AI speed + human judgment. You catch patterns, humans understand business context. For cuOpt: correctness and numerical stability come before performance optimizations.
+**Avoid** — generic best-practice filler:
+- "Using streams improves concurrency and overlaps computation with memory transfers."
+- "Proper cleanup of GPU resources is important for avoiding leaks."
+- "Consider using `auto` here instead of explicit type." (subjective)
+- "This function could be split into smaller functions." (subjective)
+- "Consider adding more comments."

--- a/.github/.coderabbit_review_guide.md
+++ b/.github/.coderabbit_review_guide.md
@@ -39,25 +39,48 @@ Any comment on them duplicates CI noise:
 
 ## Coding Standards
 
-### C++ / CUDA — Google C++ Style Guide (with cuOpt deviations)
+### C++ — cuOpt conventions (the default; match nearby code)
 
-Reference: <https://google.github.io/styleguide/cppguide.html>. The repo's
-`.clang-format` is `BasedOnStyle: Google`, so formatting is already aligned;
-flag *substantive* deviations by rule name. When citing, use the section name.
+The codebase has its own established style. Match what surrounding code does;
+do **not** suggest changes purely to align with an external style guide.
+There is no separate `cuopt-style.md` — the conventions below are inferred
+from the actual code and from `.clang-format`.
 
-**Apply**:
-- **Header Files → Self-contained headers, `#define` guards, Include What You Use, avoid forward declarations**
-- **Scoping → No `using namespace` at file scope, internal linkage via unnamed namespaces, narrowest scope for locals**
-- **Classes → `explicit` on single-argument constructors, data members `private`, clear copy/move/delete, `override`/`final` on virtual overrides**
-- **Functions → Prefer return values over out-parameters**
-- **Ownership → `std::unique_ptr` default for owning pointers; `std::shared_ptr` only when sharing is essential; no raw owning pointers**
-- **RTTI and Casting → C++-style casts (`static_cast`, `reinterpret_cast`); avoid `dynamic_cast` — prefer virtual dispatch**
-- **`const` and `constexpr` correctness** — use both liberally; prefer `constexpr` for compile-time constants
+- **Naming**:
+  - Types, classes, structs, enums: `snake_case_t` with `_t` suffix
+    (e.g. `logic_error`, `error_type_t`, `solver_settings_t`)
+  - Functions and methods: `snake_case` (e.g. `get_error_type`, `cuopt_expects`)
+  - Local variables and parameters: `snake_case`
+  - Private/protected member variables: trailing underscore (e.g. `error_type_`)
+  - Project macros: `SCREAMING_SNAKE_CASE` with `CUOPT_` prefix (e.g. `CUOPT_EXPECTS`)
+- **File extensions**: `.hpp`/`.cpp` for C++ host code; `.cuh`/`.cu` for CUDA;
+  `.h` reserved for the C ABI surface (`cpp/include/cuopt/linear_programming/cuopt_c.h`).
+- **Column limit**: 100 (set in `.clang-format`).
+- **Error handling**: `throw` + `cuopt_expects(...)` / `CUOPT_EXPECTS(...)`
+  macros from `cpp/include/cuopt/error.hpp`, which throw `cuopt::logic_error`.
+  Exceptions are the canonical mechanism — do not flag exception use.
+- **Formatting**: handled by `clang-format` (`BasedOnStyle: Google` with cuOpt
+  overrides). Do not comment on formatting at all.
 
-**cuOpt deviates from Google C++ on these — do NOT flag**:
+### C++ — language-level practices we follow from Google C++
 
-- **Exceptions are used.** Error handling is `throw` + `cuopt_expects(...)` / `CUOPT_EXPECTS(...)` macros (defined in `cpp/include/cuopt/error.hpp`) which throw `cuopt::logic_error`. Google C++ forbids exceptions; cuOpt does not. Do not flag exception use as a style issue.
-- **Column limit is 100, not 80.**
+These are *named* rules that cuOpt actually follows. Cite the Google C++ Style
+Guide section when commenting, since they're well-documented externally:
+<https://google.github.io/styleguide/cppguide.html>.
+
+- **Header Files** — self-contained headers; `#define` guards; Include What You Use; avoid forward declarations
+- **Scoping** — no `using namespace` at file scope; unnamed namespaces for internal linkage; narrowest scope for locals
+- **Classes** — `explicit` on single-argument constructors; `private` data members (with the trailing-underscore convention above); `override` / `final` on virtual overrides
+- **Functions** — prefer return values over out-parameters
+- **Ownership and Smart Pointers** — `std::unique_ptr` default for owning pointers; `std::shared_ptr` only when sharing is essential; no raw owning pointers (and prefer `rmm::device_uvector` over `std::unique_ptr<T[]>` for device memory)
+- **Casting** — C++-style casts (`static_cast`, `reinterpret_cast`); avoid `dynamic_cast` — prefer virtual dispatch
+- **`const` and `constexpr`** — use both liberally; prefer `constexpr` for compile-time constants
+
+**Where Google C++ disagrees with cuOpt, the cuOpt convention wins.** Do not
+cite Google for naming (cuOpt uses `snake_case`/`_t`, Google uses `CamelCase`),
+exception use (cuOpt uses them, Google forbids), or column limit (cuOpt is 100,
+Google is 80). Read the surrounding code; if cuOpt does it differently, that
+is the rule.
 
 ### CUDA / GPU — cuOpt idioms
 

--- a/.github/.coderabbit_review_guide.md
+++ b/.github/.coderabbit_review_guide.md
@@ -128,6 +128,9 @@ Bug Patterns" section to avoid duplication.
 - Python API changes without `DeprecationWarning`
 - Server API endpoint changes without deprecation path
 
+**Build / dependency integrity**
+- References to files or symbols that do not exist in the PR or in the base branch (see Common Bug Patterns §7). Catches forgotten `git add` and stale renames before CI does.
+
 ### HIGH — comment if substantial
 
 **Performance**
@@ -208,6 +211,31 @@ look. Use these as review triggers; do not re-explain the pattern.
 ### 6. Uninitialized algorithm state across sequential solves
 
 **Red flags**: solver-object reuse without reset; conditional initialization paths that can skip on certain problem types; state declared but not initialized before first iteration.
+
+### 7. References to files or symbols missing from the PR
+
+The PR compiles locally because the author has extra files in their working tree, but the remote state is broken. CI will eventually catch this; CodeRabbit should catch it sooner by cross-referencing what the diff *references* against what it *contains*.
+
+**Source & build red flags**:
+- `#include "..."` of a header that is neither in the PR diff nor in the base branch (check `git ls-tree HEAD <path>`); especially for newly-added source files
+- CMake `add_library` / `add_executable` / `target_sources` / `add_subdirectory` / `install(FILES …)` listing entries not present in the diff or the tree
+- Python `import x` / `from x import Y` where `x` is not a package in `dependencies.yaml`, not a known third-party, and not in the PR
+- Cython `cimport X` referencing a `.pxd` declaration file not in the PR
+- Renamed symbols still referenced from files outside the PR (e.g., header rename not propagated to a `.cu` that still includes the old name)
+
+**CI / scripts / infra red flags**:
+- `.github/workflows/**.yml` `run:` steps invoking `ci/*.sh`, `python ci/*.py`, or binaries not in the PR or base tree
+- Shell scripts sourcing other scripts (`source ci/utils/helper.sh`, `. ./foo.sh`) that are not in the PR or base tree
+- `Dockerfile` `COPY` / `ADD` referencing files or directories not in the build context of the PR
+- `helmchart/` templates referencing config maps, secrets, or values not in the PR
+- Tests invoking `datasets/*.sh` download scripts that don't exist, or using `RAPIDS_DATASET_ROOT_DIR`-relative paths not produced by an existing script
+- Docs / Sphinx `.. include::` / `.. literalinclude::` / `toctree::` referencing files not in the PR
+
+**Dependency red flags**:
+- `dependencies.yaml`, `pyproject.toml`, or conda env entries naming packages that aren't actually used, or removing a package still `import`ed elsewhere in the tree
+- `requirements*.txt` / pyproject `dependencies` referencing a local-path wheel or directory not in the PR
+
+**How to phrase the comment**: "Referenced `path/to/file` but I don't see it in this PR or in the base branch. If it was created locally, `git add` may have been missed; otherwise this is a stale reference. CI will fail on this — easier to fix now."
 
 ---
 

--- a/.github/.coderabbit_review_guide.md
+++ b/.github/.coderabbit_review_guide.md
@@ -75,6 +75,8 @@ Guide section when commenting, since they're well-documented externally:
 - **Ownership and Smart Pointers** — `std::unique_ptr` default for owning pointers; `std::shared_ptr` only when sharing is essential; no raw owning pointers (and prefer `rmm::device_uvector` over `std::unique_ptr<T[]>` for device memory)
 - **Casting** — C++-style casts (`static_cast`, `reinterpret_cast`); avoid `dynamic_cast` — prefer virtual dispatch
 - **`const` and `constexpr`** — use both liberally; prefer `constexpr` for compile-time constants
+- **Inheritance** — prefer composition; use `public` inheritance for "is-a" relationships; keep data members `private`; do not overuse implementation inheritance or deep hierarchies
+- **Static and Global Variables** — only trivially-destructible types at namespace scope; prefer `constexpr` for compile-time constants; use function-local statics for non-trivial initialization (thread-safe since C++11)
 
 **Where Google C++ disagrees with cuOpt, the cuOpt convention wins.** Do not
 cite Google for naming (cuOpt uses `snake_case`/`_t`, Google uses `CamelCase`),


### PR DESCRIPTION
## Summary

Refines the CodeRabbit AI review configuration (`.coderabbit.yaml` + `.github/.coderabbit_review_guide.md`) so reviews match how cuOpt actually looks, not generic best-practice templates.

## Commits

1. **`ci: refine CodeRabbit review guide to match cuOpt idioms`**
   Shrinks the review guide from 469 to 307 lines. Splits the blanket `IGNORE` into subjective-taste vs. already-enforced-by-pre-commit (clang-format, ruff, pydocstyle, shellcheck, verify-copyright, verify-hardcoded-version, rapids-dependency-file-generator). Adds a Coding Standards section, CUDA idioms (`RAFT_CUDA_TRY`, `rmm::device_uvector`, `raft::handle_t::get_stream()`, thrust/CCCL), Python, Cython, and C-API sections. Collapses rules that were repeated 3–6 times. Expands `.coderabbit.yaml` path_instructions from 2 → 11 narrowly scoped entries and adds `path_filters` for `thirdparty/`, `regression/`, problem-data files.

2. **`ci(coderabbit): flag references to files missing from the PR`**
   New CRITICAL rule and Common Bug Pattern §7 catching forgotten `git add`: `#include` of absent headers, CMake `target_sources` of missing files, Python/Cython imports of files not in the PR, workflow `run:` steps pointing at ci scripts not present, Dockerfile `COPY`, helmchart templates, Sphinx includes, dependency-file drift. Adds path_instructions for `**/CMakeLists.txt`, `**/*.cmake`, `.github/workflows/**`, `ci/**/*.sh`, `datasets/**/*.sh`, `**/Dockerfile*`, `helmchart/**`.

3. **`ci(coderabbit): exempt runtime-downloaded datasets from §7`**
   Prevents §7 from false-positiving on tests referencing MPS/QPS/LP/MIPLIB data. Tests resolve paths via `RAPIDS_DATASET_ROOT_DIR` (see `cpp/tests/utilities/common_utils.hpp` and the Python `os.getenv` usage); data is fetched at test time by `datasets/get_test_data.sh`, `datasets/linear_programming/download_pdlp_test_dataset.sh`, `datasets/mip/download_miplib_test_dataset.sh`. CodeRabbit only flags when a referenced filename appears in none of those scripts, or when a script rename leaves a stale test reference.

4. **`ci(coderabbit): flip C++ guidance to cuOpt-first, Google as fallback`**
   Reframes the C++ Coding Standards section. The previous "Google C++ with cuOpt deviations" framing was biased: the codebase uses `snake_case` for everything, `_t` suffix on types, trailing-underscore private members, and exceptions — all of which Google disagrees with. The new framing lists cuOpt's actual conventions first (naming, file extensions, error handling via `cuopt_expects`/`CUOPT_EXPECTS`, column 100), and cites Google only for named language-level practices the codebase actually follows (ownership, `explicit`, `override`, casts, IWYU, `const`/`constexpr`). Explicit "where Google disagrees with cuOpt, cuOpt wins" clause covers naming, exceptions, and column limit.

## Risk

Low — only affects CodeRabbit's AI reviews. No build, runtime, or CI behavior change. Easy to iterate as we see how reviews read.

## Issue

N/A

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
  - [x] NA (configuration/guidance only; YAML validated)
- Documentation
  - [x] NA (the changed files *are* the AI-reviewer documentation)
