### PR TITLE
skill-evolution: scoped removal and references/ size escape hatch

### DIFF
--- a/skills/skill-evolution/SKILL.md
+++ b/skills/skill-evolution/SKILL.md
@@ -96,13 +96,14 @@ Skill update proposal:
   Skill: skills/<name>/SKILL.md        (or skills/<name>/assets/<file>.py)
   Type: markdown | code
   Phase: learning (scored)
+  Removal: no | yes — if yes, the user must explicitly confirm before applying
   Section: <where it goes>
   Trigger: <what happened that surfaced this>
   Score: <how it was validated — e.g. "solver returned Optimal", "test passed">
   Change: <the exact content to add or modify>
 ```
 
-Only apply after the user approves. If the user declines, do not persist.
+Only apply after the user approves. If the user declines, do not persist. If `Removal: yes`, silence is not approval — proceed only on an explicit "yes" from the user.
 
 ## Phase 2: Inference (no ground truth)
 
@@ -128,6 +129,7 @@ Skill insight (unscored):
   Skill: skills/<name>/SKILL.md
   Type: markdown | code
   Phase: inference (unscored)
+  Removal: no | yes — if yes, the user must explicitly confirm before applying
   Section: <where it goes>
   Trigger: <what happened>
   Change: <the exact content to add or modify>
@@ -234,7 +236,7 @@ A proposal may:
 - **Add** new content (gotchas, examples, table rows, subsections, code assets)
 - **Clarify** existing content (more precise wording, better examples)
 - **Correct** factual errors (wrong API name, wrong status value)
-- **Remove** existing content — only when it is stale (refers to API or behavior that no longer exists), contradicted by current code, or demonstrably wrong. The proposal must cite the evidence (e.g. "function `X` removed in commit `abc123`", "current code returns `Y`, not `Z` as documented"). Removals require an extra approval step: present the proposal with `Removal: yes` highlighted, and proceed only if the user explicitly confirms — silence does not count.
+- **Remove** existing content — only when it is stale (refers to API or behavior that no longer exists), contradicted by current code, or demonstrably wrong. The proposal must cite the evidence (e.g. "function `X` removed in commit `abc123`", "current code returns `Y`, not `Z` as documented"). Removals require an extra approval step: set `Removal: yes` in the proposal format, and proceed only if the user explicitly confirms — silence does not count.
 
 A proposal must NOT:
 - **Rewrite** existing sections wholesale

--- a/skills/skill-evolution/SKILL.md
+++ b/skills/skill-evolution/SKILL.md
@@ -77,6 +77,16 @@ Choose the target using this priority:
 
 If a gotcha affects both Python and C users but is about the solver behavior (not the API), it belongs in the common formulation skill, not in both `api-python` and `api-c`.
 
+#### Size escape hatch — push to `references/` when the target is bloated
+
+A SKILL.md that grows past ~500 lines starts paying for itself in tokens on every invocation, and readers begin skimming. Before adding new prose to a target SKILL.md, check its current size:
+
+- **Under ~400 lines** — add the content inline as usual.
+- **Approaching ~500 lines** — propose a `skills/<name>/references/<topic>.md` file with the full content, and add a one-line pointer in SKILL.md (e.g. "For warmstart edge cases, see `references/warmstart.md`"). The reference file loads only when the model needs it.
+- **A dense table or long example** — even in a small SKILL.md, prefer a `references/` file when the content is reference material (lookup tables, full code listings) rather than guidance the reader needs every time.
+
+The goal is to keep SKILL.md focused on what the model needs *every* invocation, and put detail behind pointers.
+
 ### Proposal format
 
 Present to the user as:
@@ -220,15 +230,16 @@ Before proposing, verify the learning originated from **genuine problem-solving*
 
 ### Scope limits
 
-A proposal may only:
+A proposal may:
 - **Add** new content (gotchas, examples, table rows, subsections, code assets)
 - **Clarify** existing content (more precise wording, better examples)
 - **Correct** factual errors (wrong API name, wrong status value)
+- **Remove** existing content — only when it is stale (refers to API or behavior that no longer exists), contradicted by current code, or demonstrably wrong. The proposal must cite the evidence (e.g. "function `X` removed in commit `abc123`", "current code returns `Y`, not `Z` as documented"). Removals require an extra approval step: present the proposal with `Removal: yes` highlighted, and proceed only if the user explicitly confirms — silence does not count.
 
 A proposal must NOT:
-- **Remove** existing content
 - **Rewrite** existing sections wholesale
-- **Change** the meaning of existing rules or constraints
+- **Change** the meaning of existing rules or constraints (especially safety rules)
+- **Remove** content as a way to "tidy up" or because it seems unused — only stale or wrong content qualifies
 
 ## Distillation checklist
 


### PR DESCRIPTION
## Summary
Two scope-flexibility relaxations in `skills/skill-evolution/SKILL.md`:
1. Allow proposals to **remove** content when stale, contradicted by current code, or demonstrably wrong — gated behind an explicit-confirmation approval step. Other no-removal protections (no tidy-up removals, no rewriting wholesale, no meaning changes, no safety relaxations) stay.
2. Add a size escape hatch: when a target SKILL.md is approaching ~500 lines, propose a `references/<topic>.md` file with a one-line pointer in SKILL.md instead of inline content. Keeps every-invocation context lean.

## Testing
- `./ci/utils/validate_skills.sh` passes

## Docs
- Skill content only.