### PR TITLE
Fix destruction order in solve.cu

### DIFF
--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -401,8 +401,6 @@ mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_p
     // Start early FJ (CPU and GPU) during presolve to find incumbents ASAP
     // Only run if presolve is enabled (gives FJ time to find solutions)
     // and we're not in deterministic mode
-    std::unique_ptr<detail::early_cpufj_t<i_t, f_t>> early_cpufj;
-    std::unique_ptr<detail::early_gpufj_t<i_t, f_t>> early_gpufj;
 
     // Track best incumbent found during presolve (shared across CPU and GPU FJ).
     // early_best_objective is in the original problem's solver-space (always minimization),
@@ -413,6 +411,9 @@ mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_p
     f_t early_best_user_obj{std::numeric_limits<f_t>::infinity()};
     std::vector<f_t> early_best_user_assignment;
     std::mutex early_callback_mutex;
+
+    std::unique_ptr<detail::early_cpufj_t<i_t, f_t>> early_cpufj;
+    std::unique_ptr<detail::early_gpufj_t<i_t, f_t>> early_gpufj;
 
     bool run_early_fj = run_presolve && settings.determinism_mode != CUOPT_MODE_DETERMINISTIC &&
                         op_problem.get_n_integers() > 0 && op_problem.get_n_constraints() > 0;


### PR DESCRIPTION
early_cpufj and early_gpufj capture early_best_objective, early_best_user_obj, early_best_user_assignment, and early_callback_mutex by reference via the callbacks. They should be destructed before the values they capture by reference for safety.