### PR TITLE
Replace flaky determinism test

### DIFF
--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -23,8 +23,6 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/tracking_resource_adaptor.hpp>
 
-#include <rmm/mr/owning_wrapper.hpp>
-
 #include <fcntl.h>
 #include <omp.h>
 #include <sys/file.h>
@@ -85,7 +83,7 @@ void write_to_output_file(const std::string& out_dir,
   }
 }
 
-inline auto make_async() { return std::make_shared<rmm::mr::cuda_async_memory_resource>(); }
+inline auto make_async() { return rmm::mr::cuda_async_memory_resource(); }
 
 void read_single_solution_from_path(const std::string& path,
                                     const std::vector<std::string>& var_names,
@@ -274,7 +272,7 @@ void run_single_file_mp(std::string file_path,
 {
   std::cout << "running file " << file_path << " on gpu : " << device << std::endl;
   auto memory_resource = make_async();
-  rmm::mr::set_current_device_resource(memory_resource.get());
+  rmm::mr::set_current_device_resource(memory_resource);
   int sol_found = run_single_file(file_path,
                                   device,
                                   batch_id,
@@ -537,14 +535,14 @@ int main(int argc, char* argv[])
     auto memory_resource = make_async();
     if (memory_limit > 0) {
       auto limiting_adaptor =
-        rmm::mr::limiting_resource_adaptor(memory_resource.get(), memory_limit * 1024ULL * 1024ULL);
-      rmm::mr::set_current_device_resource(&limiting_adaptor);
+        rmm::mr::limiting_resource_adaptor(memory_resource, memory_limit * 1024ULL * 1024ULL);
+      rmm::mr::set_current_device_resource(limiting_adaptor);
     } else if (track_allocations) {
-      rmm::mr::tracking_resource_adaptor tracking_adaptor(memory_resource.get(),
+      rmm::mr::tracking_resource_adaptor tracking_adaptor(memory_resource,
                                                           /*capture_stacks=*/true);
-      rmm::mr::set_current_device_resource(&tracking_adaptor);
+      rmm::mr::set_current_device_resource(tracking_adaptor);
     } else {
-      rmm::mr::set_current_device_resource(memory_resource.get());
+      rmm::mr::set_current_device_resource(memory_resource);
     }
     run_single_file(path,
                     0,

--- a/cpp/tests/mip/determinism_test.cu
+++ b/cpp/tests/mip/determinism_test.cu
@@ -233,7 +233,7 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple("/mip/gen-ip054.mps", 128, 120.0, 1),
     std::make_tuple("/mip/bb_optimality.mps", 4, 60.0, 4),
     std::make_tuple("/mip/neos5.mps", 16, 60.0, 1),
-    std::make_tuple("/mip/seymour1.mps", 16, 120.0, 1),
+    std::make_tuple("/mip/pk1.mps", 16, 60.0, 1),
     // too heavy for CI
     // std::make_tuple("/mip/n2seq36q.mps", 16, 60.0, 4),
     std::make_tuple("/mip/gmu-35-50.mps", 32, 60.0, 2)),


### PR DESCRIPTION
This PR fixes the B&B determinism test flakiness by replacing seymour1.mps with another instance which completes faster.
run_mip.cpp was also fixed to build following the recent CCCL MR changes.

Closes #1134

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
