### PR TITLE
ci(nightly): set fail-fast: false on the build matrix

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         cuopt_branch:
           - "main"


### PR DESCRIPTION
## Summary

Make the two matrix entries in `.github/workflows/nightly.yaml` independent so a missing release-branch ref no longer cancels the working `main`-branch nightly.

**Why this matters now:** the matrix bumped to `release/26.06` in #1091 on 2026-04-14, but `release/26.06` has not been cut from `main` yet. Every nightly since has failed — the release entry 404s at the `gh api .../branches/release/26.06` lookup, the matrix's default `fail-fast: true` cancels the sibling `main` entry, and the wrapper job reports `failure` even though the `main` dispatch would have succeeded on its own.

**Fix:** add `fail-fast: false` so each cuopt_branch dispatch runs independently.

```yaml
strategy:
  fail-fast: false       # ← added
  matrix:
    cuopt_branch:
      - "main"
      - "release/26.06"
```

The release entry will still go red until `release/26.06` is actually cut (or the line is reverted to a release branch that exists), but it no longer drags `main` with it.

## Test plan
- [ ] Watch the next scheduled nightly — `main` matrix entry should dispatch and complete independent of the `release/26.06` entry's outcome.
- [ ] Manual dispatch via `Run workflow` from Actions UI to verify both entries run to completion (or independent failure) before waiting for the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)