### PR TITLE
ci(thirdparty-pulp): skip test_numpy_float in nightly cuOpt run

### DIFF
--- a/ci/thirdparty-testing/run_pulp_tests.sh
+++ b/ci/thirdparty-testing/run_pulp_tests.sh
@@ -30,11 +30,15 @@ rapids-logger "running PuLP tests (cuOpt-related)"
 # PuLP uses pytest; run only tests that reference cuopt/CUOPT
 # Exit code 5 = no tests collected; then try run_tests.py which detects solvers (including cuopt)
 pytest_rc=0
+# test_numpy_float calls model.solve() with no explicit solver; PuLP's
+# default-solver auto-detection list doesn't include CUOPT, so it raises
+# "No solver available" in our cuopt-only test environment. Skip it here.
 timeout 5m python -m pytest \
     --verbose \
     --capture=no \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-thirdparty-pulp.xml" \
     -k "cuopt or CUOPT" \
+    --deselect pulp/tests/test_pulp.py::CUOPTTest::test_numpy_float \
     pulp/tests/ || pytest_rc=$?
 
 if [ "$pytest_rc" -eq 5 ]; then


### PR DESCRIPTION
## Summary

PuLP's `test_numpy_float` calls `model.solve()` without an explicit solver and relies on PuLP's default-solver auto-detection. `CUOPT` is not on that default list, so in our cuopt-only nightly test environment the call raises `PulpError: No solver available` and the test fails for reasons unrelated to cuOpt.

This PR deselects the test in `ci/thirdparty-testing/run_pulp_tests.sh` with an inline comment explaining the cause.

## Context — other cuOpt-related PuLP failures

| Test | Status |
|---|---|
| `test_unbounded` | Fixed upstream by [coin-or/pulp#901](https://github.com/coin-or/pulp/pull/901) (tracked in #1114) |
| `test_integer_infeasible_2` | Fixed upstream by [coin-or/pulp#901](https://github.com/coin-or/pulp/pull/901) (tracked in #1114) |
| `test_infeasible_2` | Real cuOpt bug — PDLP returns Optimal for an infeasible LP. Tracked in #1115. Not skipped here. |
| `test_numpy_float` | **This PR** |

## Test plan

- [ ] Nightly third-party-PuLP job no longer reports `test_numpy_float` as failing
- [ ] Other cuOpt PuLP tests still execute (no over-broad deselect)