### PR TITLE
ci: forward CUOPT_SLACK_MENTION_ID secret to nightly-summary

### DIFF
--- a/.github/workflows/nightly-summary.yaml
+++ b/.github/workflows/nightly-summary.yaml
@@ -49,6 +49,8 @@ on:
         required: false
       CUOPT_SLACK_CHANNEL_ID:
         required: false
+      CUOPT_SLACK_MENTION_ID:
+        required: false
 
 jobs:
   nightly-summary:
@@ -70,6 +72,7 @@ jobs:
           CUOPT_S3_URI: ${{ secrets.CUOPT_S3_URI }}
           CUOPT_SLACK_BOT_TOKEN: ${{ secrets.CUOPT_SLACK_BOT_TOKEN }}
           CUOPT_SLACK_CHANNEL_ID: ${{ secrets.CUOPT_SLACK_CHANNEL_ID }}
+          CUOPT_SLACK_MENTION_ID: ${{ secrets.CUOPT_SLACK_MENTION_ID }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SERVER_URL: ${{ github.server_url }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -123,3 +123,4 @@ jobs:
       CUOPT_S3_URI: ${{ secrets.CUOPT_S3_URI }}
       CUOPT_SLACK_BOT_TOKEN: ${{ secrets.CUOPT_SLACK_BOT_TOKEN }}
       CUOPT_SLACK_CHANNEL_ID: ${{ secrets.CUOPT_SLACK_CHANNEL_ID }}
+      CUOPT_SLACK_MENTION_ID: ${{ secrets.CUOPT_SLACK_MENTION_ID }}


### PR DESCRIPTION
## Summary
- Declare `CUOPT_SLACK_MENTION_ID` as an optional `workflow_call` secret on the reusable `nightly-summary` workflow and forward it to the run-step env.
- Pass it from `test.yaml` to the `nightly-summary` job alongside the other Slack secrets.

## Why
`ci/nightly_summary.sh` already forwards `CUOPT_SLACK_MENTION_ID` to `ci/utils/generate_slack_payloads.py`, which uses it to prefix `<@id>` mentions on **new failures** and **new flaky tests**. Until now the env var was never populated in CI, so the mention was always empty. With this change, setting the `CUOPT_SLACK_MENTION_ID` repo secret (Slack user ID like `U01ABCDEF` or group handle like `S01ABCDEF`) will ping the configured handle. Leaving it unset preserves the no-mention default.

## Test plan
- [ ] Add `CUOPT_SLACK_MENTION_ID` repo secret.
- [ ] Trigger a nightly run (or `workflow_dispatch` on `nightly-summary`) and confirm the Slack message includes the `<@id>` mention on new failures.
- [ ] Verify behavior is unchanged when the secret is unset (no mention).