### PR TITLE
ci: format CUOPT_SLACK_MENTION_ID as subteam when ID starts with S

### DIFF
--- a/ci/utils/generate_slack_payloads.py
+++ b/ci/utils/generate_slack_payloads.py
@@ -62,11 +62,19 @@ def main():
     untracked_failed = d.get("untracked_failed_ci_jobs", [])
     workflow_jobs = d.get("workflow_jobs", [])
 
-    # Slack user/group to mention on new failures or new flaky tests.
-    # Set CUOPT_SLACK_MENTION_ID to a Slack user ID (e.g., U01ABCDEF) or
-    # group handle. Empty disables mentions.
+    # Slack user or user-group to mention on new failures or new flaky tests.
+    # Set CUOPT_SLACK_MENTION_ID to either:
+    #   - a user ID (starts with U or W, e.g. U01ABCDEF) — pings the user
+    #   - a user-group / subteam ID (starts with S, e.g. S01ABCDEF) — pings the group
+    # The group's handle name (e.g. "cuopt-ci-team") will NOT ping; Slack
+    # requires the subteam ID, formatted as <!subteam^...>. Empty disables.
     mention_id = os.environ.get("CUOPT_SLACK_MENTION_ID", "")
-    mention_tag = f"<@{mention_id}> " if mention_id else ""
+    if mention_id.startswith("S"):
+        mention_tag = f"<!subteam^{mention_id}> "
+    elif mention_id:
+        mention_tag = f"<@{mention_id}> "
+    else:
+        mention_tag = ""
 
     total_jobs = jobs.get("total", 0)
 


### PR DESCRIPTION
## Summary
- Detect user-group (subteam) IDs by their `S` prefix and emit `<!subteam^S...>` syntax.
- User IDs (prefix `U`/`W`) continue to use `<@U...>`.
- Update the contract comment to spell out both forms and warn that handle names alone will not ping.

## Why
Today's nightly Slack post (2026-05-07) showed `@cuopt-ci-team` rendered as plain text — the message arrived but produced no notification. Root cause: `ci/utils/generate_slack_payloads.py` always wrapped `CUOPT_SLACK_MENTION_ID` as `<@id>`, which is **user-only** syntax. Slack requires `<!subteam^SXXXXXXXX>` to ping a user group. Passing the group's handle name (`cuopt-ci-team`) or its `S...` ID with the old formatter both fail silently.

## Test plan
- [ ] `CUOPT_SLACK_MENTION_ID=SXXXXXXXX` → next nightly with new failures pings the `cuopt-ci-team` group.
- [ ] Sanity-check that a user ID (`U...`) still renders as `<@U...>` (no behavior change for that path).
- [ ] Empty/unset `CUOPT_SLACK_MENTION_ID` produces no mention (existing behavior preserved).

## Notes
Builds on #1182, which plumbs the `CUOPT_SLACK_MENTION_ID` secret through the workflow. Either order of merge works; this PR only touches the formatter.