### PR TITLE
ci(docker): pin all first-party cuOpt wheels to CUOPT_VER

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -60,6 +60,9 @@ RUN \
       --no-cache-dir \
       "pyyaml" \
       "cuopt-server-${cuda_suffix}==${CUOPT_VER}" \
+      "cuopt-${cuda_suffix}==${CUOPT_VER}" \
+      "libcuopt-${cuda_suffix}==${CUOPT_VER}" \
+      "cuopt-mps-parser==${CUOPT_VER}" \
       "cuopt-sh-client==${CUOPT_VER}" && \
     python -m pip list
 


### PR DESCRIPTION
## Summary

- Pin `cuopt-${cuda_suffix}`, `libcuopt-${cuda_suffix}`, and `cuopt-mps-parser` to `${CUOPT_VER}` alongside the existing `cuopt-server` / `cuopt-sh-client` pins, so all five first-party cuOpt wheels are resolved as a coherent set in a single `pip install` pass.
- Prevents nightly Docker builds from silently pulling a mismatched `libcuopt-cu13` (which surfaced as `undefined symbol: …add_order_vehicle_match…iPKiib` at test time when `cuopt-cu13 a141` was paired with `libcuopt-cu13 a207`).

## Background

`cuopt-cu13`'s `Requires-Dist` declares `libcuopt-cu13==26.6.*,>=0.0.0a0` — a loose range. Because `libcuopt-cu13` ships as `py3-none-…` (Python-version-agnostic) while `cuopt-cu13` ships as `cp314-cp314` (Python-ABI-specific), the resolver picks the highest available `libcuopt-cu13` for any Python, but the highest `cuopt-cu13` with a matching `cp314` tag — and these can diverge when nightly cp314 builds skip versions. Pinning all first-party packages on a single install line forces a coherent set or fails fast.

The deeper fix still belongs upstream in `cuopt-cu13`'s metadata (pin `libcuopt-cu13` to the exact alpha at wheel-build time), but this PR closes the immediate hole.

## Test plan

- [ ] Build the image with `CUOPT_VER` set to a known-good nightly and confirm `pip list` shows all five packages at the same `aN`.
- [ ] Build with a known-broken pair (`CUOPT_VER` pointing to an alpha where `libcuopt-${cuda_suffix}` was not published) and confirm the build fails fast at the `pip install` step rather than producing a working-looking image that crashes at import.
- [ ] Run the routing test suite inside the resulting image and confirm `from cuopt import routing` succeeds (no undefined-symbol error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)