### PR TITLE
fix(benchmarks): drop removed rmm owning_wrapper; build in CI

### DIFF
--- a/benchmarks/linear_programming/cuopt/benchmark_helper.hpp
+++ b/benchmarks/linear_programming/cuopt/benchmark_helper.hpp
@@ -21,7 +21,6 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cstdlib>
@@ -34,7 +33,7 @@
 #include <stdexcept>
 #include <string>
 
-inline auto make_async() { return std::make_shared<rmm::mr::cuda_async_memory_resource>(); }
+inline auto make_async() { return rmm::mr::cuda_async_memory_resource(); }
 inline auto make_pool()
 {
   size_t free_mem, total_mem;
@@ -43,8 +42,7 @@ inline auto make_pool()
   double alloc_ratio    = 0.4;
   // allocate 40%
   size_t initial_pool_size = (size_t(free_mem * alloc_ratio) / rmm_alloc_gran) * rmm_alloc_gran;
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_async(),
-                                                                     initial_pool_size);
+  return rmm::mr::pool_memory_resource(make_async(), initial_pool_size);
 }
 
 template <typename T>

--- a/benchmarks/linear_programming/cuopt/run_pdlp.cu
+++ b/benchmarks/linear_programming/cuopt/run_pdlp.cu
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
 
   // Setup up RMM memory pool
   auto memory_resource = make_pool();
-  rmm::mr::set_current_device_resource(memory_resource.get());
+  rmm::mr::set_current_device_resource(memory_resource);
 
   // Initialize raft handle and running stream
   const raft::handle_t handle_{};

--- a/conda/recipes/libcuopt/recipe.yaml
+++ b/conda/recipes/libcuopt/recipe.yaml
@@ -29,7 +29,7 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
-        ./build.sh -n -v ${BUILD_EXTRA_FLAGS} libmps_parser libcuopt deb --allgpuarch --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+        ./build.sh -n -v ${BUILD_EXTRA_FLAGS} libmps_parser libcuopt deb --allgpuarch --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DBUILD_LP_BENCHMARKS=ON -DBUILD_MIP_BENCHMARKS=ON\"
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- `rmm::mr::owning_wrapper` / `make_owning_wrapper` were removed in [rapidsai/rmm#2286](https://github.com/rapidsai/rmm/pull/2286). `pool_memory_resource` now takes the upstream by value via `cuda::mr::any_resource` and manages its lifetime itself — construct directly, matching the pattern already used in `cpp/tests/utilities/base_fixture.hpp:39`.
- Enable `BUILD_LP_BENCHMARKS` and `BUILD_MIP_BENCHMARKS` in the libcuopt conda build so `solve_LP` (`run_pdlp.cu`) and `solve_MIP` (`run_mip.cpp`) compile on every PR. The targets have no `install(TARGETS ...)` directive, so conda and wheel artifacts are unchanged — this is compile-only coverage to catch upstream API breakage.

## Changes
- `benchmarks/linear_programming/cuopt/benchmark_helper.hpp` — drop `owning_wrapper.hpp` include; `make_async()` / `make_pool()` return by value.
- `benchmarks/linear_programming/cuopt/run_pdlp.cu` — `set_current_device_resource(memory_resource.get())` → `set_current_device_resource(memory_resource)` (pool is now a value, not a `shared_ptr`).
- `conda/recipes/libcuopt/recipe.yaml` — add `-DBUILD_LP_BENCHMARKS=ON -DBUILD_MIP_BENCHMARKS=ON` to the existing `--cmake-args`.

## CI cost
- Adds ~3–5 min cold per matrix entry (driven by the one `.cu` TU × `--allgpuarch`); ~seconds warm with sccache.
- No new packaged binaries.

## Test plan
- [ ] `conda-cpp-build` job compiles `solve_LP` and `solve_MIP` successfully.
- [ ] No new files appear in `libcuopt` / `libcuopt-tests` conda packages (verify `tests: package_contents` still matches).
- [ ] Existing `conda-cpp-tests`, wheel builds, and other jobs remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)