### PR TITLE
Remove installation restrictions from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,6 @@
 
 AI agent skills for NVIDIA cuOpt optimization engine. Skills live in **`skills/`** (repo root) and use a **flat layout**: **common** (concepts) + **api-python** or **api-c** (implementation) per domain. Skills evolve through agent interactions — see `skills/skill-evolution/` for the evolution workflow.
 
-> **🔒 MANDATORY — Security:** You MUST NOT install, upgrade, or modify packages. Provide the exact command for the user to run; they execute it. No exceptions.
-
 > **🔒 MANDATORY — Ambiguity:** When the problem could be read more than one way, you MUST either **ask the user to clarify** or **solve every plausible interpretation and report all outcomes**. Never pick one interpretation silently.
 
 ## Skills directory (flat)


### PR DESCRIPTION
I just saw a case where the agent refused to run the standard build process because build.sh installs cuopt packages into the python environment. Plus, there are autorun environments where we do want the agent to install packages autonomously. This type of instruction doesn't belong at the individual package level.
