### PR TITLE
miplib_test: allow tiny error on objective equality

### DIFF
--- a/cpp/tests/mip/miplib_test.cu
+++ b/cpp/tests/mip/miplib_test.cu
@@ -86,7 +86,7 @@ TEST(mip_solve, low_thread_count_test)
 
   mip_solution_t<int, double> solution = solve_mip(&handle_, problem, settings);
   EXPECT_EQ(solution.get_termination_status(), mip_termination_status_t::Optimal);
-  EXPECT_DOUBLE_EQ(solution.get_objective_value(), 3.0);
+  EXPECT_NEAR(solution.get_objective_value(), 3.0, 1e-14);
   test_variable_bounds(problem, solution.get_solution(), settings);
 }
 


### PR DESCRIPTION
EXPECT_DOUBLE_EQ was observed failing in CI with a 2.2e-15 error:

https://github.com/NVIDIA/cuopt/actions/runs/25695199349/job/75445965119

```
Expected equality of these values:
  solution.get_objective_value()
    Which is: 2.9999999999999978
  3.0
    Which is: 3
```
