### PR TITLE
test: freeze mps-parser dependency at 26.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,33 +71,9 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-  wheel-build-cuopt-mps-parser:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      script: ci/build_wheel_cuopt_mps_parser.sh
-      package-name: cuopt_mps_parser
-      package-type: python
-      append-cuda-suffix: false
-      # need 1 build per Python version and arch (but CUDA version doesn't matter so choose the latest)
-      matrix_filter: 'group_by([.ARCH, (.PY_VER |split(".") | map(tonumber))])|map(max_by([(.CUDA_VER|split(".")|map(tonumber))]))'
-  wheel-publish-cuopt-mps-parser:
-    needs: wheel-build-cuopt-mps-parser
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: cuopt_mps_parser
-      package-type: python
+  # cuopt-mps-parser wheel build/publish disabled — consumed externally at 26.04
+  # (see PR test/freeze-mps-parser-26.04). Re-enable when the freeze is reverted.
   wheel-build-libcuopt:
-    needs: wheel-build-cuopt-mps-parser
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
@@ -121,7 +97,7 @@ jobs:
       package-name: libcuopt
       package-type: cpp
   wheel-build-cuopt:
-    needs: [wheel-build-cuopt-mps-parser, wheel-build-libcuopt]
+    needs: [wheel-build-libcuopt]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
@@ -215,7 +191,6 @@ jobs:
     needs:
       - upload-conda
       - wheel-publish-cuopt
-      - wheel-publish-cuopt-mps-parser
       - wheel-publish-cuopt-server
       - wheel-publish-cuopt-sh-client
       - wheel-publish-libcuopt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,6 @@ jobs:
       - wheel-tests-cuopt
       - wheel-build-cuopt-server
       - wheel-tests-cuopt-server
-      - wheel-build-cuopt-mps-parser
       - wheel-build-cuopt-sh-client
       - test-self-hosted-server
     secrets: inherit
@@ -83,7 +82,6 @@ jobs:
       conda_lean_filter: ${{ steps.set-filters.outputs.conda_lean_filter }}
       conda_test_filter: ${{ steps.set-filters.outputs.conda_test_filter }}
       wheel_lean_filter: ${{ steps.set-filters.outputs.wheel_lean_filter }}
-      mps_parser_filter: ${{ steps.set-filters.outputs.mps_parser_filter }}
       libcuopt_filter: ${{ steps.set-filters.outputs.libcuopt_filter }}
       cuopt_server_filter: ${{ steps.set-filters.outputs.cuopt_server_filter }}
       cuopt_sh_client_filter: ${{ steps.set-filters.outputs.cuopt_sh_client_filter }}
@@ -95,7 +93,6 @@ jobs:
             echo "conda_lean_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.11\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "conda_test_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.13\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "wheel_lean_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
-            echo "mps_parser_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "libcuopt_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "cuopt_server_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "cuopt_sh_client_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
@@ -103,7 +100,6 @@ jobs:
             echo "conda_lean_filter=." >> $GITHUB_OUTPUT
             echo "conda_test_filter=." >> $GITHUB_OUTPUT
             echo "wheel_lean_filter=." >> $GITHUB_OUTPUT
-            echo "mps_parser_filter=group_by([.ARCH, (.PY_VER |split(\".\") | map(tonumber))])|map(max_by([(.CUDA_VER|split(\".\")|map(tonumber))]))" >> $GITHUB_OUTPUT
             echo "libcuopt_filter=group_by([.ARCH, (.CUDA_VER|split(\".\")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(\".\")|map(tonumber)))" >> $GITHUB_OUTPUT
             echo "cuopt_server_filter=map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER|split(\".\")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(\".\")|map(tonumber)), (.CUDA_VER|split(\".\")|map(tonumber))]))" >> $GITHUB_OUTPUT
             echo "cuopt_sh_client_filter=[map(select(.ARCH == \"amd64\")) | min_by((.PY_VER | split(\".\") | map(tonumber)), (.CUDA_VER | split(\".\") | map(-tonumber)))]" >> $GITHUB_OUTPUT
@@ -421,22 +417,10 @@ jobs:
       artifact-name: "cuopt_docs"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: "ci/build_docs.sh"
-  wheel-build-cuopt-mps-parser:
-    needs: [compute-matrix-filters, changed-files]
-    # All wheel-build-* jobs feed the wheel test jobs, so they gate on the same group.
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_wheel_cuopt_mps_parser.sh
-      package-name: cuopt_mps_parser
-      package-type: python
-      append-cuda-suffix: false
-      # need 1 build per Python version and arch (but CUDA version doesn't matter so choose the latest)
-      matrix_filter: ${{ needs.compute-matrix-filters.outputs.mps_parser_filter }}
+  # cuopt-mps-parser wheel build disabled — consumed externally at 26.04
+  # (see PR test/freeze-mps-parser-26.04). Re-enable when the freeze is reverted.
   wheel-build-libcuopt:
-    needs: [wheel-build-cuopt-mps-parser, compute-matrix-filters, changed-files]
+    needs: [compute-matrix-filters, changed-files]
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
@@ -448,7 +432,7 @@ jobs:
       build_type: pull-request
       script: ci/build_wheel_libcuopt.sh
   wheel-build-cuopt:
-    needs: [wheel-build-cuopt-mps-parser, wheel-build-libcuopt, compute-matrix-filters, changed-files]
+    needs: [wheel-build-libcuopt, compute-matrix-filters, changed-files]
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
@@ -459,7 +443,7 @@ jobs:
       package-type: python
       matrix_filter: ${{ needs.compute-matrix-filters.outputs.wheel_lean_filter }}
   wheel-tests-cuopt:
-    needs: [wheel-build-cuopt, wheel-build-cuopt-mps-parser, wheel-build-cuopt-sh-client, changed-files, compute-matrix-filters]
+    needs: [wheel-build-cuopt, wheel-build-cuopt-sh-client, changed-files, compute-matrix-filters]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -26,7 +26,8 @@ for package_name in cuopt cuopt_server; do
   sed -i "/^__git_commit__/ s/= .*/= \"${git_commit}\"/g" "${package_dir}/${package_name}/${package_name}/_version.py"
 done
 
-sed -i "/^__git_commit__/ s/= .*/= \"${git_commit}\"/g" "${package_dir}/cuopt/cuopt/linear_programming/cuopt_mps_parser/_version.py"
+# cuopt-mps-parser is consumed externally at 26.04; the in-tree recipe build is disabled
+# (see PR test/freeze-mps-parser-26.04). Re-enable when the freeze is reverted.
 
 # populates `RATTLER_CHANNELS` array and `RATTLER_ARGS` array
 source rapids-rattler-channel-string
@@ -41,19 +42,6 @@ rapids-logger "Prepending channel ${CPP_CHANNEL} to RATTLER_CHANNELS"
 
 RATTLER_CHANNELS=("--channel" "${CPP_CHANNEL}" "${RATTLER_CHANNELS[@]}")
 
-sccache --zero-stats
-
-rapids-logger "Building mps-parser"
-
-# --no-build-id allows for caching with `sccache`
-# more info is available at
-# https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
-rattler-build build --recipe conda/recipes/mps-parser \
-                    --test skip \
-                    "${RATTLER_ARGS[@]}" \
-                    "${RATTLER_CHANNELS[@]}"
-
-sccache --show-adv-stats
 sccache --zero-stats
 
 rapids-logger "Building cuopt"

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
+- libmps-parser==26.04.*,>=0.0.0a0
 - libprotobuf
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
+- libmps-parser==26.04.*,>=0.0.0a0
 - libprotobuf
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
+- libmps-parser==26.04.*,>=0.0.0a0
 - libprotobuf
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
+- libmps-parser==26.04.*,>=0.0.0a0
 - libprotobuf
 - libraft-headers==26.6.*,>=0.0.0a0
 - librmm==26.6.*,>=0.0.0a0

--- a/conda/recipes/cuopt/recipe.yaml
+++ b/conda/recipes/cuopt/recipe.yaml
@@ -85,7 +85,7 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
-    - cuopt-mps-parser =${{ version }}
+    - cuopt-mps-parser ==26.04.*,>=0.0.0a0
     - cupy >=13.6.0
     - h5py
     - libcuopt =${{ version }}

--- a/conda/recipes/libcuopt/recipe.yaml
+++ b/conda/recipes/libcuopt/recipe.yaml
@@ -29,7 +29,7 @@ cache:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
-        ./build.sh -n -v ${BUILD_EXTRA_FLAGS} libmps_parser libcuopt deb --allgpuarch --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DBUILD_LP_BENCHMARKS=ON -DBUILD_MIP_BENCHMARKS=ON\"
+        ./build.sh -n -v ${BUILD_EXTRA_FLAGS} libcuopt deb --allgpuarch --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DBUILD_LP_BENCHMARKS=ON -DBUILD_MIP_BENCHMARKS=ON\"
       secrets:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
@@ -80,6 +80,7 @@ cache:
     host:
       - cpp-argparse
       - cuda-version =${{ cuda_version }}
+      - libmps-parser ==26.04.*,>=0.0.0a0
       - libraft-headers =${{ minor_version }}
       - librmm =${{ minor_version }}
       - rapids-logger =0.2
@@ -100,59 +101,6 @@ cache:
 
 outputs:
   - package:
-      name: libmps-parser
-      version: ${{ version }}
-    build:
-      script:
-        content: |
-          cmake --install cpp/libmps_parser/build
-      dynamic_linking:
-        overlinking_behavior: "error"
-      prefix_detection:
-        ignore:
-          # See https://github.com/rapidsai/build-planning/issues/160
-          - lib/libmps_parser.so
-      string: ${{ date_string }}_${{ head_rev }}
-    requirements:
-      build:
-        - cmake ${{ cmake_version }}
-        - ${{ stdlib("c") }}
-        - zlib
-        - bzip2
-      host:
-        - zlib
-        - bzip2
-      run:
-        - zlib
-        - bzip2
-      ignore_run_exports:
-        by_name:
-          - c-ares
-          - cuda-nvtx
-          - cuda-version
-          - libabseil
-          - libboost
-          - libcudss
-          - libcurand
-          - libcusparse
-          - libgrpc
-          - libprotobuf
-          - librmm
-          - libbz2
-          - libzlib
-          - openssl
-          - re2
-          - tbb
-    tests:
-    - package_contents:
-        files:
-          - lib/libmps_parser.so
-    about:
-      homepage: ${{ load_from_file("python/cuopt/cuopt/linear_programming/pyproject.toml").project.urls.Homepage }}
-      license: ${{ load_from_file("python/cuopt/cuopt/linear_programming/pyproject.toml").project.license }}
-      summary: ${{ load_from_file("python/cuopt/cuopt/linear_programming/pyproject.toml").project.description }}
-
-  - package:
       name: libcuopt
       version: ${{ version }}
     build:
@@ -171,7 +119,7 @@ outputs:
         - cmake ${{ cmake_version }}
         - ${{ stdlib("c") }}
       host:
-        - ${{ pin_subpackage("libmps-parser", exact=True) }}
+        - libmps-parser ==26.04.*,>=0.0.0a0
         - libboost-devel
         - cuda-version =${{ cuda_version }}
         - rapids-logger =0.2
@@ -189,7 +137,7 @@ outputs:
         - tbb-devel
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-        - ${{ pin_subpackage("libmps-parser", exact=True) }}
+        - libmps-parser ==26.04.*,>=0.0.0a0
         - libboost-devel
         - librmm =${{ minor_version }}
         - cuda-nvrtc
@@ -238,7 +186,7 @@ outputs:
         - ${{ stdlib("c") }}
       host:
         - ${{ pin_subpackage("libcuopt", exact=True) }}
-        - ${{ pin_subpackage("libmps-parser", exact=True) }}
+        - libmps-parser ==26.04.*,>=0.0.0a0
         - libboost-devel
         - libcublas
         - libcudss-dev >=0.7
@@ -250,7 +198,7 @@ outputs:
         - libabseil
       run:
         - ${{ pin_subpackage("libcuopt", exact=True) }}
-        - ${{ pin_subpackage("libmps-parser", exact=True) }}
+        - libmps-parser ==26.04.*,>=0.0.0a0
       ignore_run_exports:
         by_name:
           - cuda-nvtx

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -484,7 +484,6 @@ target_include_directories(cuopt
         PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libmps_parser/include>"
         INTERFACE
         "$<INSTALL_INTERFACE:include>"
         ${CUDSS_INCLUDE}
@@ -505,8 +504,10 @@ set(CUOPT_PRIVATE_CUDA_LIBS
 
 list(PREPEND CUOPT_PRIVATE_CUDA_LIBS CUDA::cublasLt)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libmps_parser)
-set(CMAKE_LIBRARY_PATH ${CMAKE_CURRENT_BINARY_DIR}/libmps_parser/)
+rapids_find_package(mps_parser REQUIRED
+        BUILD_EXPORT_SET cuopt-exports
+        INSTALL_EXPORT_SET cuopt-exports
+)
 
 
 # Pass CUDSS_MT_LIB_FILE_NAME as a compile definition
@@ -583,14 +584,14 @@ else ()
 endif ()
 
 # adds the .so files to the runtime deb package
-install(TARGETS cuopt mps_parser
+install(TARGETS cuopt
         DESTINATION ${_LIB_DEST}
         COMPONENT runtime
         EXPORT cuopt-exports
 )
 
 # adds the .so files to the development deb package
-install(TARGETS cuopt mps_parser
+install(TARGETS cuopt
         DESTINATION ${_LIB_DEST}
         COMPONENT dev
 )
@@ -803,7 +804,6 @@ if (NOT SKIP_GRPC_BUILD)
             "${CMAKE_CURRENT_SOURCE_DIR}/src/grpc"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/grpc/server"
             "${CMAKE_CURRENT_SOURCE_DIR}/include"
-            "${CMAKE_CURRENT_SOURCE_DIR}/libmps_parser/include"
             "${CMAKE_CURRENT_BINARY_DIR}"
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -43,7 +43,6 @@ function(ConfigureTest CMAKE_TEST_NAME)
     target_include_directories(${CMAKE_TEST_NAME}
         PRIVATE
         "${CUOPT_TEST_DIR}/../src"
-        "${CUOPT_TEST_DIR}/../libmps_parser/src"
         "${CUOPT_TEST_DIR}"
         "${papilo_SOURCE_DIR}/src"
         "${papilo_BINARY_DIR}"
@@ -52,7 +51,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
 
     target_link_libraries(${CMAKE_TEST_NAME}
        PRIVATE
-        mps_parser
+        cuopt::mps_parser
         cuopt
         cuopttestutils
         GTest::gmock

--- a/cpp/tests/linear_programming/CMakeLists.txt
+++ b/cpp/tests/linear_programming/CMakeLists.txt
@@ -42,14 +42,13 @@ if (NOT SKIP_C_PYTHON_ADAPTERS)
     target_include_directories(C_API_TEST
         PRIVATE
         "${CUOPT_TEST_DIR}/../src"
-        "${CUOPT_TEST_DIR}/../libmps_parser/src"
         "${CUOPT_TEST_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/c_api_tests"
     )
 
     target_link_libraries(C_API_TEST
         PRIVATE
-        mps_parser
+        cuopt::mps_parser
         cuopt
         cuopttestutils
         c_api_tester

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,6 +32,7 @@ files:
       - depends_on_cudf
       - depends_on_cupy
       - depends_on_libraft_headers
+      - depends_on_libmps_parser
       - depends_on_librmm
       - depends_on_pylibraft
       - depends_on_rapids_logger
@@ -501,12 +502,18 @@ dependencies:
     common:
       - output_types: [requirements, pyproject, conda]
         packages:
-          - cuopt-mps-parser==26.6.*,>=0.0.0a0
+          # Frozen at 26.04 — cuopt no longer builds mps-parser in-tree, see
+          # PR test/freeze-mps-parser-26.04.
+          - cuopt-mps-parser==26.04.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+  depends_on_libmps_parser:
+    common:
+      - output_types: conda
+        packages:
+          - libmps-parser==26.04.*,>=0.0.0a0
   depends_on_libraft_headers:
     common:
       - output_types: conda

--- a/python/cuopt/CMakeLists.txt
+++ b/python/cuopt/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CUDA_STANDARD 20)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 find_package(cuopt "${RAPIDS_VERSION}")
-find_package(mps_parser "${RAPIDS_VERSION}")
+find_package(mps_parser REQUIRED)
 
 include(rapids-cython-core)
 rapids_cython_init()

--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cudf==26.6.*,>=0.0.0a0",
-    "cuopt-mps-parser==26.6.*,>=0.0.0a0",
+    "cuopt-mps-parser==26.04.*,>=0.0.0a0",
     "cupy-cuda13x>=13.6.0",
     "libcuopt==26.6.*,>=0.0.0a0",
     "numba-cuda>=0.22.1",
@@ -101,7 +101,7 @@ dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.30.4",
-    "cuopt-mps-parser==26.6.*,>=0.0.0a0",
+    "cuopt-mps-parser==26.04.*,>=0.0.0a0",
     "cupy-cuda13x>=13.6.0",
     "cython>=3.0.3",
     "libcuopt==26.6.*,>=0.0.0a0",

--- a/python/cuopt_self_hosted/pyproject.toml
+++ b/python/cuopt_self_hosted/pyproject.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "cuopt-mps-parser==26.6.*,>=0.0.0a0",
+    "cuopt-mps-parser==26.04.*,>=0.0.0a0",
     "msgpack-numpy==0.4.8",
     "msgpack==1.1.2",
     "requests",

--- a/python/libcuopt/pyproject.toml
+++ b/python/libcuopt/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "cuda-toolkit[cublas,cudart,curand,cusolver,cusparse,nvtx]==13.*",
-    "cuopt-mps-parser==26.6.*,>=0.0.0a0",
+    "cuopt-mps-parser==26.04.*,>=0.0.0a0",
     "librmm==26.6.*,>=0.0.0a0",
     "nvidia-cudss-cu13",
     "nvidia-nvjitlink>=13.0,<14",
@@ -77,7 +77,7 @@ dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=3.30.4",
-    "cuopt-mps-parser==26.6.*,>=0.0.0a0",
+    "cuopt-mps-parser==26.04.*,>=0.0.0a0",
     "librmm==26.6.*,>=0.0.0a0",
     "ninja",
     "rapids-logger==0.2.*,>=0.0.0a0",


### PR DESCRIPTION
## Summary

**Test PR — do not merge.** Goal is to flip cuopt's build to consume external `libmps-parser` / `cuopt-mps-parser` at 26.04 and let CI tell us whether the 26.04 API surface is sufficient for current cuopt `main`.

- `cpp/CMakeLists.txt`: drop `add_subdirectory(libmps_parser)` and the in-tree include path; add `rapids_find_package(mps_parser REQUIRED ... cuopt-exports)` so `cuopt::mps_parser` resolves to the imported target and the cuopt CMake export carries the `find_dependency`.
- `python/cuopt/CMakeLists.txt`: relax `find_package(mps_parser \"\${RAPIDS_VERSION}\")` to unversioned so a 26.04 install satisfies it.
- `cpp/tests/**/CMakeLists.txt`: drop the in-tree `libmps_parser/src` include path (test-private); link against `cuopt::mps_parser` imported target.
- `dependencies.yaml`: pin `cuopt-mps-parser==26.04.*`, add `depends_on_libmps_parser` group (`libmps-parser==26.04.*`, conda-only) and include it in the dev env.
- `conda/recipes/libcuopt/recipe.yaml`: drop the `libmps-parser` subpackage build, remove `libmps_parser` from `./build.sh`, replace four `pin_subpackage(\"libmps-parser\", exact=True)` with external range constraint.
- `conda/recipes/cuopt/recipe.yaml`: pin `cuopt-mps-parser ==26.04.*`.
- Regenerated derived `pyproject.toml` files via `rapids-dependency-file-generator`.

## What we expect to learn from CI

1. Whether 26.04's installed headers (`parser.hpp`, `mps_data_model.hpp`, `data_model_view.hpp`, `writer.hpp`) contain every symbol that current cuopt source uses (compile + link).
2. Whether 26.04's `cuopt-mps-parser` Python package exposes the symbols cuopt's Python code calls — `ParseMps`, `toDict(model, json=...)`, `parser_wrapper.DataModel`, `utilities.InputValidationError`, `utilities.catch_mps_parser_exception`.
3. Whether 26.04 conda/wheel artifacts exist on a release channel (not just nightly) for cuopt's current build matrix.
4. Whether the transitive rapids-cmake / rapids-logger versions declared by 26.04's installed CMake config conflict with cuopt 26.06's build.

## Intentionally NOT in this PR

Deferred to follow-ups if this passes:

- Deleting `cpp/libmps_parser/` and `python/cuopt/cuopt/linear_programming/cuopt_mps_parser/` source trees.
- Removing `conda/recipes/mps-parser/recipe.yaml` and the cuopt_mps_parser wheel-publish CI jobs (`.github/workflows/build.yaml`, `pr.yaml`, `ci/build_wheel_cuopt_mps_parser.sh`).
- Trimming the `libmps_parser` / `cuopt_mps_parser` targets from `build.sh` (they still exist, just no longer invoked from the libcuopt conda recipe).
- Decision on where mps-parser source lives for 26.04.x bugfixes (maintenance branch vs. extracted repo).

## Test plan

- [ ] CI passes the libcuopt conda build against external `libmps-parser==26.04.*`.
- [ ] CI passes the cuopt wheel build with `cuopt-mps-parser==26.04.*` resolved from the configured indexes.
- [ ] CI passes Python tests that import `cuopt_mps_parser` (`test_lp_solver.py`, `test_cpu_only_execution.py`, `test_parser.py`, `test_incumbent_callbacks.py`, `test_pdlp_warmstart.py`).
- [ ] If any of the above fail, capture the missing-symbol / missing-artifact signal in a comment for the follow-up plan.