### PR TITLE
ci: surface crashed-test failures and add per-step summaries (cpp, python, thirdparty)

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -57,6 +57,31 @@ extract_failed_tests() {
 }
 
 OVERALL_RC=0
+FAILED_BINARIES=()
+
+# Record a failed gtest binary for the end-of-run summary.
+# Args: <test_name> <reason>
+record_binary_failure() {
+    FAILED_BINARIES+=("$1 — $2")
+}
+
+# Synthesize a JUnit crash record so a binary-level crash is visible to
+# nightly_report.py. gtest only writes its XML at the end of
+# RUN_ALL_TESTS(); a SIGSEGV/SIGABRT mid-run leaves no XML behind, so
+# without this record the failure is invisible to the classifier.
+# Written to a separate *-crash.xml file to preserve any partial XML.
+# Args: <test_name> <xml_dir> <rc>
+write_binary_crash_marker() {
+    local test_name="$1"
+    local xml_dir="$2"
+    local rc="$3"
+    local sig
+    sig=$(signal_name "${rc}")
+    local crash_xml="${xml_dir}/${test_name}-crash.xml"
+    write_crash_xml "${crash_xml}" "${test_name}" "PROCESS_CRASH" \
+        "${test_name} crashed with ${sig} (exit code ${rc})" \
+        "Process terminated by ${sig} mid-run. gtest did not emit a JUnit XML because RUN_ALL_TESTS() did not complete; inspect the run log for [FAILED] / stack-trace lines that preceded the crash."
+}
 
 run_gtest_with_retry() {
     local gt="$1"
@@ -78,6 +103,16 @@ run_gtest_with_retry() {
     # For non-nightly builds: fail immediately, no retries
     # PRs should surface failures directly so authors can see what broke
     if [ "${IS_NIGHTLY}" != "nightly" ]; then
+        if was_signal_death "${rc}"; then
+            local sig
+            sig=$(signal_name "${rc}")
+            echo "CRASH: ${test_name} died from ${sig} (exit code ${rc})"
+            write_binary_crash_marker "${test_name}" "${RAPIDS_TESTS_DIR}" "${rc}"
+            record_binary_failure "${test_name}" "CRASH (${sig})"
+        else
+            echo "FAILED: ${test_name} (exit code ${rc})"
+            record_binary_failure "${test_name}" "exit ${rc}"
+        fi
         OVERALL_RC=1
         return 1
     fi
@@ -115,6 +150,7 @@ run_gtest_with_retry() {
             write_crash_xml "${xml_file}" "${test_name}" "PROCESS_CRASH" \
                 "${test_name} crashed with $(signal_name ${rc}) (exit code ${rc})" \
                 "Process terminated by $(signal_name ${rc}). This may indicate a segfault, double-free, or stack overflow."
+            record_binary_failure "${test_name}" "CRASH ($(signal_name ${rc})), gtest_list_tests unavailable"
             OVERALL_RC=1
             return 1
         fi
@@ -124,6 +160,7 @@ run_gtest_with_retry() {
 
         if [ -z "${tests_to_retry}" ]; then
             echo "FAILED: ${test_name} failed but could not identify failing test cases"
+            record_binary_failure "${test_name}" "exit ${rc}, no failing testcase parseable from XML"
             OVERALL_RC=1
             return 1
         fi
@@ -168,6 +205,7 @@ run_gtest_with_retry() {
     done <<< "${tests_to_retry}"
 
     if [ "${all_passed}" = false ]; then
+        record_binary_failure "${test_name}" "retries exhausted"
         OVERALL_RC=1
         return 1
     fi
@@ -184,6 +222,19 @@ if [ -x "${GTEST_DIR}/C_API_TEST" ]; then
   CUOPT_USE_CPU_MEM_FOR_LOCAL=1 run_gtest_with_retry "${GTEST_DIR}/C_API_TEST" --gtest_filter=-c_api/TimeLimitTestFixture.* "$@" || true
 else
   echo "Skipping C_API_TEST with CUOPT_USE_CPU_MEM_FOR_LOCAL (binary not found)"
+fi
+
+# Final summary so failures are easy to spot in the raw run log.
+# nightly_report.py also produces a structured report from the XML files,
+# but this prints early (before any post-test-script steps) and surfaces
+# crashes that bypassed gtest's XML output.
+if [ "${#FAILED_BINARIES[@]}" -gt 0 ]; then
+    echo ""
+    echo "==================== FAILED gtest BINARIES (${#FAILED_BINARIES[@]}) ===================="
+    for entry in "${FAILED_BINARIES[@]}"; do
+        echo "  - ${entry}"
+    done
+    echo "================================================================"
 fi
 
 exit ${OVERALL_RC}

--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -46,8 +46,11 @@ fi
 
 echo "CRASH: pytest process died from $(signal_name ${rc}) (exit code ${rc})"
 
-# For non-nightly builds, fail immediately — no crash isolation
+# For non-nightly builds, fail immediately — no crash isolation. But
+# still write a synthetic crash XML so nightly_report.py reports the
+# failure (pytest didn't finalize JUnit on a mid-run crash).
 if [ "${IS_NIGHTLY}" != "nightly" ]; then
+    write_pytest_crash_marker "${xml_file}" "pytest-cuopt" "${rc}"
     exit ${rc}
 fi
 

--- a/ci/run_cuopt_server_pytests.sh
+++ b/ci/run_cuopt_server_pytests.sh
@@ -45,6 +45,7 @@ fi
 echo "CRASH: pytest process died from $(signal_name ${rc}) (exit code ${rc})"
 
 if [ "${IS_NIGHTLY}" != "nightly" ]; then
+    write_pytest_crash_marker "${xml_file}" "pytest-cuopt-server" "${rc}"
     exit ${rc}
 fi
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -45,6 +45,7 @@ pushd "${RAPIDS_DATASET_ROOT_DIR}"
 popd
 
 EXITCODE=0
+FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
@@ -53,11 +54,19 @@ set +e
 export RAPIDS_TESTS_DIR
 
 rapids-logger "Run gtests"
-timeout 50m ./ci/run_ctests.sh
+timeout 50m ./ci/run_ctests.sh || FAILED_STEPS+=("gtests (run_ctests.sh)")
 
 rapids-logger "Generate nightly test report"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"
 generate_nightly_report "cpp"
+
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+    EXITCODE=1
+    echo ""
+    echo "==================== FAILED TEST STEPS (${#FAILED_STEPS[@]}) ===================="
+    for s in "${FAILED_STEPS[@]}"; do echo "  - ${s}"; done
+    echo "================================================================"
+fi
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -49,6 +49,7 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 EXITCODE=0
+FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
@@ -56,7 +57,7 @@ set +e
 export OMP_NUM_THREADS=1
 
 rapids-logger "Test cuopt_cli"
-timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh
+timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh || FAILED_STEPS+=("cuopt_cli")
 
 rapids-logger "pytest cuopt"
 timeout 30m ./ci/run_cuopt_pytests.sh \
@@ -65,7 +66,7 @@ timeout 30m ./ci/run_cuopt_pytests.sh \
   --cov=cuopt \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuopt-coverage.xml" \
   --cov-report=term \
-  --ignore=raft
+  --ignore=raft || FAILED_STEPS+=("pytest cuopt")
 
 rapids-logger "pytest cuopt-server"
 timeout 20m ./ci/run_cuopt_server_pytests.sh \
@@ -73,14 +74,22 @@ timeout 20m ./ci/run_cuopt_server_pytests.sh \
   --cov-config=.coveragerc \
   --cov=cuopt_server \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuopt-server-coverage.xml" \
-  --cov-report=term
+  --cov-report=term || FAILED_STEPS+=("pytest cuopt-server")
 
 rapids-logger "Test skills/ assets (Python, C, CLI)"
-timeout 10m ./ci/test_skills_assets.sh
+timeout 10m ./ci/test_skills_assets.sh || FAILED_STEPS+=("skills assets")
 
 rapids-logger "Generate nightly test report"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"
 generate_nightly_report "python" --with-python-version
+
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+    EXITCODE=1
+    echo ""
+    echo "==================== FAILED TEST STEPS (${#FAILED_STEPS[@]}) ===================="
+    for s in "${FAILED_STEPS[@]}"; do echo "  - ${s}"; done
+    echo "================================================================"
+fi
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_wheel_cuopt.sh
+++ b/ci/test_wheel_cuopt.sh
@@ -68,11 +68,12 @@ export RAPIDS_TESTS_DIR
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 EXITCODE=0
+FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
 # Run CLI tests
-timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh
+timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh || FAILED_STEPS+=("cuopt_cli")
 
 # Run Python tests
 
@@ -81,18 +82,26 @@ export OMP_NUM_THREADS=1
 
 timeout 30m ./ci/run_cuopt_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-wheel-cuopt.xml" \
-  --verbose --capture=no
+  --verbose --capture=no || FAILED_STEPS+=("pytest cuopt (wheel)")
 
 # run thirdparty integration tests for only nightly builds
 if [[ "${RAPIDS_BUILD_TYPE}" == "nightly" ]]; then
-    ./ci/thirdparty-testing/run_jump_tests.sh
-    ./ci/thirdparty-testing/run_cvxpy_tests.sh
-    ./ci/thirdparty-testing/run_pulp_tests.sh
-    ./ci/thirdparty-testing/run_pyomo_tests.sh
+    ./ci/thirdparty-testing/run_jump_tests.sh || FAILED_STEPS+=("thirdparty jump")
+    ./ci/thirdparty-testing/run_cvxpy_tests.sh || FAILED_STEPS+=("thirdparty cvxpy")
+    ./ci/thirdparty-testing/run_pulp_tests.sh || FAILED_STEPS+=("thirdparty pulp")
+    ./ci/thirdparty-testing/run_pyomo_tests.sh || FAILED_STEPS+=("thirdparty pyomo")
 fi
 
 # Generate nightly test report
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"
 generate_nightly_report "wheel-python" --with-python-version
+
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+    EXITCODE=1
+    echo ""
+    echo "==================== FAILED TEST STEPS (${#FAILED_STEPS[@]}) ===================="
+    for s in "${FAILED_STEPS[@]}"; do echo "  - ${s}"; done
+    echo "================================================================"
+fi
 
 exit ${EXITCODE}

--- a/ci/test_wheel_cuopt_server.sh
+++ b/ci/test_wheel_cuopt_server.sh
@@ -43,18 +43,27 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 EXITCODE=0
+FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
 timeout 30m ./ci/run_cuopt_server_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-wheel-cuopt-server.xml" \
-  --verbose --capture=no
+  --verbose --capture=no || FAILED_STEPS+=("pytest cuopt-server (wheel)")
 
 # Run documentation tests
-./ci/test_doc_examples.sh
+./ci/test_doc_examples.sh || FAILED_STEPS+=("doc examples")
 
 # Generate nightly test report
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"
 generate_nightly_report "wheel-server" --with-python-version
+
+if [ "${#FAILED_STEPS[@]}" -gt 0 ]; then
+    EXITCODE=1
+    echo ""
+    echo "==================== FAILED TEST STEPS (${#FAILED_STEPS[@]}) ===================="
+    for s in "${FAILED_STEPS[@]}"; do echo "  - ${s}"; done
+    echo "================================================================"
+fi
 
 exit ${EXITCODE}

--- a/ci/thirdparty-testing/run_cvxpy_tests.sh
+++ b/ci/thirdparty-testing/run_cvxpy_tests.sh
@@ -4,6 +4,9 @@
 
 set -e -u -o pipefail
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../utils/crash_helpers.sh"
+
 echo "building 'cvxpy' from source"
 
 PYTHON_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
@@ -36,10 +39,19 @@ RAPIDS_TESTS_DIR="${RAPIDS_TESTS_DIR:-${PWD}/test-results}"
 mkdir -p "${RAPIDS_TESTS_DIR}"
 
 echo "running 'cvxpy' tests"
+pytest_rc=0
 timeout 3m python -m pytest \
     --verbose \
     --capture=no \
     --error-for-skips \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-thirdparty-cvxpy.xml" \
     -k "TestCUOPT" \
-    ./cvxpy/tests/test_conic_solvers.py
+    ./cvxpy/tests/test_conic_solvers.py || pytest_rc=$?
+
+# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
+# nightly_report.py reports the failure instead of "All tests passed."
+if [ "${pytest_rc}" -gt 128 ]; then
+    write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-cvxpy.xml" "thirdparty-cvxpy" "${pytest_rc}"
+fi
+
+exit "${pytest_rc}"

--- a/ci/thirdparty-testing/run_cvxpy_tests.sh
+++ b/ci/thirdparty-testing/run_cvxpy_tests.sh
@@ -48,9 +48,12 @@ timeout 3m python -m pytest \
     -k "TestCUOPT" \
     ./cvxpy/tests/test_conic_solvers.py || pytest_rc=$?
 
-# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
-# nightly_report.py reports the failure instead of "All tests passed."
-if [ "${pytest_rc}" -gt 128 ]; then
+# pytest's normal exit codes are 0-5 (passed / failed / interrupted /
+# internal error / usage / no tests collected). Anything beyond that
+# (timeout=124, signal deaths >128, etc.) means pytest did not finalize
+# its JUnit XML, so synthesize a crash marker — otherwise nightly_report.py
+# would see no failure and report "All tests passed."
+if [ "${pytest_rc}" -gt 5 ]; then
     write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-cvxpy.xml" "thirdparty-cvxpy" "${pytest_rc}"
 fi
 

--- a/ci/thirdparty-testing/run_pulp_tests.sh
+++ b/ci/thirdparty-testing/run_pulp_tests.sh
@@ -46,9 +46,12 @@ if [ "$pytest_rc" -eq 5 ]; then
     pytest_rc=$?
 fi
 
-# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
-# nightly_report.py reports the failure instead of "All tests passed."
-if [ "${pytest_rc}" -gt 128 ]; then
+# pytest's normal exit codes are 0-5 (passed / failed / interrupted /
+# internal error / usage / no tests collected). Anything beyond that
+# (timeout=124, signal deaths >128, etc.) means pytest did not finalize
+# its JUnit XML, so synthesize a crash marker — otherwise nightly_report.py
+# would see no failure and report "All tests passed."
+if [ "${pytest_rc}" -gt 5 ]; then
     write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-pulp.xml" "thirdparty-pulp" "${pytest_rc}"
 fi
 

--- a/ci/thirdparty-testing/run_pulp_tests.sh
+++ b/ci/thirdparty-testing/run_pulp_tests.sh
@@ -4,6 +4,9 @@
 
 set -e -u -o pipefail
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../utils/crash_helpers.sh"
+
 rapids-logger "building 'pulp' from source and running cuOpt tests"
 
 if [ -z "${PIP_CONSTRAINT:-}" ]; then
@@ -41,6 +44,12 @@ if [ "$pytest_rc" -eq 5 ]; then
     rapids-logger "No pytest -k cuopt tests found; running PuLP run_tests.py (solver auto-detection, includes cuopt)"
     timeout 5m python pulp/tests/run_tests.py
     pytest_rc=$?
+fi
+
+# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
+# nightly_report.py reports the failure instead of "All tests passed."
+if [ "${pytest_rc}" -gt 128 ]; then
+    write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-pulp.xml" "thirdparty-pulp" "${pytest_rc}"
 fi
 
 popd || exit 1

--- a/ci/thirdparty-testing/run_pyomo_tests.sh
+++ b/ci/thirdparty-testing/run_pyomo_tests.sh
@@ -39,9 +39,12 @@ timeout 5m python -m pytest \
     -k "cuopt or CUOPT" \
     pyomo/solvers/tests/ || pytest_rc=$?
 
-# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
-# nightly_report.py reports the failure instead of "All tests passed."
-if [ "${pytest_rc}" -gt 128 ]; then
+# pytest's normal exit codes are 0-5 (passed / failed / interrupted /
+# internal error / usage / no tests collected). Anything beyond that
+# (timeout=124, signal deaths >128, etc.) means pytest did not finalize
+# its JUnit XML, so synthesize a crash marker — otherwise nightly_report.py
+# would see no failure and report "All tests passed."
+if [ "${pytest_rc}" -gt 5 ]; then
     write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-pyomo.xml" "thirdparty-pyomo" "${pytest_rc}"
 fi
 

--- a/ci/thirdparty-testing/run_pyomo_tests.sh
+++ b/ci/thirdparty-testing/run_pyomo_tests.sh
@@ -4,6 +4,9 @@
 
 set -e -u -o pipefail
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../utils/crash_helpers.sh"
+
 rapids-logger "building 'pyomo' from source and running cuOpt tests"
 
 if [ -z "${PIP_CONSTRAINT:-}" ]; then
@@ -28,11 +31,19 @@ mkdir -p "${RAPIDS_TESTS_DIR}"
 
 rapids-logger "running Pyomo tests (cuopt_direct / cuOpt-related)"
 # Run only tests that reference cuopt (cuopt_direct solver)
+pytest_rc=0
 timeout 5m python -m pytest \
     --verbose \
     --capture=no \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-thirdparty-pyomo.xml" \
     -k "cuopt or CUOPT" \
-    pyomo/solvers/tests/
+    pyomo/solvers/tests/ || pytest_rc=$?
+
+# On signal death, pytest didn't finalize JUnit; synthesize a crash XML so
+# nightly_report.py reports the failure instead of "All tests passed."
+if [ "${pytest_rc}" -gt 128 ]; then
+    write_pytest_crash_marker "${RAPIDS_TESTS_DIR}/junit-thirdparty-pyomo.xml" "thirdparty-pyomo" "${pytest_rc}"
+fi
 
 popd || exit 1
+exit "${pytest_rc}"

--- a/ci/utils/crash_helpers.sh
+++ b/ci/utils/crash_helpers.sh
@@ -5,13 +5,19 @@
 # Shared helpers for crash detection and JUnit XML crash markers.
 # Source this from test runner scripts (run_ctests.sh, run_cuopt_pytests.sh, etc.)
 
-# Convert exit code > 128 to a human-readable signal name.
+# Convert an abnormal exit code to a human-readable description.
+# Handles GNU coreutils 'timeout' (124) and signal deaths (> 128).
 signal_name() {
-    local sig=$(($1 - 128))
-    case "${sig}" in
-        6)  echo "SIGABRT" ;;
-        11) echo "SIGSEGV (segfault)" ;;
-        *)  echo "signal ${sig}" ;;
+    case "$1" in
+        124) echo "timeout (killed by 'timeout' command)" ;;
+        *)
+            local sig=$(($1 - 128))
+            case "${sig}" in
+                6)  echo "SIGABRT" ;;
+                11) echo "SIGSEGV (segfault)" ;;
+                *)  echo "signal ${sig}" ;;
+            esac
+            ;;
     esac
 }
 

--- a/ci/utils/crash_helpers.sh
+++ b/ci/utils/crash_helpers.sh
@@ -60,6 +60,32 @@ ${detail}
 XMLEOF
 }
 
+# Synthesize a JUnit XML crash record for a pytest invocation that died
+# from a signal mid-run. Without this marker, nightly_report.py — which
+# classifies tests purely from XML files — sees no failure and reports
+# "All tests passed." even though the runner exited non-zero.
+#
+# Written to <junitxml>-crash.xml so any partial XML pytest may have
+# emitted is preserved alongside it.
+#
+# Usage: write_pytest_crash_marker <junitxml_path> <suite_name> <rc>
+write_pytest_crash_marker() {
+    local junitxml_path="$1"
+    local suite_name="$2"
+    local rc="$3"
+
+    if [ -z "${junitxml_path}" ]; then
+        return
+    fi
+
+    local sig
+    sig=$(signal_name "${rc}")
+    local crash_xml="${junitxml_path%.xml}-crash.xml"
+    write_crash_xml "${crash_xml}" "${suite_name}" "PROCESS_CRASH" \
+        "${suite_name} crashed with ${sig} (exit code ${rc})" \
+        "pytest process terminated by ${sig} mid-run. The JUnit XML was not finalized; the test that triggered the crash is unknown — inspect the run log for the last test invoked."
+}
+
 # Isolate crashing pytest tests by retrying individually.
 # Called after pytest exits with a signal (exit code > 128) on nightly builds.
 #


### PR DESCRIPTION
## Summary

When a test runner — gtest binary or pytest — is killed by a signal mid-run, it doesn't finalize its `--gtest_output=xml:` / `--junitxml` output. `ci/utils/nightly_report.py` classifies tests purely from those XML files, so a mid-run crash with no other captured failures was reported as **"All tests passed."** while the script exited non-zero. The GitHub step was correctly red, but the textual summary lied.

Observed in a recent cpp run: `PDLP_TEST` reported five `[ FAILED ]` cases and then segfaulted, but the structured summary said `Classification: 459 passed, 0 failed, 0 errors, 0 flaky, 0 skipped` and concluded `All tests passed.`

## Changes

### Crash-XML synthesis (the actual fix)
- `ci/utils/crash_helpers.sh` — add `write_pytest_crash_marker` helper that writes `<junitxml>-crash.xml` on pytest signal death, alongside (not over) any partial XML pytest may have emitted.
- `ci/run_ctests.sh` — non-nightly crash path now calls `write_crash_xml` for the gtest binary; tracks failed binaries in a `FAILED_BINARIES` array and prints them at end of run.
- `ci/run_cuopt_pytests.sh`, `ci/run_cuopt_server_pytests.sh` — call `write_pytest_crash_marker` on the non-nightly crash path.
- `ci/thirdparty-testing/run_pulp_tests.sh`, `run_pyomo_tests.sh`, `run_cvxpy_tests.sh` — capture pytest's exit code and synthesize a crash XML on signal death.

### Per-step failure summaries
- `ci/test_cpp.sh`, `ci/test_python.sh`, `ci/test_wheel_cuopt.sh`, `ci/test_wheel_cuopt_server.sh` — track each major step in a `FAILED_STEPS` array via `|| FAILED_STEPS+=(...)` and print a `==== FAILED TEST STEPS ====` block before the final `exit ${EXITCODE}`.

### Out of scope
`test_notebooks.sh` and `test_doc_examples.sh` don't produce JUnit XML and exit non-zero on the first failure (notebooks via `exit 1`, doc-examples via its own EXIT-trap counter), so they don't have the same false-pass mode.

## Why this shape
- Crash XMLs go to a separate `*-crash.xml` filename so we never clobber a partial XML emitted by gtest/pytest before the crash.
- The nightly retry path is untouched — it already calls `write_crash_xml` per retry attempt and via `pytest_crash_isolate`. This PR plugs the gap on the non-nightly path (PR runs and any non-`nightly` `RAPIDS_BUILD_TYPE`).
- Step summaries print to stdout only (per maintainer preference). `nightly_report.py` continues to write the structured markdown / HTML / GITHUB_STEP_SUMMARY.

## Test plan

- [ ] On a deliberately-crashing gtest binary, verify `<test_name>-crash.xml` is written and `nightly_report.py` lists it as a failure.
- [ ] On a deliberately-crashing pytest invocation, verify `<junit-name>-crash.xml` is written and the failure surfaces in the report.
- [ ] On a normal (non-crash) test failure, verify behavior is unchanged.
- [ ] On a fully-passing run, verify no `FAILED gtest BINARIES` / `FAILED TEST STEPS` block is printed.
- [ ] `pre-commit run --files ci/...` passes (shellcheck wired in).