### PR TITLE
mps_parser: switch ptr+size setters to std::span on mps_data_model_t

### DIFF
--- a/cpp/libmps_parser/include/mps_parser/mps_data_model.hpp
+++ b/cpp/libmps_parser/include/mps_parser/mps_data_model.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -63,44 +64,31 @@ class mps_data_model_t {
    * @note Setting before calling the solver is mandatory.
    *
    * @throws std::logic_error when an error occurs.
-   * @param[in] A_values Values of the CSR representation of the constraint matrix as a host memory
-   pointer to a floating point array of size size_values.
-   * MPS Parser copies this data.
-   * @param size_values Size of the A_values array.
-   * @param[in] A_indices Indices of the CSR representation of the constraint matrix as a host
-   memory pointer to an integer array of size size_indices.
-   * MPS Parser copies this data.
-   * @param size_indices Size of the A_indices array.
-   * @param[in] A_offsets Offsets of the CSR representation of the constraint matrix as a host
-   memory pointer to a integer array of size size_offsets.
-   * MPS Parser copies this data.
-   * @param size_offsets Size of the A_offsets array.
+   * @param[in] A_values Values of the CSR representation of the constraint matrix; host memory.
+   * The model copies this data.
+   * @param[in] A_indices Indices of the CSR representation of the constraint matrix; host memory.
+   * The model copies this data.
+   * @param[in] A_offsets Offsets of the CSR representation of the constraint matrix; host memory.
+   * The model copies this data.
    */
-  void set_csr_constraint_matrix(const f_t* A_values,
-                                 i_t size_values,
-                                 const i_t* A_indices,
-                                 i_t size_indices,
-                                 const i_t* A_offsets,
-                                 i_t size_offsets);
+  void set_csr_constraint_matrix(std::span<const f_t> A_values,
+                                 std::span<const i_t> A_indices,
+                                 std::span<const i_t> A_offsets);
 
   /**
    * @brief Set the constraint bounds (b / right-hand side) array.
    * @note Setting before calling the solver is mandatory.
    *
-   * @param[in] b Host memory pointer to a floating point array of size size.
-   * MPS Parser copies this data.
-   * @param size Size of the b array.
+   * @param[in] b Constraint bounds; host memory. The model copies this data.
    */
-  void set_constraint_bounds(const f_t* b, i_t size);
+  void set_constraint_bounds(std::span<const f_t> b);
   /**
    * @brief Set the objective coefficients (c) array.
    * @note Setting before calling the solver is mandatory.
    *
-   * @param[in] c Host memory pointer to a floating point array of size size.
-   * MPS Parser copies this data.
-   * @param size Size of the c array.
+   * @param[in] c Objective coefficients; host memory. The model copies this data.
    */
-  void set_objective_coefficients(const f_t* c, i_t size);
+  void set_objective_coefficients(std::span<const f_t> c);
   /**
    * @brief Set the scaling factor of the objective function (scaling_factor * objective_value).
    * @note Setting before calling the solver is optional, default value if 1.
@@ -120,45 +108,37 @@ class mps_data_model_t {
    * @brief Set the variables (x) lower bounds.
    * @note Setting before calling the solver is optional, default value for all is 0.
    *
-   * @param[in] variable_lower_bounds Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the variable_lower_bounds array
+   * @param[in] variable_lower_bounds Variable lower bounds; host memory. The model copies
+   * this data.
    */
-  void set_variable_lower_bounds(const f_t* variable_lower_bounds, i_t size);
+  void set_variable_lower_bounds(std::span<const f_t> variable_lower_bounds);
   /**
    * @brief Set the variables (x) upper bounds.
    * @note Setting before calling the solver is optional, default value for all is +infinity.
    *
-   * @param[in] variable_upper_bounds Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the variable_upper_bounds array.
+   * @param[in] variable_upper_bounds Variable upper bounds; host memory. The model copies
+   * this data.
    */
-  void set_variable_upper_bounds(const f_t* variable_upper_bounds, i_t size);
+  void set_variable_upper_bounds(std::span<const f_t> variable_upper_bounds);
   /**
    * @brief Set the constraints lower bounds.
    * @note Setting before calling the solver is optional if you set the row type, else it's
    * mandatory along with the upper bounds.
    *
-   * @param[in] constraint_lower_bounds Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the constraint_lower_bounds array
+   * @param[in] constraint_lower_bounds Constraint lower bounds; host memory. The model copies
+   * this data.
    */
-  void set_constraint_lower_bounds(const f_t* constraint_lower_bounds, i_t size);
+  void set_constraint_lower_bounds(std::span<const f_t> constraint_lower_bounds);
   /**
    * @brief Set the constraints upper bounds.
    * @note Setting before calling the solver is optional if you set the row type, else it's
    * mandatory along with the lower bounds.
    * If both are set, priority goes to set_constraints.
    *
-   * @param[in] constraint_upper_bounds Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the constraint_upper_bounds array
+   * @param[in] constraint_upper_bounds Constraint upper bounds; host memory. The model copies
+   * this data.
    */
-  void set_constraint_upper_bounds(const f_t* constraint_upper_bounds, i_t size);
+  void set_constraint_upper_bounds(std::span<const f_t> constraint_upper_bounds);
 
   /**
    * @brief Set the type of each row (constraint). Possible values are:
@@ -171,12 +151,9 @@ class mps_data_model_t {
    * bounds, else it's mandatory
    * If both are set, priority goes to set_constraints.
    *
-   * @param[in] row_types Host memory pointer to a character array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the row_types array
+   * @param[in] row_types Row types; host memory. The model copies this data.
    */
-  void set_row_types(const char* row_types, i_t size);
+  void set_row_types(std::span<const char> row_types);
 
   /**
    * @brief Set the name of the objective function.
@@ -223,24 +200,20 @@ class mps_data_model_t {
    *
    * @note Default value is all 0.
    *
-   * @param[in] initial_primal_solution Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the initial_primal_solution array.
+   * @param[in] initial_primal_solution Initial primal solution; host memory. The model copies
+   * this data.
    */
-  void set_initial_primal_solution(const f_t* initial_primal_solution, i_t size);
+  void set_initial_primal_solution(std::span<const f_t> initial_primal_solution);
 
   /**
    * @brief Set an initial dual solution.
    *
    * @note Default value is all 0.
    *
-   * @param[in] initial_dual_solution Host memory pointer to a floating point array of
-   * size size.
-   * MPS Parser copies this data.
-   * @param size Size of the initial_dual_solution array.
+   * @param[in] initial_dual_solution Initial dual solution; host memory. The model copies
+   * this data.
    */
-  void set_initial_dual_solution(const f_t* initial_dual_solution, i_t size);
+  void set_initial_dual_solution(std::span<const f_t> initial_dual_solution);
 
   /**
    * @brief Set the quadratic objective matrix (Q) in CSR format for QPS files.
@@ -248,19 +221,16 @@ class mps_data_model_t {
    * @note This is used for quadratic programming problems where the objective
    * function contains quadratic terms: (1/2) * x^T * Q * x + c^T * x
    *
-   * @param[in] Q_values Values of the CSR representation of the quadratic objective matrix
-   * @param size_values Size of the Q_values array
-   * @param[in] Q_indices Indices of the CSR representation of the quadratic objective matrix
-   * @param size_indices Size of the Q_indices array
-   * @param[in] Q_offsets Offsets of the CSR representation of the quadratic objective matrix
-   * @param size_offsets Size of the Q_offsets array
+   * @param[in] Q_values Values of the CSR representation of the quadratic objective matrix; host
+   * memory. The model copies this data.
+   * @param[in] Q_indices Indices of the CSR representation of the quadratic objective matrix; host
+   * memory. The model copies this data.
+   * @param[in] Q_offsets Offsets of the CSR representation of the quadratic objective matrix; host
+   * memory. The model copies this data.
    */
-  void set_quadratic_objective_matrix(const f_t* Q_values,
-                                      i_t size_values,
-                                      const i_t* Q_indices,
-                                      i_t size_indices,
-                                      const i_t* Q_offsets,
-                                      i_t size_offsets);
+  void set_quadratic_objective_matrix(std::span<const f_t> Q_values,
+                                      std::span<const i_t> Q_indices,
+                                      std::span<const i_t> Q_offsets);
 
   /**
    * @brief One quadratic constraint as parsed from MPS sections (ROWS, COLUMNS, RHS, QCMATRIX).
@@ -288,8 +258,7 @@ class mps_data_model_t {
 
   /**
    * @brief Append one complete quadratic constraint (row + linear + rhs + quadratic Q).
-   * @note Pointer+size signature is kept for current CI/toolchain compatibility; `std::span`
-   *       can be revisited later when compatibility constraints are lifted.
+   * @note All span inputs are host memory; the model copies this data.
    * @param linear_values, linear_indices Same nnz; can be empty for a purely quadratic row (rare).
    * @param quadratic_values, quadratic_indices CSR nnz; may be empty if Q is empty.
    * @param quadratic_offsets CSR row starts; must be non-empty.
@@ -299,17 +268,12 @@ class mps_data_model_t {
   void append_quadratic_constraint(i_t constraint_row_index,
                                    const std::string& constraint_row_name,
                                    char constraint_row_type,
-                                   const f_t* linear_values,
-                                   i_t linear_nnz,
-                                   const i_t* linear_indices,
-                                   i_t linear_indices_nnz,
+                                   std::span<const f_t> linear_values,
+                                   std::span<const i_t> linear_indices,
                                    f_t rhs_value,
-                                   const f_t* quadratic_values,
-                                   i_t quadratic_size_values,
-                                   const i_t* quadratic_indices,
-                                   i_t quadratic_size_indices,
-                                   const i_t* quadratic_offsets,
-                                   i_t quadratic_size_offsets);
+                                   std::span<const f_t> quadratic_values,
+                                   std::span<const i_t> quadratic_indices,
+                                   std::span<const i_t> quadratic_offsets);
 
   const std::vector<quadratic_constraint_t>& get_quadratic_constraints() const;
 

--- a/cpp/libmps_parser/src/mps_data_model.cpp
+++ b/cpp/libmps_parser/src/mps_data_model.cpp
@@ -14,55 +14,29 @@
 namespace cuopt::mps_parser {
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_csr_constraint_matrix(const f_t* A_values,
-                                                           i_t size_values,
-                                                           const i_t* A_indices,
-                                                           i_t size_indices,
-                                                           const i_t* A_offsets,
-                                                           i_t size_offsets)
+void mps_data_model_t<i_t, f_t>::set_csr_constraint_matrix(std::span<const f_t> A_values,
+                                                           std::span<const i_t> A_indices,
+                                                           std::span<const i_t> A_offsets)
 {
-  if (size_values != 0) {
-    mps_parser_expects(
-      A_values != nullptr, error_type_t::ValidationError, "A_values cannot be null");
-  }
-  A_.resize(size_values);
-  std::copy(A_values, A_values + size_values, A_.data());
-
-  if (size_indices != 0) {
-    mps_parser_expects(
-      A_indices != nullptr, error_type_t::ValidationError, "A_indices cannot be null");
-  }
-  A_indices_.resize(size_indices);
-  std::copy(A_indices, A_indices + size_indices, A_indices_.data());
-
   mps_parser_expects(
-    A_offsets != nullptr, error_type_t::ValidationError, "A_offsets cannot be null");
-  mps_parser_expects(
-    size_offsets > 0, error_type_t::ValidationError, "size_offsets cannot be empty");
-  A_offsets_.resize(size_offsets);
-  std::copy(A_offsets, A_offsets + size_offsets, A_offsets_.data());
+    !A_offsets.empty(), error_type_t::ValidationError, "A_offsets cannot be empty");
+  A_.assign(A_values.begin(), A_values.end());
+  A_indices_.assign(A_indices.begin(), A_indices.end());
+  A_offsets_.assign(A_offsets.begin(), A_offsets.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_constraint_bounds(const f_t* b, i_t size)
+void mps_data_model_t<i_t, f_t>::set_constraint_bounds(std::span<const f_t> b)
 {
-  if (size != 0) {
-    mps_parser_expects(b != nullptr, error_type_t::ValidationError, "b cannot be null");
-  }
-  b_.resize(size);
-  n_constraints_ = size;
-  std::copy(b, b + size, b_.data());
+  b_.assign(b.begin(), b.end());
+  n_constraints_ = static_cast<i_t>(b.size());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_objective_coefficients(const f_t* c, i_t size)
+void mps_data_model_t<i_t, f_t>::set_objective_coefficients(std::span<const f_t> c)
 {
-  if (size != 0) {
-    mps_parser_expects(c != nullptr, error_type_t::ValidationError, "c cannot be null");
-  }
-  c_.resize(size);
-  n_vars_ = size;
-  std::copy(c, c + size, c_.data());
+  c_.assign(c.begin(), c.end());
+  n_vars_ = static_cast<i_t>(c.size());
 }
 
 template <typename i_t, typename f_t>
@@ -78,67 +52,38 @@ void mps_data_model_t<i_t, f_t>::set_objective_offset(f_t objective_offset)
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_variable_lower_bounds(const f_t* variable_lower_bounds,
-                                                           i_t size)
+void mps_data_model_t<i_t, f_t>::set_variable_lower_bounds(
+  std::span<const f_t> variable_lower_bounds)
 {
-  if (size != 0) {
-    mps_parser_expects(variable_lower_bounds != nullptr,
-                       error_type_t::ValidationError,
-                       "variable_lower_bounds cannot be null");
-  }
-  variable_lower_bounds_.resize(size);
-  std::copy(variable_lower_bounds, variable_lower_bounds + size, variable_lower_bounds_.data());
+  variable_lower_bounds_.assign(variable_lower_bounds.begin(), variable_lower_bounds.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_variable_upper_bounds(const f_t* variable_upper_bounds,
-                                                           i_t size)
+void mps_data_model_t<i_t, f_t>::set_variable_upper_bounds(
+  std::span<const f_t> variable_upper_bounds)
 {
-  if (size != 0) {
-    mps_parser_expects(variable_upper_bounds != nullptr,
-                       error_type_t::ValidationError,
-                       "variable_upper_bounds cannot be null");
-  }
-  variable_upper_bounds_.resize(size);
-  std::copy(variable_upper_bounds, variable_upper_bounds + size, variable_upper_bounds_.data());
+  variable_upper_bounds_.assign(variable_upper_bounds.begin(), variable_upper_bounds.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_constraint_lower_bounds(const f_t* constraint_lower_bounds,
-                                                             i_t size)
+void mps_data_model_t<i_t, f_t>::set_constraint_lower_bounds(
+  std::span<const f_t> constraint_lower_bounds)
 {
-  if (size != 0) {
-    mps_parser_expects(constraint_lower_bounds != nullptr,
-                       error_type_t::ValidationError,
-                       "constraint_lower_bounds cannot be null");
-  }
-  constraint_lower_bounds_.resize(size);
-  n_constraints_ = size;
-  std::copy(
-    constraint_lower_bounds, constraint_lower_bounds + size, constraint_lower_bounds_.data());
+  constraint_lower_bounds_.assign(constraint_lower_bounds.begin(), constraint_lower_bounds.end());
+  n_constraints_ = static_cast<i_t>(constraint_lower_bounds.size());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_constraint_upper_bounds(const f_t* constraint_upper_bounds,
-                                                             i_t size)
+void mps_data_model_t<i_t, f_t>::set_constraint_upper_bounds(
+  std::span<const f_t> constraint_upper_bounds)
 {
-  if (size != 0) {
-    mps_parser_expects(constraint_upper_bounds != nullptr,
-                       error_type_t::ValidationError,
-                       "constraint_upper_bounds cannot be null");
-  }
-  constraint_upper_bounds_.resize(size);
-  std::copy(
-    constraint_upper_bounds, constraint_upper_bounds + size, constraint_upper_bounds_.data());
+  constraint_upper_bounds_.assign(constraint_upper_bounds.begin(), constraint_upper_bounds.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_row_types(const char* row_types, i_t size)
+void mps_data_model_t<i_t, f_t>::set_row_types(std::span<const char> row_types)
 {
-  mps_parser_expects(
-    row_types != nullptr, error_type_t::ValidationError, "row_types cannot be null");
-  row_types_.resize(size);
-  std::copy(row_types, row_types + size, row_types_.data());
+  row_types_.assign(row_types.begin(), row_types.end());
 }
 
 template <typename i_t, typename f_t>
@@ -168,73 +113,41 @@ void mps_data_model_t<i_t, f_t>::set_row_names(const std::vector<std::string>& r
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_initial_primal_solution(const f_t* initial_primal_solution,
-                                                             i_t size)
+void mps_data_model_t<i_t, f_t>::set_initial_primal_solution(
+  std::span<const f_t> initial_primal_solution)
 {
-  mps_parser_expects(initial_primal_solution != nullptr,
-                     error_type_t::ValidationError,
-                     "initial_primal_solution cannot be null");
-  initial_primal_solution_.resize(size);
-  std::copy(
-    initial_primal_solution, initial_primal_solution + size, initial_primal_solution_.data());
+  initial_primal_solution_.assign(initial_primal_solution.begin(), initial_primal_solution.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_initial_dual_solution(const f_t* initial_dual_solution,
-                                                           i_t size)
+void mps_data_model_t<i_t, f_t>::set_initial_dual_solution(
+  std::span<const f_t> initial_dual_solution)
 {
-  mps_parser_expects(initial_dual_solution != nullptr,
-                     error_type_t::ValidationError,
-                     "initial_dual_solution cannot be null");
-  initial_dual_solution_.resize(size);
-  std::copy(initial_dual_solution, initial_dual_solution + size, initial_dual_solution_.data());
+  initial_dual_solution_.assign(initial_dual_solution.begin(), initial_dual_solution.end());
 }
 
 template <typename i_t, typename f_t>
-void mps_data_model_t<i_t, f_t>::set_quadratic_objective_matrix(const f_t* Q_values,
-                                                                i_t size_values,
-                                                                const i_t* Q_indices,
-                                                                i_t size_indices,
-                                                                const i_t* Q_offsets,
-                                                                i_t size_offsets)
+void mps_data_model_t<i_t, f_t>::set_quadratic_objective_matrix(std::span<const f_t> Q_values,
+                                                                std::span<const i_t> Q_indices,
+                                                                std::span<const i_t> Q_offsets)
 {
-  if (size_values != 0) {
-    mps_parser_expects(
-      Q_values != nullptr, error_type_t::ValidationError, "Q_values cannot be null");
-  }
-  Q_objective_values_.resize(size_values);
-  std::copy(Q_values, Q_values + size_values, Q_objective_values_.data());
-
-  if (size_indices != 0) {
-    mps_parser_expects(
-      Q_indices != nullptr, error_type_t::ValidationError, "Q_indices cannot be null");
-  }
-  Q_objective_indices_.resize(size_indices);
-  std::copy(Q_indices, Q_indices + size_indices, Q_objective_indices_.data());
-
   mps_parser_expects(
-    Q_offsets != nullptr, error_type_t::ValidationError, "Q_offsets cannot be null");
-  mps_parser_expects(
-    size_offsets > 0, error_type_t::ValidationError, "size_offsets cannot be empty");
-  Q_objective_offsets_.resize(size_offsets);
-  std::copy(Q_offsets, Q_offsets + size_offsets, Q_objective_offsets_.data());
+    !Q_offsets.empty(), error_type_t::ValidationError, "Q_offsets cannot be empty");
+  Q_objective_values_.assign(Q_values.begin(), Q_values.end());
+  Q_objective_indices_.assign(Q_indices.begin(), Q_indices.end());
+  Q_objective_offsets_.assign(Q_offsets.begin(), Q_offsets.end());
 }
 
 template <typename i_t, typename f_t>
 void mps_data_model_t<i_t, f_t>::append_quadratic_constraint(i_t constraint_row_index,
                                                              const std::string& constraint_row_name,
                                                              char constraint_row_type,
-                                                             const f_t* linear_values,
-                                                             i_t linear_nnz,
-                                                             const i_t* linear_indices,
-                                                             i_t linear_indices_nnz,
+                                                             std::span<const f_t> linear_values,
+                                                             std::span<const i_t> linear_indices,
                                                              f_t rhs_value,
-                                                             const f_t* quadratic_values,
-                                                             i_t quadratic_size_values,
-                                                             const i_t* quadratic_indices,
-                                                             i_t quadratic_size_indices,
-                                                             const i_t* quadratic_offsets,
-                                                             i_t quadratic_size_offsets)
+                                                             std::span<const f_t> quadratic_values,
+                                                             std::span<const i_t> quadratic_indices,
+                                                             std::span<const i_t> quadratic_offsets)
 {
   mps_parser_expects(constraint_row_index >= 0,
                      error_type_t::ValidationError,
@@ -246,58 +159,23 @@ void mps_data_model_t<i_t, f_t>::append_quadratic_constraint(i_t constraint_row_
                      "Only 'L' is supported for convex quadratic constraints.",
                      constraint_row_type);
 
-  mps_parser_expects(linear_nnz == linear_indices_nnz,
+  mps_parser_expects(linear_values.size() == linear_indices.size(),
                      error_type_t::ValidationError,
                      "linear_values and linear_indices must have the same nnz count");
-  if (linear_nnz != 0) {
-    mps_parser_expects(linear_values != nullptr && linear_indices != nullptr,
-                       error_type_t::ValidationError,
-                       "linear_values and linear_indices cannot be null when linear_nnz > 0");
-  }
 
-  if (quadratic_size_values != 0) {
-    mps_parser_expects(quadratic_values != nullptr,
-                       error_type_t::ValidationError,
-                       "quadratic_values cannot be null");
-  }
-  mps_parser_expects(quadratic_offsets != nullptr,
-                     error_type_t::ValidationError,
-                     "quadratic_offsets cannot be null");
-  if (quadratic_size_indices != 0) {
-    mps_parser_expects(quadratic_indices != nullptr,
-                       error_type_t::ValidationError,
-                       "quadratic_indices cannot be null");
-  }
-  mps_parser_expects(quadratic_size_offsets > 0,
-                     error_type_t::ValidationError,
-                     "quadratic_size_offsets cannot be empty");
+  mps_parser_expects(
+    !quadratic_offsets.empty(), error_type_t::ValidationError, "quadratic_offsets cannot be empty");
 
   quadratic_constraint_t qc;
   qc.constraint_row_index = constraint_row_index;
   qc.constraint_row_name  = constraint_row_name;
   qc.constraint_row_type  = constraint_row_type;
   qc.rhs_value            = rhs_value;
-
-  qc.linear_values.resize(linear_nnz);
-  qc.linear_indices.resize(linear_nnz);
-  if (linear_nnz > 0) {
-    std::copy(linear_values, linear_values + linear_nnz, qc.linear_values.data());
-    std::copy(linear_indices, linear_indices + linear_nnz, qc.linear_indices.data());
-  }
-
-  qc.quadratic_values.resize(quadratic_size_values);
-  if (quadratic_size_values > 0) {
-    std::copy(
-      quadratic_values, quadratic_values + quadratic_size_values, qc.quadratic_values.data());
-  }
-  qc.quadratic_indices.resize(quadratic_size_indices);
-  if (quadratic_size_indices > 0) {
-    std::copy(
-      quadratic_indices, quadratic_indices + quadratic_size_indices, qc.quadratic_indices.data());
-  }
-  qc.quadratic_offsets.resize(quadratic_size_offsets);
-  std::copy(
-    quadratic_offsets, quadratic_offsets + quadratic_size_offsets, qc.quadratic_offsets.data());
+  qc.linear_values.assign(linear_values.begin(), linear_values.end());
+  qc.linear_indices.assign(linear_indices.begin(), linear_indices.end());
+  qc.quadratic_values.assign(quadratic_values.begin(), quadratic_values.end());
+  qc.quadratic_indices.assign(quadratic_indices.begin(), quadratic_indices.end());
+  qc.quadratic_offsets.assign(quadratic_offsets.begin(), quadratic_offsets.end());
 
   quadratic_constraints_.push_back(std::move(qc));
 }

--- a/cpp/libmps_parser/src/mps_parser.cpp
+++ b/cpp/libmps_parser/src/mps_parser.cpp
@@ -309,12 +309,7 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
       h_offsets.push_back(static_cast<i_t>(h_indices.size()));
     }
 
-    problem.set_csr_constraint_matrix(h_values.data(),
-                                      h_values.size(),
-                                      h_indices.data(),
-                                      h_indices.size(),
-                                      h_offsets.data(),
-                                      h_offsets.size());
+    problem.set_csr_constraint_matrix(h_values, h_indices, h_offsets);
 
     mps_parser_expects(static_cast<size_t>(num_linear_rows) + 1 == h_offsets.size(),
                        error_type_t::ValidationError,
@@ -346,16 +341,16 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
   for (i_t i = 0; i < (i_t)b_values.size(); ++i) {
     if (!is_quadratic_row(i)) { b_compacted.push_back(b_values[i]); }
   }
-  problem.set_constraint_bounds(b_compacted.data(), static_cast<i_t>(b_compacted.size()));
-  problem.set_objective_coefficients(c_values.data(), c_values.size());
+  problem.set_constraint_bounds(b_compacted);
+  problem.set_objective_coefficients(c_values);
 
   // Set offset and scaling factor of objective function
   problem.set_objective_scaling_factor(objective_scaling_factor_value);
   problem.set_objective_offset(objective_offset_value);
 
   // Set lower and upper bounds
-  problem.set_variable_lower_bounds(variable_lower_bounds.data(), variable_lower_bounds.size());
-  problem.set_variable_upper_bounds(variable_upper_bounds.data(), variable_upper_bounds.size());
+  problem.set_variable_lower_bounds(variable_lower_bounds);
+  problem.set_variable_upper_bounds(variable_upper_bounds);
 
   mps_parser_expects(
     (problem.get_variable_lower_bounds().size() == problem.get_variable_upper_bounds().size()) &&
@@ -445,10 +440,8 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
         !std::isnan(h_constraint_upper_bounds[r]), error_type_t::ValidationError, "Cannot be nan");
     }
 
-    problem.set_constraint_lower_bounds(h_constraint_lower_bounds.data(),
-                                        h_constraint_lower_bounds.size());
-    problem.set_constraint_upper_bounds(h_constraint_upper_bounds.data(),
-                                        h_constraint_upper_bounds.size());
+    problem.set_constraint_lower_bounds(h_constraint_lower_bounds);
+    problem.set_constraint_upper_bounds(h_constraint_upper_bounds);
 
     mps_parser_expects(
       (problem.get_constraint_lower_bounds().size() ==
@@ -543,12 +536,8 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
       quadobj_entries, num_vars_for_quad, num_vars_for_quad, true, k_mps_quad_half_scale);
 
     // Use optimized double transpose method - O(m+n+nnz) instead of O(nnz*log(nnz))
-    problem.set_quadratic_objective_matrix(csr_result.values.data(),
-                                           csr_result.values.size(),
-                                           csr_result.indices.data(),
-                                           csr_result.indices.size(),
-                                           csr_result.offsets.data(),
-                                           csr_result.offsets.size());
+    problem.set_quadratic_objective_matrix(
+      csr_result.values, csr_result.indices, csr_result.offsets);
   } else if (!qmatrix_entries.empty()) {
     // Convert quadratic objective entries to CSR format using double transpose
     // QMATRIX stores full symmetric matrix
@@ -557,12 +546,8 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
       qmatrix_entries, num_vars_for_quad, num_vars_for_quad, false, k_mps_quad_half_scale);
 
     // Use optimized double transpose method - O(m+n+nnz) instead of O(nnz*log(nnz))
-    problem.set_quadratic_objective_matrix(csr_result.values.data(),
-                                           csr_result.values.size(),
-                                           csr_result.indices.data(),
-                                           csr_result.indices.size(),
-                                           csr_result.offsets.data(),
-                                           csr_result.offsets.size());
+    problem.set_quadratic_objective_matrix(
+      csr_result.values, csr_result.indices, csr_result.offsets);
   }
 
   // QCMATRIX: one symmetric Q per constraint row (no extra ½ factor vs file coeffs).
@@ -581,17 +566,12 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
     problem.append_quadratic_constraint(linear_row_count + quadratic_row_id,
                                         row_names[row_id],
                                         static_cast<char>(row_types[row_id]),
-                                        A_values[row_id].data(),
-                                        static_cast<i_t>(A_values[row_id].size()),
-                                        A_indices[row_id].data(),
-                                        static_cast<i_t>(A_indices[row_id].size()),
+                                        A_values[row_id],
+                                        A_indices[row_id],
                                         b_values[row_id],
-                                        csr_result.values.data(),
-                                        static_cast<i_t>(csr_result.values.size()),
-                                        csr_result.indices.data(),
-                                        static_cast<i_t>(csr_result.indices.size()),
-                                        csr_result.offsets.data(),
-                                        static_cast<i_t>(csr_result.offsets.size()));
+                                        csr_result.values,
+                                        csr_result.indices,
+                                        csr_result.offsets);
     ++quadratic_row_id;
   }
 
@@ -607,18 +587,14 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
       }
     }
     problem.set_row_names(std::move(linear_row_names));
-    if (!row_types_linear.empty()) {
-      problem.set_row_types(row_types_linear.data(), static_cast<i_t>(row_types_linear.size()));
-    }
+    problem.set_row_types(row_types_linear);
   } else {
     std::vector<char> row_types_host(row_types.size());
     for (size_t i = 0; i < row_types.size(); ++i) {
       row_types_host[i] = static_cast<char>(row_types[i]);
     }
     problem.set_row_names(std::move(row_names));
-    if (!row_types_host.empty()) {
-      problem.set_row_types(row_types_host.data(), static_cast<i_t>(row_types_host.size()));
-    }
+    problem.set_row_types(row_types_host);
   }
 }
 

--- a/cpp/libmps_parser/tests/mps_parser_test.cpp
+++ b/cpp/libmps_parser/tests/mps_parser_test.cpp
@@ -904,12 +904,7 @@ TEST(qps_parser, quadratic_objective_basic)
   std::vector<int> Q_indices   = {0, 1, 0, 1};
   std::vector<int> Q_offsets   = {0, 2, 4};  // CSR offsets
 
-  model.set_quadratic_objective_matrix(Q_values.data(),
-                                       Q_values.size(),
-                                       Q_indices.data(),
-                                       Q_indices.size(),
-                                       Q_offsets.data(),
-                                       Q_offsets.size());
+  model.set_quadratic_objective_matrix(Q_values, Q_indices, Q_offsets);
 
   // Verify the data was stored correctly
   EXPECT_TRUE(model.has_quadratic_objective());
@@ -946,17 +941,12 @@ TEST(qps_parser, qcmatrix_append_api)
   model.append_quadratic_constraint(0,
                                     "QC0",
                                     'L',
-                                    qc0_linear_values.data(),
-                                    qc0_linear_values.size(),
-                                    qc0_linear_indices.data(),
-                                    qc0_linear_indices.size(),
+                                    qc0_linear_values,
+                                    qc0_linear_indices,
                                     5.0,
-                                    qc0_values.data(),
-                                    qc0_values.size(),
-                                    qc0_indices.data(),
-                                    qc0_indices.size(),
-                                    qc0_offsets.data(),
-                                    qc0_offsets.size());
+                                    qc0_values,
+                                    qc0_indices,
+                                    qc0_offsets);
 
   // QC1: [[4, 1], [1, 6]]
   const std::vector<double> qc1_values        = {4.0, 1.0, 1.0, 6.0};
@@ -967,17 +957,12 @@ TEST(qps_parser, qcmatrix_append_api)
   model.append_quadratic_constraint(1,
                                     "QC1",
                                     'L',
-                                    qc1_linear_values.data(),
-                                    qc1_linear_values.size(),
-                                    qc1_linear_indices.data(),
-                                    qc1_linear_indices.size(),
+                                    qc1_linear_values,
+                                    qc1_linear_indices,
                                     10.0,
-                                    qc1_values.data(),
-                                    qc1_values.size(),
-                                    qc1_indices.data(),
-                                    qc1_indices.size(),
-                                    qc1_offsets.data(),
-                                    qc1_offsets.size());
+                                    qc1_values,
+                                    qc1_indices,
+                                    qc1_offsets);
 
   ASSERT_TRUE(model.has_quadratic_constraints());
   const auto& qcs = model.get_quadratic_constraints();

--- a/cpp/src/branch_and_bound/pseudo_costs.cpp
+++ b/cpp/src/branch_and_bound/pseudo_costs.cpp
@@ -569,10 +569,13 @@ static cuopt::mps_parser::mps_data_model_t<i_t, f_t> simplex_problem_to_mps_data
 
   // Set CSR constraint matrix
   mps_model.set_csr_constraint_matrix(
-    csr_A.x.data(), nz, csr_A.j.data(), nz, csr_A.row_start.data(), m + 1);
+    std::span<const f_t>{csr_A.x.data(), static_cast<size_t>(nz)},
+    std::span<const i_t>{csr_A.j.data(), static_cast<size_t>(nz)},
+    std::span<const i_t>{csr_A.row_start.data(), static_cast<size_t>(m + 1)});
 
   // Set objective coefficients
-  mps_model.set_objective_coefficients(lp.objective.data(), n);
+  mps_model.set_objective_coefficients(
+    std::span<const f_t>{lp.objective.data(), static_cast<size_t>(n)});
 
   // The LP is already in minimization form (objective negated for max problems).
   // Pass identity scaling so PDLP returns the raw DS-space objective directly.
@@ -580,8 +583,10 @@ static cuopt::mps_parser::mps_data_model_t<i_t, f_t> simplex_problem_to_mps_data
   mps_model.set_objective_offset(f_t(0.0));
 
   // Set variable bounds
-  mps_model.set_variable_lower_bounds(lp.lower.data(), n);
-  mps_model.set_variable_upper_bounds(lp.upper.data(), n);
+  mps_model.set_variable_lower_bounds(
+    std::span<const f_t>{lp.lower.data(), static_cast<size_t>(n)});
+  mps_model.set_variable_upper_bounds(
+    std::span<const f_t>{lp.upper.data(), static_cast<size_t>(n)});
 
   // Convert row sense and RHS to constraint bounds
   std::vector<f_t> constraint_lower(m);
@@ -629,8 +634,8 @@ static cuopt::mps_parser::mps_data_model_t<i_t, f_t> simplex_problem_to_mps_data
     }
   }
 
-  mps_model.set_constraint_lower_bounds(constraint_lower.data(), m);
-  mps_model.set_constraint_upper_bounds(constraint_upper.data(), m);
+  mps_model.set_constraint_lower_bounds(constraint_lower);
+  mps_model.set_constraint_upper_bounds(constraint_upper);
   mps_model.set_maximize(false);
 
   return mps_model;

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -165,7 +165,7 @@ TEST(pdlp_class, run_double_initial_solution)
 
   std::vector<double> inital_primal_sol(op_problem.get_n_variables());
   std::fill(inital_primal_sol.begin(), inital_primal_sol.end(), 1.0);
-  op_problem.set_initial_primal_solution(inital_primal_sol.data(), inital_primal_sol.size());
+  op_problem.set_initial_primal_solution(inital_primal_sol);
 
   auto solver_settings   = pdlp_solver_settings_t<int, double>{};
   solver_settings.method = cuopt::linear_programming::method_t::PDLP;

--- a/cpp/tests/mip/cuts_test.cu
+++ b/cpp/tests/mip/cuts_test.cu
@@ -54,24 +54,19 @@ mps_parser::mps_data_model_t<int, double> create_pairwise_triangle_set_packing_p
   std::vector<int> offsets         = {0, 2, 4, 6};
   std::vector<int> indices         = {0, 1, 1, 2, 0, 2};
   std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
   std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
   std::vector<double> objective_coefficients = {-1.0, -1.0, -1.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
   std::vector<char> variable_types = {'I', 'I', 'I'};
   problem.set_variable_types(variable_types);
   problem.set_maximize(false);
@@ -86,24 +81,19 @@ mps_parser::mps_data_model_t<int, double> create_pairwise_triangle_with_isolated
   std::vector<int> offsets         = {0, 2, 4, 6};
   std::vector<int> indices         = {0, 1, 1, 2, 0, 2};
   std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
   std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
   std::vector<double> objective_coefficients = {-1.0, -1.0, -1.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
   std::vector<char> variable_types = {'I', 'I', 'I', 'I'};
   problem.set_variable_types(variable_types);
   problem.set_maximize(false);
@@ -118,23 +108,18 @@ mps_parser::mps_data_model_t<int, double> create_binary_continuous_mixed_conflic
   std::vector<int> offsets         = {0, 2, 4};
   std::vector<int> indices         = {0, 1, 0, 2};
   std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
   std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
   std::vector<double> objective_coefficients = {0.0, 0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
   std::vector<char> variable_types = {'I', 'C', 'I'};
   problem.set_variable_types(variable_types);
   problem.set_maximize(false);
@@ -149,22 +134,17 @@ mps_parser::mps_data_model_t<int, double> create_near_binary_bound_conflict_prob
   std::vector<int> offsets         = {0, 2};
   std::vector<int> indices         = {0, 1};
   std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {1.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
   std::vector<double> var_lower_bounds = {0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 0.9999999};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
   std::vector<double> objective_coefficients = {0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
   std::vector<char> variable_types = {'I', 'I'};
   problem.set_variable_types(variable_types);
   problem.set_maximize(false);
@@ -180,22 +160,17 @@ mps_parser::mps_data_model_t<int, double> create_weighted_addtl_conflict_problem
   std::vector<int> offsets         = {0, 4};
   std::vector<int> indices         = {0, 1, 2, 3};
   std::vector<double> coefficients = {1.0, 2.0, 3.0, 4.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {5.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
   std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
   std::vector<double> objective_coefficients = {0.0, 0.0, 0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
   std::vector<char> variable_types = {'I', 'I', 'I', 'I'};
   problem.set_variable_types(variable_types);
   problem.set_maximize(false);
@@ -781,18 +756,11 @@ mps_parser::mps_data_model_t<int, double> append_literal_cut_prefix_to_lp_model(
     row_names.push_back("literal_cut_" + std::to_string(cut_idx));
   }
 
-  model_with_cuts.set_csr_constraint_matrix(matrix_values.data(),
-                                            matrix_values.size(),
-                                            matrix_indices.data(),
-                                            matrix_indices.size(),
-                                            matrix_offsets.data(),
-                                            matrix_offsets.size());
-  if (!constraint_rhs.empty()) {
-    model_with_cuts.set_constraint_bounds(constraint_rhs.data(), constraint_rhs.size());
-  }
-  model_with_cuts.set_constraint_lower_bounds(constraint_lbs.data(), constraint_lbs.size());
-  model_with_cuts.set_constraint_upper_bounds(constraint_ubs.data(), constraint_ubs.size());
-  if (!row_types.empty()) { model_with_cuts.set_row_types(row_types.data(), row_types.size()); }
+  model_with_cuts.set_csr_constraint_matrix(matrix_values, matrix_indices, matrix_offsets);
+  if (!constraint_rhs.empty()) { model_with_cuts.set_constraint_bounds(constraint_rhs); }
+  model_with_cuts.set_constraint_lower_bounds(constraint_lbs);
+  model_with_cuts.set_constraint_upper_bounds(constraint_ubs);
+  if (!row_types.empty()) { model_with_cuts.set_row_types(row_types); }
   model_with_cuts.set_row_names(row_names);
   return model_with_cuts;
 }
@@ -859,30 +827,25 @@ mps_parser::mps_data_model_t<int, double> create_cuts_problem_1()
   std::vector<int> offsets         = {0, 2, 4, 6};
   std::vector<int> indices         = {0, 1, 0, 1, 0, 1};
   std::vector<double> coefficients = {-1.0, 2.0, 5.0, 1.0, -2.0, -2.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {4.0, 20.0, -7.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower_bounds = {0.0, 0.0};
   std::vector<double> var_upper_bounds = {10.0, 10.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
 
   // Set objective coefficients (minimize -7*x1 -2*x2)
   std::vector<double> objective_coefficients = {-7.0, -2.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
 
   // Set variable types
   std::vector<char> variable_types = {'I', 'I'};
@@ -928,29 +891,24 @@ mps_parser::mps_data_model_t<int, double> create_cuts_problem_2()
   std::vector<int> offsets         = {0, 3, 6};
   std::vector<int> indices         = {0, 1, 2, 0, 1, 2};
   std::vector<double> coefficients = {774.0, 76.0, 42.0, 67.0, 27.0, 53.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
                                       -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {875.0, 875.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
   std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
 
   // Set objective coefficients (minimize -86*y1 -4*y2 -40*y3)
   std::vector<double> objective_coefficients = {-86.0, -4.0, -40.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
 
   // Set variable types
   std::vector<char> variable_types = {'I', 'I', 'I'};

--- a/cpp/tests/mip/doc_example_test.cu
+++ b/cpp/tests/mip/doc_example_test.cu
@@ -36,29 +36,24 @@ mps_parser::mps_data_model_t<int, double> create_doc_example_problem()
   std::vector<int> offsets         = {0, 2, 4};
   std::vector<int> indices         = {0, 1, 0, 1};
   std::vector<double> coefficients = {2.0, 4.0, 3.0, 2.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {230.0, -std::numeric_limits<double>::infinity()};
   std::vector<double> upper_bounds = {std::numeric_limits<double>::infinity(), 190.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower_bounds = {0.0, 0.0};
   std::vector<double> var_upper_bounds = {std::numeric_limits<double>::infinity(),
                                           std::numeric_limits<double>::infinity()};
-  problem.set_variable_lower_bounds(var_lower_bounds.data(), var_lower_bounds.size());
-  problem.set_variable_upper_bounds(var_upper_bounds.data(), var_upper_bounds.size());
+  problem.set_variable_lower_bounds(var_lower_bounds);
+  problem.set_variable_upper_bounds(var_upper_bounds);
 
   // Set objective coefficients (maximize 5x + 3y)
   std::vector<double> objective_coefficients = {5.0, 3.0};
-  problem.set_objective_coefficients(objective_coefficients.data(), objective_coefficients.size());
+  problem.set_objective_coefficients(objective_coefficients);
 
   // Set variable types (x is integer, y is continuous)
   std::vector<char> variable_types = {'I', 'C'};  // 'I' for Integer, 'C' for Continuous

--- a/cpp/tests/mip/server_test.cu
+++ b/cpp/tests/mip/server_test.cu
@@ -34,28 +34,23 @@ mps_parser::mps_data_model_t<int, double> create_std_lp_problem()
   std::vector<int> offsets         = {0, 2};
   std::vector<int> indices         = {0, 1};
   std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {0.0};
   std::vector<double> upper_bounds = {5000.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower = {0.0, 0.0};
   std::vector<double> var_upper = {3000.0, 5000.0};
-  problem.set_variable_lower_bounds(var_lower.data(), var_lower.size());
-  problem.set_variable_upper_bounds(var_upper.data(), var_upper.size());
+  problem.set_variable_lower_bounds(var_lower);
+  problem.set_variable_upper_bounds(var_upper);
 
   // Set objective coefficients
   std::vector<double> obj_coeffs = {1.2, 1.7};
-  problem.set_objective_coefficients(obj_coeffs.data(), obj_coeffs.size());
+  problem.set_objective_coefficients(obj_coeffs);
   problem.set_maximize(false);
 
   return problem;

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -37,28 +37,23 @@ mps_parser::mps_data_model_t<int, double> create_std_lp_problem()
   std::vector<int> offsets         = {0, 2};
   std::vector<int> indices         = {0, 1};
   std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {0.0};
   std::vector<double> upper_bounds = {5000.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower = {0.0, 0.0};
   std::vector<double> var_upper = {3000.0, 5000.0};
-  problem.set_variable_lower_bounds(var_lower.data(), var_lower.size());
-  problem.set_variable_upper_bounds(var_upper.data(), var_upper.size());
+  problem.set_variable_lower_bounds(var_lower);
+  problem.set_variable_upper_bounds(var_upper);
 
   // Set objective coefficients
   std::vector<double> obj_coeffs = {1.2, 1.7};
-  problem.set_objective_coefficients(obj_coeffs.data(), obj_coeffs.size());
+  problem.set_objective_coefficients(obj_coeffs);
   problem.set_maximize(false);
 
   return problem;
@@ -72,28 +67,23 @@ mps_parser::mps_data_model_t<int, double> create_single_var_lp_problem()
   std::vector<int> offsets         = {0, 1};
   std::vector<int> indices         = {0};
   std::vector<double> coefficients = {1.0};
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
+  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
 
   // Set constraint bounds
   std::vector<double> lower_bounds = {0.0};
   std::vector<double> upper_bounds = {0.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   // Set variable bounds
   std::vector<double> var_lower = {0.0};
   std::vector<double> var_upper = {0.0};
-  problem.set_variable_lower_bounds(var_lower.data(), var_lower.size());
-  problem.set_variable_upper_bounds(var_upper.data(), var_upper.size());
+  problem.set_variable_lower_bounds(var_lower);
+  problem.set_variable_upper_bounds(var_upper);
 
   // Set objective coefficients
   std::vector<double> obj_coeffs = {-0.23};
-  problem.set_objective_coefficients(obj_coeffs.data(), obj_coeffs.size());
+  problem.set_objective_coefficients(obj_coeffs);
   problem.set_maximize(false);
 
   return problem;
@@ -150,22 +140,17 @@ TEST(LPTest, TestSampleLP2)
 
   // Build the problem
   mps_parser::mps_data_model_t<int, double> problem;
-  problem.set_csr_constraint_matrix(A_values.data(),
-                                    A_values.size(),
-                                    A_indices.data(),
-                                    A_indices.size(),
-                                    A_offsets.data(),
-                                    A_offsets.size());
-  problem.set_constraint_upper_bounds(b.data(), b.size());
-  problem.set_constraint_lower_bounds(b_lower.data(), b_lower.size());
+  problem.set_csr_constraint_matrix(A_values, A_indices, A_offsets);
+  problem.set_constraint_upper_bounds(b);
+  problem.set_constraint_lower_bounds(b_lower);
 
   // Set variable bounds (x >= 0)
   std::vector<double> var_lower = {0.0};
   std::vector<double> var_upper = {std::numeric_limits<double>::infinity()};
-  problem.set_variable_lower_bounds(var_lower.data(), var_lower.size());
-  problem.set_variable_upper_bounds(var_upper.data(), var_upper.size());
+  problem.set_variable_lower_bounds(var_lower);
+  problem.set_variable_upper_bounds(var_upper);
 
-  problem.set_objective_coefficients(c.data(), c.size());
+  problem.set_objective_coefficients(c);
   problem.set_maximize(false);
   // Set up solver settings
   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings{};
@@ -217,8 +202,8 @@ TEST(ErrorTest, TestError)
   // Set constraint bounds
   std::vector<double> lower_bounds = {1.0};
   std::vector<double> upper_bounds = {1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds.data(), lower_bounds.size());
-  problem.set_constraint_upper_bounds(upper_bounds.data(), upper_bounds.size());
+  problem.set_constraint_lower_bounds(lower_bounds);
+  problem.set_constraint_upper_bounds(upper_bounds);
 
   auto result = cuopt::linear_programming::solve_mip(&handle, problem, settings);
 
@@ -316,21 +301,20 @@ static mps_parser::mps_data_model_t<int, double> create_wide_spread_milp()
   std::vector<int> indices = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
                               0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
   std::vector<int> offsets = {0, 4, 8, 12, 16, 20, 24};
-  problem.set_csr_constraint_matrix(
-    values.data(), values.size(), indices.data(), indices.size(), offsets.data(), offsets.size());
+  problem.set_csr_constraint_matrix(values, indices, offsets);
 
   std::vector<double> cl = {0, 0, 0, 0, 0, 0};
   std::vector<double> cu = {1e6, 1e8, 1e4, 1e8, 100, 1e4};
-  problem.set_constraint_lower_bounds(cl.data(), cl.size());
-  problem.set_constraint_upper_bounds(cu.data(), cu.size());
+  problem.set_constraint_lower_bounds(cl);
+  problem.set_constraint_upper_bounds(cu);
 
   std::vector<double> vl = {0, 0, 0, 0};
   std::vector<double> vu = {1000, 1000, 1000, 1e6};
-  problem.set_variable_lower_bounds(vl.data(), vl.size());
-  problem.set_variable_upper_bounds(vu.data(), vu.size());
+  problem.set_variable_lower_bounds(vl);
+  problem.set_variable_upper_bounds(vu);
 
   std::vector<double> obj = {1.0, 2.0, 3.0, 0.5};
-  problem.set_objective_coefficients(obj.data(), obj.size());
+  problem.set_objective_coefficients(obj);
   problem.set_maximize(false);
 
   std::vector<char> var_types = {'I', 'I', 'I', 'C'};


### PR DESCRIPTION
mps_parser::mps_data_model_t::set_*  and append_quadratic_constraint take std::span<const T> instead of (const T*, size). These setters copy the input into an owned std::vector on the host, so std::span is a clean, accurate fit and resolves the existing TODO on append_quadratic_constraint.

Internal libmps_parser callers (mps_parser.cpp, mps_writer setup), the cuopt branch-and-bound simplex-to-MPS conversion, and the affected tests are updated to pass spans.

Breaks the non-public C++ API.