### PR TITLE
ci: skip CMAKE_C_COMPILER_LAUNCHER under gcc-toolset

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -12,6 +12,15 @@ source rapids-configure-sccache
 source rapids-date-string
 source rapids-init-pip
 
+# Workaround for sccache regression (0.14.0-rapids.12): the launcher
+# mishandles .c files when wrapping a gcc-toolset gcc, causing
+# __cplusplus to be defined and CMake's C compiler test to fail with
+# 'The CMAKE_C_COMPILER is set to a C++ compiler'. Drop the launcher
+# for C only; keep it for CXX/CUDA where the bug does not trigger.
+if [[ "$(command -v gcc 2>/dev/null)" == /opt/rh/gcc-toolset-*/root/usr/bin/gcc ]]; then
+  unset CMAKE_C_COMPILER_LAUNCHER
+fi
+
 # Update the version to accomdate nightly and release changes for the wheel name
 rapids-generate-version > ./VERSION
 


### PR DESCRIPTION
## Summary
- Unsets `CMAKE_C_COMPILER_LAUNCHER` in `ci/build_wheel.sh` when `gcc-toolset` gcc is on PATH, working around an sccache 0.14.0-rapids.12 regression that makes `__cplusplus` get defined for `.c` files and breaks CMake's C compiler test (`The CMAKE_C_COMPILER is set to a C++ compiler`).
- Launcher stays active for CXX and CUDA, so sccache benefit is preserved where it matters.

## Testing
- Diff verified locally; `pre-commit run --files ci/build_wheel.sh` passes (shellcheck + copyright + others).
- CI on this PR will exercise the wheel builds that were failing on `main` (libcuopt × {12.9.1, 13.0.2} × {amd64, arm64}, py3.14).

## Docs
- No doc changes; comment in the script explains the workaround and points to the upstream sccache regression so it can be removed once fixed.