### PR TITLE
build gRPC against OpenSSL 3

### DIFF
--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -29,6 +29,22 @@ bash ci/utils/install_protobuf_grpc.sh
 
 export SKBUILD_CMAKE_ARGS="-DCUOPT_BUILD_WHEELS=ON;-DDISABLE_DEPRECATION_WARNING=ON"
 
+# OpenSSL 3 hints for libcuopt's own find_package(OpenSSL).
+#
+# install_protobuf_grpc.sh links gRPC against OpenSSL 3 (see that script for
+# rationale). libcuopt then re-resolves OpenSSL via find_package because
+# gRPC's imported targets propagate it transitively. On Rocky/RHEL 8 the
+# EPEL openssl3-devel package installs in non-default paths, so we have to
+# point CMake at them; on Rocky/RHEL 9+ and Ubuntu 22.04+ the default
+# OpenSSL is already 3.x and no hints are needed.
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    if [[ "$ID" == "rocky" || "$ID" == "centos" || "$ID" == "rhel" || "$ID" == "fedora" ]] && \
+       [[ "${VERSION_ID%%.*}" == "8" ]]; then
+        SKBUILD_CMAKE_ARGS="${SKBUILD_CMAKE_ARGS};-DOPENSSL_INCLUDE_DIR=/usr/include/openssl3;-DOPENSSL_SSL_LIBRARY=/usr/lib64/openssl3/libssl.so;-DOPENSSL_CRYPTO_LIBRARY=/usr/lib64/openssl3/libcrypto.so"
+    fi
+fi
+
 # For pull requests we are enabling assert mode.
 if [ "$RAPIDS_BUILD_TYPE" = "pull-request" ]; then
     echo "Building in assert mode"
@@ -72,6 +88,14 @@ EXCLUDE_ARGS=(
   --exclude "libnvJitLink*"
   --exclude "librapids_logger.so"
   --exclude "librmm.so"
+  # OpenSSL 3 is intentionally NOT bundled. Resolving libssl.so.3 / libcrypto.so.3
+  # at runtime via the host (or container image) keeps libcrypto and the FIPS
+  # provider (system or mounted) byte-version-matched, which is required for
+  # the FIPS provider's HMAC integrity check and avoids loading two libcrypto.so.3
+  # in the same process. Hosts must provide libssl.so.3 / libcrypto.so.3 (Ubuntu
+  # 22.04+, RHEL/Rocky 9+, manylinux_2_28+ with openssl3, Debian 12+).
+  --exclude "libssl.so.3"
+  --exclude "libcrypto.so.3"
 )
 
 ci/build_wheel.sh libcuopt ${package_dir}

--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -29,6 +29,22 @@ bash ci/utils/install_protobuf_grpc.sh
 
 export SKBUILD_CMAKE_ARGS="-DCUOPT_BUILD_WHEELS=ON;-DDISABLE_DEPRECATION_WARNING=ON"
 
+# OpenSSL 3 hints for libcuopt's own find_package(OpenSSL).
+#
+# install_protobuf_grpc.sh links gRPC against OpenSSL 3 (see that script for
+# rationale). libcuopt then re-resolves OpenSSL via find_package because
+# gRPC's imported targets propagate it transitively. On Rocky/RHEL 8 the
+# EPEL openssl3-devel package installs in non-default paths, so we have to
+# point CMake at them; on Rocky/RHEL 9+ and Ubuntu 22.04+ the default
+# OpenSSL is already 3.x and no hints are needed.
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    if [[ "$ID" == "rocky" || "$ID" == "centos" || "$ID" == "rhel" || "$ID" == "fedora" ]] && \
+       [[ "${VERSION_ID%%.*}" == "8" ]]; then
+        SKBUILD_CMAKE_ARGS="${SKBUILD_CMAKE_ARGS};-DOPENSSL_INCLUDE_DIR=/usr/include/openssl3;-DOPENSSL_SSL_LIBRARY=/usr/lib64/openssl3/libssl.so;-DOPENSSL_CRYPTO_LIBRARY=/usr/lib64/openssl3/libcrypto.so"
+    fi
+fi
+
 # For pull requests we are enabling assert mode.
 if [ "$RAPIDS_BUILD_TYPE" = "pull-request" ]; then
     echo "Building in assert mode"
@@ -77,6 +93,14 @@ EXCLUDE_ARGS=(
   --exclude "librapids_logger.so"
   --exclude "libmps_parser.so"
   --exclude "librmm.so"
+  # OpenSSL 3 is intentionally NOT bundled. Resolving libssl.so.3 / libcrypto.so.3
+  # at runtime via the host (or container image) keeps libcrypto and the FIPS
+  # provider (system or mounted) byte-version-matched, which is required for
+  # the FIPS provider's HMAC integrity check and avoids loading two libcrypto.so.3
+  # in the same process. Hosts must provide libssl.so.3 / libcrypto.so.3 (Ubuntu
+  # 22.04+, RHEL/Rocky 9+, manylinux_2_28+ with openssl3, Debian 12+).
+  --exclude "libssl.so.3"
+  --exclude "libcrypto.so.3"
 )
 
 ci/build_wheel.sh libcuopt ${package_dir}

--- a/ci/test_wheel_cuopt.sh
+++ b/ci/test_wheel_cuopt.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 # so those constraints will affect all future 'pip install' calls
 source rapids-init-pip
 
+# Make sure libssl.so.3 / libcrypto.so.3 are on the linker path before any
+# 'import cuopt'. cuopt wheels link OpenSSL 3 and don't bundle it; on Rocky 8
+# the runtime needs to come from EPEL (no-op on distros that already ship it).
+bash "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/install_openssl3_runtime.sh"
+
 # Download the packages built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUOPT_SH_CLIENT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuopt_sh_client" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)

--- a/ci/test_wheel_cuopt.sh
+++ b/ci/test_wheel_cuopt.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 # so those constraints will affect all future 'pip install' calls
 source rapids-init-pip
 
+# Make sure libssl.so.3 / libcrypto.so.3 are on the linker path before any
+# 'import cuopt'. cuopt wheels link OpenSSL 3 and don't bundle it; on Rocky 8
+# the runtime needs to come from EPEL (no-op on distros that already ship it).
+bash "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/install_openssl3_runtime.sh"
+
 # Download the packages built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUOPT_MPS_PARSER_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuopt_mps_parser" rapids-download-wheels-from-github python)

--- a/ci/test_wheel_cuopt_server.sh
+++ b/ci/test_wheel_cuopt_server.sh
@@ -7,6 +7,11 @@ set -eou pipefail
 
 source rapids-init-pip
 
+# Make sure libssl.so.3 / libcrypto.so.3 are on the linker path before any
+# 'import cuopt'. cuopt wheels link OpenSSL 3 and don't bundle it; on Rocky 8
+# the runtime needs to come from EPEL (no-op on distros that already ship it).
+bash "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/install_openssl3_runtime.sh"
+
 # Download the packages built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUOPT_SERVER_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuopt_server_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)

--- a/ci/test_wheel_cuopt_server.sh
+++ b/ci/test_wheel_cuopt_server.sh
@@ -7,6 +7,11 @@ set -eou pipefail
 
 source rapids-init-pip
 
+# Make sure libssl.so.3 / libcrypto.so.3 are on the linker path before any
+# 'import cuopt'. cuopt wheels link OpenSSL 3 and don't bundle it; on Rocky 8
+# the runtime needs to come from EPEL (no-op on distros that already ship it).
+bash "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/install_openssl3_runtime.sh"
+
 # Download the packages built in the previous step
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 CUOPT_MPS_PARSER_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="cuopt_mps_parser" rapids-download-wheels-from-github python)

--- a/ci/utils/install_openssl3_runtime.sh
+++ b/ci/utils/install_openssl3_runtime.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Install OpenSSL 3 runtime libraries when the host distro doesn't ship them
+# by default. cuopt wheels DT_NEEDED libssl.so.3 / libcrypto.so.3 and do NOT
+# bundle them (see docs/openssl3-runtime-requirements.md), so the test image
+# has to provide them at runtime.
+#
+# Coverage:
+#   - Rocky/RHEL/Alma 8: needs openssl3 from EPEL (default OpenSSL is 1.0.x).
+#   - Other distros (Ubuntu 22.04+, Debian 12+, RHEL/Rocky 9+, Fedora 36+):
+#     already ship libssl.so.3 / libcrypto.so.3 — no-op.
+#
+# Safe to run unconditionally; only takes action where needed.
+
+set -euo pipefail
+
+if [ ! -f /etc/os-release ]; then
+    exit 0
+fi
+
+. /etc/os-release
+
+case "${ID:-}" in
+  rocky|rhel|centos|almalinux)
+    if [[ "${VERSION_ID%%.*}" == "8" ]]; then
+        echo "==> Installing OpenSSL 3 runtime from EPEL (Rocky/RHEL/Alma 8)"
+        if ! rpm -q epel-release >/dev/null 2>&1; then
+            dnf install -y -q epel-release
+        fi
+        # 'openssl3' is the runtime package; it drops libssl.so.3 /
+        # libcrypto.so.3 into /usr/lib64 and ldconfig picks them up
+        # automatically. ('openssl3-devel' is what the build host uses.)
+        dnf install -y -q openssl3
+        if ! ldconfig -p | grep -qE "libssl\.so\.3|libcrypto\.so\.3"; then
+            echo "ERROR: libssl.so.3 / libcrypto.so.3 still not on linker path" >&2
+            exit 1
+        fi
+    fi
+    ;;
+  *)
+    # Ubuntu 22.04+, Debian 12+, etc. ship OpenSSL 3 by default; nothing to do.
+    ;;
+esac

--- a/ci/utils/install_openssl3_runtime.sh
+++ b/ci/utils/install_openssl3_runtime.sh
@@ -34,7 +34,9 @@ case "${ID:-}" in
         # libcrypto.so.3 into /usr/lib64 and ldconfig picks them up
         # automatically. ('openssl3-devel' is what the build host uses.)
         dnf install -y -q openssl3
-        if ! ldconfig -p | grep -qE "libssl\.so\.3|libcrypto\.so\.3"; then
+        ldconfig_out="$(ldconfig -p)"
+        if ! grep -q "libssl\.so\.3" <<<"${ldconfig_out}" || \
+           ! grep -q "libcrypto\.so\.3" <<<"${ldconfig_out}"; then
             echo "ERROR: libssl.so.3 / libcrypto.so.3 still not on linker path" >&2
             exit 1
         fi

--- a/ci/utils/install_protobuf_grpc.sh
+++ b/ci/utils/install_protobuf_grpc.sh
@@ -90,6 +90,16 @@ echo "  Build dir: ${BUILD_DIR}"
 echo "  Skip deps: ${SKIP_DEPS}"
 echo "=============================================="
 
+# OpenSSL 3 hints for CMake's find_package(OpenSSL).
+#
+# On Rocky/RHEL 8 the default 'openssl-devel' is still 1.1.1k, so we install
+# 'openssl3-devel' from EPEL. That package installs in non-default paths
+# (/usr/include/openssl3 and /usr/lib64/openssl3) so we have to point CMake
+# at them explicitly. On Rocky/RHEL 9+ and Ubuntu 22.04+ the default OpenSSL
+# devel package is already 3.x, so no special handling is needed.
+OPENSSL_INCLUDE_DIR_HINT=""
+OPENSSL_LIB_DIR_HINT=""
+
 # Install system dependencies if not skipped
 if [ "${SKIP_DEPS}" = false ]; then
     echo ""
@@ -100,10 +110,15 @@ if [ "${SKIP_DEPS}" = false ]; then
             # Enable PowerTools (Rocky 8) or CRB (Rocky 9) for some packages
             if [[ "${VERSION_ID%%.*}" == "8" ]]; then
                 dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled PowerTools || true
+                # EPEL provides 'openssl3-devel' in parallel with the system OpenSSL 1.1.x.
+                dnf install -y epel-release
+                dnf install -y git cmake ninja-build gcc gcc-c++ openssl3-devel zlib-devel c-ares-devel
+                OPENSSL_INCLUDE_DIR_HINT="/usr/include/openssl3"
+                OPENSSL_LIB_DIR_HINT="/usr/lib64/openssl3"
             elif [[ "${VERSION_ID%%.*}" == "9" ]]; then
                 dnf config-manager --set-enabled crb || true
+                dnf install -y git cmake ninja-build gcc gcc-c++ openssl-devel zlib-devel c-ares-devel
             fi
-            dnf install -y git cmake ninja-build gcc gcc-c++ openssl-devel zlib-devel c-ares-devel
         elif [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
             apt-get update
             apt-get install -y git cmake ninja-build g++ libssl-dev zlib1g-dev libc-ares-dev
@@ -200,6 +215,17 @@ cmake --install "${PROTOBUF_BUILD}"
 
 echo ""
 echo "Building gRPC (using installed Abseil and Protobuf)..."
+# When building on Rocky/RHEL 8, the EPEL openssl3-devel package installs
+# headers in /usr/include/openssl3 and libs in /usr/lib64/openssl3. CMake's
+# FindOpenSSL.cmake doesn't know to look there, so pass explicit hints.
+GRPC_OPENSSL_HINTS=()
+if [[ -n "${OPENSSL_INCLUDE_DIR_HINT}" && -n "${OPENSSL_LIB_DIR_HINT}" ]]; then
+    GRPC_OPENSSL_HINTS=(
+        "-DOPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR_HINT}"
+        "-DOPENSSL_SSL_LIBRARY=${OPENSSL_LIB_DIR_HINT}/libssl.so"
+        "-DOPENSSL_CRYPTO_LIBRARY=${OPENSSL_LIB_DIR_HINT}/libcrypto.so"
+    )
+fi
 cmake -S "${GRPC_SRC}" -B "${GRPC_BUILD}" -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
@@ -214,6 +240,7 @@ cmake -S "${GRPC_SRC}" -B "${GRPC_BUILD}" -G Ninja \
     -DgRPC_SSL_PROVIDER=package \
     -DgRPC_ZLIB_PROVIDER=package \
     -DgRPC_CARES_PROVIDER=package \
+    "${GRPC_OPENSSL_HINTS[@]}" \
     -DCMAKE_PREFIX_PATH="${PREFIX}" \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 cmake --build "${GRPC_BUILD}" --parallel

--- a/ci/utils/install_protobuf_grpc.sh
+++ b/ci/utils/install_protobuf_grpc.sh
@@ -118,6 +118,13 @@ if [ "${SKIP_DEPS}" = false ]; then
             elif [[ "${VERSION_ID%%.*}" == "9" ]]; then
                 dnf config-manager --set-enabled crb || true
                 dnf install -y git cmake ninja-build gcc gcc-c++ openssl-devel zlib-devel c-ares-devel
+            elif [[ "$ID" == "fedora" ]]; then
+                # Fedora 36+ ships OpenSSL 3.x as the default 'openssl-devel'.
+                dnf install -y git cmake ninja-build gcc gcc-c++ openssl-devel zlib-devel c-ares-devel
+            else
+                echo "ERROR: ${PRETTY_NAME:-$ID $VERSION_ID} is not a supported RHEL-family release for OpenSSL 3 builds." >&2
+                echo "Supported: Rocky/RHEL/CentOS/Alma 8 or 9, or Fedora. Re-run with --skip-deps to bypass." >&2
+                exit 1
             fi
         elif [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
             # The default 'libssl-dev' package is OpenSSL 3.x on Ubuntu 22.04+

--- a/ci/utils/install_protobuf_grpc.sh
+++ b/ci/utils/install_protobuf_grpc.sh
@@ -120,6 +120,18 @@ if [ "${SKIP_DEPS}" = false ]; then
                 dnf install -y git cmake ninja-build gcc gcc-c++ openssl-devel zlib-devel c-ares-devel
             fi
         elif [[ "$ID" == "ubuntu" || "$ID" == "debian" ]]; then
+            # The default 'libssl-dev' package is OpenSSL 3.x on Ubuntu 22.04+
+            # and Debian 12+. Older releases (Ubuntu 20.04, Debian 11) ship
+            # OpenSSL 1.1.1, which we deliberately do not link against (see top
+            # of file). Refuse to proceed there rather than silently regress.
+            DISTRO_MAJOR="${VERSION_ID%%.*}"
+            if [[ "$ID" == "ubuntu" && "${DISTRO_MAJOR}" -lt 22 ]] || \
+               [[ "$ID" == "debian" && "${DISTRO_MAJOR}" -lt 12 ]]; then
+                echo "ERROR: ${PRETTY_NAME:-$ID $VERSION_ID} ships OpenSSL 1.1; cuopt requires OpenSSL 3." >&2
+                echo "Upgrade to Ubuntu 22.04+ / Debian 12+, or install OpenSSL 3 manually" >&2
+                echo "(e.g. via PPA or backport) and re-run this script with --skip-deps." >&2
+                exit 1
+            fi
             apt-get update
             apt-get install -y git cmake ninja-build g++ libssl-dev zlib1g-dev libc-ares-dev
         else

--- a/docs/cuopt/source/faq.rst
+++ b/docs/cuopt/source/faq.rst
@@ -81,6 +81,27 @@ General FAQ
 
    #. The complete round-trip solve time might be more than what was set.
 
+.. dropdown:: Why am I getting "libssl.so.3: cannot open shared object file" or "libcrypto.so.3: cannot open shared object file" when importing cuOpt?
+
+   The cuOpt wheel links against OpenSSL 3 and intentionally does not bundle ``libssl.so.3`` / ``libcrypto.so.3``; the host must provide them. This keeps libcrypto and any FIPS provider (system or mounted) byte-version-matched at runtime.
+
+   Most modern Linux distributions provide OpenSSL 3 out of the box: Ubuntu 22.04+, Debian 12+, RHEL/Rocky/Alma 9+, and Fedora 36+. For older distributions:
+
+   - **RHEL / Rocky / Alma / CentOS 8**: install the ``openssl3`` runtime package from EPEL:
+
+     .. code-block:: bash
+
+         dnf install -y epel-release
+         dnf install -y openssl3
+         # Verify
+         ldconfig -p | grep -E 'libssl\.so\.3|libcrypto\.so\.3'
+
+   - **Ubuntu 20.04**: install OpenSSL 3 from a PPA or backport, or use the cuOpt container image (Ubuntu 22.04 base) instead.
+
+   - **Other distributions**: install your distribution's OpenSSL 3 development/runtime package, or use the cuOpt container.
+
+   After installing, re-run ``pip install`` (or restart the Python process) and the import should succeed.
+
 .. dropdown:: Why am I getting "libcuopt.so: cannot open shared object file: No such file or directory" error?
 
    This error indicates that the cuOpt shared library is not found. Please check the following:

--- a/docs/cuopt/source/system-requirements.rst
+++ b/docs/cuopt/source/system-requirements.rst
@@ -28,6 +28,12 @@ Dependencies are installed automatically when using the pip and Conda installati
    * Python:
       - >= 3.11.* and <= 3.14.*
 
+   * OpenSSL:
+      - 3.x runtime (``libssl.so.3`` and ``libcrypto.so.3``) must be present on the host
+      - Shipped by default on Ubuntu 22.04+, Debian 12+, RHEL/Rocky/Alma 9+, Fedora 36+
+      - On RHEL/Rocky/Alma 8, install the ``openssl3`` package from EPEL (see :doc:`faq`)
+      - On Ubuntu 20.04, install OpenSSL 3 from a PPA/backport or use the cuOpt container
+
    * NVIDIA drivers:
       - 525.60.13+ (Linux)
       - 527.41+ (Windows)


### PR DESCRIPTION
Switch the wheel build to link gRPC against OpenSSL 3.  This is good for modernization, and also necessary to enable FIPS compliance on many current OS platforms.

* install_protobuf_grpc.sh: on Rocky/RHEL 8, install epel-release and openssl3-devel. Rocky/RHEL 9 and Ubuntu/Debian already have openssl-devel at version 3 so use that.

* build_wheel_libcuopt.sh: Add libssl.so.3 / libcrypto.so.3 to the auditwheel exclude list so the wheel does not bundle them; runtime resolves to the host's OpenSSL 3, ensuring libcrypto and any FIPS provider (system or mounted) stay byte-version-matched.

Verified that the resulting binary links require only OPENSSL_3.0.0 symbol versions (159 refs, 0 newer), so the wheel is ABI-compatible with the cuopt container's Ubuntu 22.04 (libssl 3.0.2), RHEL/Rocky 9 (3.0.7), and any OpenSSL 3.x runtime.

Hosts must provide libssl.so.3 / libcrypto.so.3 (Ubuntu 22.04+, Debian 12+, RHEL/Rocky/Alma 9+, Fedora 36+ provides). Stock RHEL/Rocky 8 and Ubuntu 20.04 are not covered by this; users on those systems should either use the cuopt container image or install OpenSSL 3 from EPEL or a backport before pip-installing cuopt.

