### PR TITLE
Fix loose tolerances in the objective function integrality detection

### DIFF
--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -1349,26 +1349,29 @@ void problem_t<i_t, f_t>::set_implied_integers(const std::vector<i_t>& implied_i
 template <typename i_t, typename f_t>
 void problem_t<i_t, f_t>::recompute_objective_integrality()
 {
-  // FIXME: we do not consider implied integers here
-  // because it incorrectly considers neos-827175 as having an integer optimal.
-  // need to figure out if Papilo is producing an incorrect flag.
-  objective_is_integral = thrust::all_of(handle_ptr->get_thrust_policy(),
-                                         thrust::make_counting_iterator(0),
-                                         thrust::make_counting_iterator(n_variables),
-                                         [v = view()] __device__(i_t var_idx) -> bool {
-                                           if (v.objective_coefficients[var_idx] == 0) return true;
-                                           return v.is_integer(v.objective_coefficients[var_idx]) &&
-                                                  (v.variable_types[var_idx] == var_t::INTEGER);
-                                         });
+  objective_is_integral =
+    thrust::all_of(handle_ptr->get_thrust_policy(),
+                   thrust::make_counting_iterator(0),
+                   thrust::make_counting_iterator(n_variables),
+                   [v = view()] __device__(i_t var_idx) -> bool {
+                     if (v.objective_coefficients[var_idx] == 0) return true;
+                     // Need a tight tolerance for integrality to weed out instances like
+                     // neos-827175 with very small objective coefficients
+                     return raft::abs(round(v.objective_coefficients[var_idx]) -
+                                      v.objective_coefficients[var_idx]) <= 1e-9 &&
+                            ((v.variable_types[var_idx] == var_t::INTEGER) ||
+                             (v.var_flags[var_idx] & (i_t)VAR_IMPLIED_INTEGER));
+                   });
 
-  bool objvars_all_integral = thrust::all_of(handle_ptr->get_thrust_policy(),
-                                             thrust::make_counting_iterator(0),
-                                             thrust::make_counting_iterator(n_variables),
-                                             [v = view()] __device__(i_t var_idx) -> bool {
-                                               if (v.objective_coefficients[var_idx] == 0)
-                                                 return true;
-                                               return (v.variable_types[var_idx] == var_t::INTEGER);
-                                             });
+  bool objvars_all_integral =
+    thrust::all_of(handle_ptr->get_thrust_policy(),
+                   thrust::make_counting_iterator(0),
+                   thrust::make_counting_iterator(n_variables),
+                   [v = view()] __device__(i_t var_idx) -> bool {
+                     if (v.objective_coefficients[var_idx] == 0) return true;
+                     return (v.variable_types[var_idx] == var_t::INTEGER) ||
+                            (v.var_flags[var_idx] & (i_t)VAR_IMPLIED_INTEGER);
+                   });
   if (objvars_all_integral && !objective_is_integral) {
     auto h_objective_coefficients =
       cuopt::host_copy(objective_coefficients, handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -1349,6 +1349,8 @@ void problem_t<i_t, f_t>::set_implied_integers(const std::vector<i_t>& implied_i
 template <typename i_t, typename f_t>
 void problem_t<i_t, f_t>::recompute_objective_integrality()
 {
+  using cuopt::linear_programming::detail::is_integer;
+
   objective_is_integral =
     thrust::all_of(handle_ptr->get_thrust_policy(),
                    thrust::make_counting_iterator(0),
@@ -1357,8 +1359,7 @@ void problem_t<i_t, f_t>::recompute_objective_integrality()
                      if (v.objective_coefficients[var_idx] == 0) return true;
                      // Need a tight tolerance for integrality to weed out instances like
                      // neos-827175 with very small objective coefficients
-                     return raft::abs(round(v.objective_coefficients[var_idx]) -
-                                      v.objective_coefficients[var_idx]) <= 1e-9 &&
+                     return is_integer<f_t>(v.objective_coefficients[var_idx], 1e-9) &&
                             ((v.variable_types[var_idx] == var_t::INTEGER) ||
                              (v.var_flags[var_idx] & (i_t)VAR_IMPLIED_INTEGER));
                    });


### PR DESCRIPTION
The objective function integrality detection was relying on weak tolerances, which caused neos-827175 to be incorrectly accounted as integral and causing an incorrect solution bound to be reported. (objective coefficients were as low as 1e-5)

This PR uses a tighter 1e-9 tolerance for integrality detection in the objective function to avoid such issues.

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
