### PR TITLE
ci: split build.yaml concurrency group by build_type

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.build_type || 'branch' }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Summary
- The concurrency group in `build.yaml` was keyed on `workflow + ref`, so a push to `main` (or `release/*`) would cancel an in-progress nightly-dispatched `build.yaml` run on the same branch — and the reverse was equally true.
- Add the `build_type` input to the group key (falling back to `'branch'` when `inputs` is unset on `push`) so nightly and branch builds occupy separate groups.
- Same-type, same-ref runs still cancel older runs (e.g. rapid pushes to `main` still supersede each other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)