### PR TITLE
ci: assign benchmarks/ to engine codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 #cpp code owners
 cpp/               @nvidia/cuopt-engine-codeowners
+benchmarks/        @nvidia/cuopt-engine-codeowners
 
 #python code owners
 python/            @nvidia/cuopt-infra-codeowners


### PR DESCRIPTION
## Summary
- Route `benchmarks/` reviews to `@nvidia/cuopt-engine-codeowners` alongside `cpp/`, since benchmarks directly exercise solver internals and performance.

## Test plan
- [ ] Confirm GitHub picks up the new CODEOWNERS rule by checking that a PR touching `benchmarks/` auto-requests review from the engine team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)