### PR TITLE
build: make docs build opt-in from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ HELP="$0 [<target> ...] [<flag> ...]
    --show_depr_warn - show cmake deprecation warnings
    -h               - print this text
 
- default action (no args) is to build and install 'libcuopt' then 'cuopt' (pass 'docs' explicitly to build documentation)
+ default action (no args) is to build and install 'libmps_parser', 'libcuopt', 'cuopt', 'cuopt_mps_parser', 'cuopt_server', and 'cuopt_sh_client' targets (pass 'docs' explicitly to build documentation)
 
  libcuopt build dir is: ${LIBCUOPT_BUILD_DIR}
 

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ HELP="$0 [<target> ...] [<flag> ...]
    --show_depr_warn - show cmake deprecation warnings
    -h               - print this text
 
- default action (no args) is to build and install 'libcuopt' then 'cuopt' then 'docs' targets
+ default action (no args) is to build and install 'libcuopt' then 'cuopt' (pass 'docs' explicitly to build documentation)
 
  libcuopt build dir is: ${LIBCUOPT_BUILD_DIR}
 
@@ -450,8 +450,8 @@ if buildAll || hasArg cuopt_sh_client; then
     python "${PYTHON_ARGS_FOR_INSTALL[@]}" .
 fi
 
-# Build the docs
-if buildAll || hasArg docs; then
+# Build the docs (opt-in; pass 'docs' explicitly to build)
+if hasArg docs; then
     cd "${REPODIR}"/cpp/doxygen
     doxygen Doxyfile
 


### PR DESCRIPTION
## Summary
Running bare \`./build.sh\` currently triggers a full docs build (Sphinx + Doxygen + linkcheck) as part of the default target set. Docs take significantly longer than the code itself, and devs iterating on cuOpt rarely want them. Make docs opt-in: only built when the user explicitly passes \`docs\`.

## Changes
- \`build.sh\` — change \`if buildAll || hasArg docs\` → \`if hasArg docs\`, and update the help text so \`-h\` reflects the new default.

## Impact on CI / downstream
No CI caller is affected — all callers already pass explicit targets:
- \`ci/build_docs.sh:38\` — \`./build.sh docs\` (explicit, unchanged behavior).
- \`conda/recipes/libcuopt/recipe.yaml\` — \`./build.sh ... libmps_parser libcuopt deb ...\` (explicit).
- \`conda/recipes/mps-parser/recipe.yaml\` — \`./build.sh cuopt_mps_parser\`.
- \`conda/recipes/cuopt/recipe.yaml\` — \`./build.sh cuopt\`.
- \`conda/recipes/cuopt-sh-client/recipe.yaml\` — \`./build.sh cuopt_sh_client\`.

Default \`./build.sh\` now builds and installs \`libcuopt\` then \`cuopt\` only. To build docs, run \`./build.sh docs\` (alone or alongside other targets).

## Test plan
- [ ] \`./build.sh -h\` shows updated help text.
- [ ] \`./build.sh\` builds libcuopt + cuopt and skips docs.
- [ ] \`./build.sh docs\` still builds docs.
- [ ] CI \`docs-build\` job continues to pass (uses \`ci/build_docs.sh\` which calls \`./build.sh docs\` explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)