### PR TITLE
Declare defaulted move ops noexcept (SonarQube BLOCKER cpp:S5018)

### DIFF
--- a/cpp/include/cuopt/linear_programming/optimization_problem.hpp
+++ b/cpp/include/cuopt/linear_programming/optimization_problem.hpp
@@ -116,8 +116,8 @@ class optimization_problem_t : public optimization_problem_interface_t<i_t, f_t>
 
   explicit optimization_problem_t(raft::handle_t const* handle_ptr);
   optimization_problem_t(const optimization_problem_t<i_t, f_t>& other);
-  optimization_problem_t(optimization_problem_t<i_t, f_t>&&)            = default;
-  optimization_problem_t& operator=(optimization_problem_t<i_t, f_t>&&) = default;
+  optimization_problem_t(optimization_problem_t<i_t, f_t>&&) noexcept            = default;
+  optimization_problem_t& operator=(optimization_problem_t<i_t, f_t>&&) noexcept = default;
 
   std::vector<internals::base_solution_callback_t*> mip_callbacks_;
 

--- a/cpp/include/cuopt/linear_programming/pdlp/pdlp_warm_start_data.hpp
+++ b/cpp/include/cuopt/linear_programming/pdlp/pdlp_warm_start_data.hpp
@@ -68,7 +68,7 @@ struct pdlp_warm_start_data_t {
 
   // Copy constructor for when copying the solver_settings object in the PDLP object
   pdlp_warm_start_data_t(const pdlp_warm_start_data_t<i_t, f_t>& other);
-  pdlp_warm_start_data_t& operator=(pdlp_warm_start_data_t&& other) = default;
+  pdlp_warm_start_data_t& operator=(pdlp_warm_start_data_t&& other) noexcept = default;
 
   // Check if warmstart data is populated (same sentinel check as release/26.02)
   bool is_populated() const { return last_restart_duality_gap_dual_solution_.size() > 0; }

--- a/cpp/src/branch_and_bound/deterministic_workers.hpp
+++ b/cpp/src/branch_and_bound/deterministic_workers.hpp
@@ -310,8 +310,8 @@ class deterministic_diving_worker_t
 
   deterministic_diving_worker_t(const deterministic_diving_worker_t&)            = delete;
   deterministic_diving_worker_t& operator=(const deterministic_diving_worker_t&) = delete;
-  deterministic_diving_worker_t(deterministic_diving_worker_t&&)                 = default;
-  deterministic_diving_worker_t& operator=(deterministic_diving_worker_t&&)      = default;
+  deterministic_diving_worker_t(deterministic_diving_worker_t&&) noexcept            = default;
+  deterministic_diving_worker_t& operator=(deterministic_diving_worker_t&&) noexcept = default;
 
   bool has_work_impl() const { return !dive_queue.empty(); }
 

--- a/cpp/src/branch_and_bound/deterministic_workers.hpp
+++ b/cpp/src/branch_and_bound/deterministic_workers.hpp
@@ -308,8 +308,8 @@ class deterministic_diving_worker_t
     dive_upper = original_lp.upper;
   }
 
-  deterministic_diving_worker_t(const deterministic_diving_worker_t&)            = delete;
-  deterministic_diving_worker_t& operator=(const deterministic_diving_worker_t&) = delete;
+  deterministic_diving_worker_t(const deterministic_diving_worker_t&)                = delete;
+  deterministic_diving_worker_t& operator=(const deterministic_diving_worker_t&)     = delete;
   deterministic_diving_worker_t(deterministic_diving_worker_t&&) noexcept            = default;
   deterministic_diving_worker_t& operator=(deterministic_diving_worker_t&&) noexcept = default;
 

--- a/cpp/src/branch_and_bound/mip_node.hpp
+++ b/cpp/src/branch_and_bound/mip_node.hpp
@@ -58,8 +58,8 @@ class mip_node_t {
     // scope-exit ensure destruction of all detached leaves
   }
 
-  mip_node_t(mip_node_t&&)            = default;
-  mip_node_t& operator=(mip_node_t&&) = default;
+  mip_node_t(mip_node_t&&) noexcept            = default;
+  mip_node_t& operator=(mip_node_t&&) noexcept = default;
 
   mip_node_t()
     : status(node_status_t::PENDING),


### PR DESCRIPTION
SonarQube rule **`cpp:S5018`** flags `= default`ed move constructors and move-assignment operators that arent declared `noexcept`. This PR adds `noexcept` to the seven flagged sites on `main`, clearing **7 of 8 BLOCKER** findings.

All affected classes already move trivially-noexcept members (`std::vector`, `std::unique_ptr`, `rmm::device_uvector`, raw pointers, scalars), so the specifier compiles cleanly. None of these four types are currently stored by value in an STL container (`mip_node_t` is always behind `unique_ptr` or raw pointer; the other three dont appear in containers), so on the current code this is a runtime no-op — it just satisfies the lint rule.