### PR TITLE
CI: suppress shell:S4830 false positive and scope GHA permissions to job level

### DIFF
--- a/.github/workflows/build_test_publish_images.yaml
+++ b/.github/workflows/build_test_publish_images.yaml
@@ -36,24 +36,11 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  actions: read
-  checks: none
-  contents: read
-  deployments: none
-  discussions: none
-  id-token: write
-  issues: none
-  packages: read
-  pages: none
-  pull-requests: read
-  repository-projects: none
-  security-events: none
-  statuses: none
-
 jobs:
   compute-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: rapidsai/ci-conda:26.06-latest
     outputs:
@@ -111,6 +98,8 @@ jobs:
   build-images:
     name: Build images
     needs: compute-matrix
+    permissions:
+      contents: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     strategy:
       matrix: ${{ fromJson(needs.compute-matrix.outputs.MATRIX) }}
@@ -127,6 +116,8 @@ jobs:
   build-cuopt-multiarch-manifest:
     name: Build cuopt multiarch manifest
     needs: [build-images, compute-matrix]
+    permissions:
+      contents: read
     strategy:
       matrix:
         CUDA_VER: ${{ fromJson(needs.compute-matrix.outputs.MATRIX).cuda_ver }}
@@ -171,6 +162,8 @@ jobs:
   test-images:
     name: Test images
     needs: [build-cuopt-multiarch-manifest, compute-matrix]
+    permissions:
+      contents: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     strategy:
       matrix:

--- a/ci/test_self_hosted_service.sh
+++ b/ci/test_self_hosted_service.sh
@@ -79,7 +79,7 @@ DELAY=10
 
 sleep $DELAY
 
-server_status=$(curl -k -sL https://0.0.0.0:$CUOPT_SERVER_PORT/cuopt/health)
+server_status=$(curl -k -sL https://0.0.0.0:$CUOPT_SERVER_PORT/cuopt/health) # NOSONAR — self-signed cert generated locally by this script for CI; not a real TLS endpoint.
 
 EXITCODE=0
 


### PR DESCRIPTION
## Summary

Closes **6 SonarQube findings** on `main` — 1 CRITICAL VULN and 5 MAJOR VULNs — without changing runtime behavior.

### `ci/test_self_hosted_service.sh` — suppress `shell:S4830`
The `curl -k` on the health probe is intentional: this same script generates a self-signed cert and starts the cuOpt server two lines earlier, so there is no real TLS endpoint to validate against (subsequent `cuopt_sh` calls *do* validate using the test CA in `$CLIENT_CERT`). Added a `# NOSONAR` marker with rationale.

### `.github/workflows/build_test_publish_images.yaml` — job-scoped permissions
Moved the workflow-level `permissions:` block to per-job blocks (rule `githubactions:S8264`/`S8233`). After reading the two reusable workflows (`build_images.yaml`, `test_images.yaml`), every job only does `actions/checkout` + DockerHub/NGC logins via username/password secrets — no OIDC, no GHCR pull, no artifact download, no PR API. So each job is reduced to `contents: read` only, dropping unused `actions: read`, `id-token: write`, `packages: read`, `pull-requests: read`.