### PR TITLE
Fix concurrent LP exception cleanup

### DIFF
--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -1490,12 +1490,20 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
     std::tuple<dual_simplex::lp_solution_t<i_t, f_t>, dual_simplex::lp_status_t, f_t, f_t, f_t>>
     sol_dual_simplex_ptr;
   std::thread dual_simplex_thread;
+  std::exception_ptr dual_simplex_exception;
+  auto request_concurrent_halt = [&settings_pdlp]() {
+    if (settings_pdlp.concurrent_halt != nullptr) { settings_pdlp.concurrent_halt->store(1); }
+  };
   if (!settings.inside_mip) {
-    dual_simplex_thread = std::thread(run_dual_simplex_thread<i_t, f_t>,
-                                      std::ref(dual_simplex_problem),
-                                      std::ref(settings_pdlp),
-                                      std::ref(sol_dual_simplex_ptr),
-                                      std::ref(timer));
+    dual_simplex_thread = std::thread([&]() {
+      try {
+        run_dual_simplex_thread<i_t, f_t>(
+          dual_simplex_problem, settings_pdlp, sol_dual_simplex_ptr, timer);
+      } catch (...) {
+        dual_simplex_exception = std::current_exception();
+        request_concurrent_halt();
+      }
+    });
   }
   // Create a thread for barrier.
   // The barrier handle is owned here so that its destructor runs on the
@@ -1505,25 +1513,28 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
   std::unique_ptr<
     std::tuple<dual_simplex::lp_solution_t<i_t, f_t>, dual_simplex::lp_status_t, f_t, f_t, f_t>>
     sol_barrier_ptr;
+  std::exception_ptr barrier_exception;
   auto barrier_thread = std::thread([&]() {
-    auto call_barrier_thread = [&]() {
-      rmm::cuda_stream_view barrier_stream = rmm::cuda_stream_per_thread;
-      barrier_handle_ptr                   = std::make_unique<raft::handle_t>(barrier_stream);
-      auto barrier_problem                 = dual_simplex_problem;
-      barrier_problem.handle_ptr           = barrier_handle_ptr.get();
+    try {
+      auto call_barrier_thread = [&]() {
+        rmm::cuda_stream_view barrier_stream = rmm::cuda_stream_per_thread;
+        barrier_handle_ptr                   = std::make_unique<raft::handle_t>(barrier_stream);
+        auto barrier_problem                 = dual_simplex_problem;
+        barrier_problem.handle_ptr           = barrier_handle_ptr.get();
 
-      run_barrier_thread<i_t, f_t>(std::ref(barrier_problem),
-                                   std::ref(settings_pdlp),
-                                   std::ref(sol_barrier_ptr),
-                                   std::ref(timer));
-    };
-    if (settings.num_gpus > 1) {
-      problem.handle_ptr->sync_stream();
-      raft::device_setter device_setter(1);  // Scoped variable
-      CUOPT_LOG_DEBUG("Barrier device: %d", device_setter.get_current_device());
-      call_barrier_thread();
-    } else {
-      call_barrier_thread();
+        run_barrier_thread<i_t, f_t>(barrier_problem, settings_pdlp, sol_barrier_ptr, timer);
+      };
+      if (settings.num_gpus > 1) {
+        problem.handle_ptr->sync_stream();
+        raft::device_setter device_setter(1);  // Scoped variable
+        CUOPT_LOG_DEBUG("Barrier device: %d", device_setter.get_current_device());
+        call_barrier_thread();
+      } else {
+        call_barrier_thread();
+      }
+    } catch (...) {
+      barrier_exception = std::current_exception();
+      request_concurrent_halt();
     }
   });
 
@@ -1540,18 +1551,21 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
   try {
     sol_pdlp = run_pdlp(problem, settings_pdlp, timer, is_batch_mode);
   } catch (...) {
-    pdlp_exception                 = std::current_exception();
-    *settings_pdlp.concurrent_halt = 1;
-    std::rethrow_exception(pdlp_exception);
+    pdlp_exception = std::current_exception();
+    request_concurrent_halt();
   }
 
   // Wait for dual simplex thread to finish
-  if (!settings.inside_mip) { dual_simplex_thread.join(); }
+  if (dual_simplex_thread.joinable()) { dual_simplex_thread.join(); }
 
-  barrier_thread.join();
+  if (barrier_thread.joinable()) { barrier_thread.join(); }
   // At this point, it is safe to destroy the barrier context since we're outside of any PDLP graph
   // capture.
   barrier_handle_ptr.reset();
+
+  if (pdlp_exception) { std::rethrow_exception(pdlp_exception); }
+  if (dual_simplex_exception) { std::rethrow_exception(dual_simplex_exception); }
+  if (barrier_exception) { std::rethrow_exception(barrier_exception); }
 
   // copy the dual simplex solution to the device
   auto sol_dual_simplex =

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -42,6 +42,7 @@
 #include <thrust/functional.h>
 #include <thrust/logical.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
@@ -140,6 +141,30 @@ TEST(pdlp_class, precision_mixed)
   EXPECT_NEAR(solution_mixed.get_additional_termination_information().primal_objective,
               solution_full.get_additional_termination_information().primal_objective,
               1e-2);
+}
+
+TEST(pdlp_class, concurrent_pdlp_exception_joins_worker_threads)
+{
+  const raft::handle_t handle_{};
+
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mps_parser::mps_data_model_t<int, double> op_problem =
+    cuopt::mps_parser::parse_mps<int, double>(path, true);
+
+  auto settings           = pdlp_solver_settings_t<int, double>{};
+  settings.method         = cuopt::linear_programming::method_t::Concurrent;
+  settings.presolver      = cuopt::linear_programming::presolver_t::None;
+  settings.log_to_console = false;
+  // In concurrent mode, dual simplex and barrier workers are started before PDLP validates that
+  // all_primal_feasible is batch-only. This exercises the exception path with live worker threads.
+  settings.all_primal_feasible = true;
+
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+  const auto error_status                               = solution.get_error_status();
+
+  EXPECT_EQ(error_status.get_error_type(), cuopt::error_type_t::ValidationError);
+  EXPECT_THAT(error_status.what(),
+              testing::HasSubstr("all_primal_feasible only applies in batch mode"));
 }
 
 TEST(pdlp_class, run_double_very_low_accuracy)


### PR DESCRIPTION
Join concurrent solver worker threads before rethrowing exceptions so std::thread destructors do not terminate the process. Add a deterministic regression test that exercises a PDLP validation error after concurrent workers start.

Prevents some core dumps and gives a more useful error message for the test_incumbent_callbacks flaky test failure.

Old failure:
```
 | Explored | Unexplored |    Objective    |     Bound     | IntInf | Depth | Iter/Node |   Gap    |  Time  |
terminate called without an active exception
Fatal Python error: Aborted

Current thread 0x0000e727cfdde020 (most recent call first):
  File "/pyenv/versions/3.11.15/lib/python3.11/site-packages/cuopt/linear_programming/solver/solver.py", line 98 in Solve
  File "/pyenv/versions/3.11.15/lib/python3.11/site-packages/cuopt/utilities/exception_handler.py", line 24 in func
  File "/__w/cuopt/cuopt/python/cuopt/cuopt/tests/linear_programming/test_incumbent_callbacks.py", line 87 in _run_incumbent_solver_callback
  File "/__w/cuopt/cuopt/python/cuopt/cuopt/tests/linear_programming/test_incumbent_callbacks.py", line 112 in test_incumbent_get_callback
```

New failure:
```
=================================== FAILURES ===================================
_________________ test_incumbent_get_callback[/mip/swath1.mps] _________________

file_name = '/mip/swath1.mps'

    @pytest.mark.parametrize(
        "file_name",
        [
            ("/mip/swath1.mps"),
            ("/mip/neos5-free-bound.mps"),
        ],
    )
    def test_incumbent_get_callback(file_name):
>       _run_incumbent_solver_callback(file_name, include_set_callback=False)

tests/linear_programming/test_incumbent_callbacks.py:112: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/linear_programming/test_incumbent_callbacks.py:87: in _run_incumbent_solver_callback
    solution = solver.Solve(data_model_obj, settings)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/conda/envs/test/lib/python3.12/site-packages/cuopt/utilities/exception_handler.py:48: in func
    raise e
/opt/conda/envs/test/lib/python3.12/site-packages/cuopt/utilities/exception_handler.py:24: in func
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
/opt/conda/envs/test/lib/python3.12/site-packages/cuopt/linear_programming/solver/solver.py:98: in Solve
    s = solver_wrapper.Solve(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   RuntimeError: CUDA error encountered at: file=/tmp/conda-bld-output/bld/rattler-build_libmps-parser/work/cpp/src/pdlp/utilities/ping_pong_graph.cu line=57: call='cudaStreamEndCapture(stream_view_.value(), &even_graph)', Reason=cudaErrorStreamCaptureInvalidated:operation failed due to a previous error during capture
```