### PR TITLE
Drop constness in raft handle for `data_model_view_t` (routing)

### DIFF
--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-main
+release/26.06

--- a/cpp/include/cuopt/routing/cython/cython.hpp
+++ b/cpp/include/cuopt/routing/cython/cython.hpp
@@ -89,7 +89,7 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
 
 // Wrapper for dataset to expose the API to cython.
 std::unique_ptr<dataset_ret_t> call_generate_dataset(
-  raft::handle_t const& handle, routing::generator::dataset_params_t<int, float> const& params);
+  raft::handle_t& handle, routing::generator::dataset_params_t<int, float> const& params);
 
 }  // namespace cython
 }  // namespace cuopt

--- a/cpp/include/cuopt/routing/data_model_view.hpp
+++ b/cpp/include/cuopt/routing/data_model_view.hpp
@@ -49,7 +49,7 @@ class data_model_view_t {
    * contains the smallest possible number of vehicles which may be smaller or
    * equal to the fleet_size.
    */
-  data_model_view_t(raft::handle_t const* handle_ptr,
+  data_model_view_t(raft::handle_t* handle_ptr,
                     i_t num_locations,
                     i_t const fleet_size,
                     i_t num_orders = -1);
@@ -611,10 +611,10 @@ class data_model_view_t {
    * @brief Get raft handle object containing GPU resource objects
    * @return Handle object
    */
-  raft::handle_t const* get_handle_ptr() const noexcept;
+  raft::handle_t* get_handle_ptr() const noexcept;
 
  private:
-  raft::handle_t const* handle_ptr_{nullptr};
+  raft::handle_t* handle_ptr_{nullptr};
   i_t num_locations_{};
   i_t fleet_size_{};
   i_t num_orders_{};

--- a/cpp/include/cuopt/routing/data_model_view.hpp
+++ b/cpp/include/cuopt/routing/data_model_view.hpp
@@ -611,7 +611,13 @@ class data_model_view_t {
    * @brief Get raft handle object containing GPU resource objects
    * @return Handle object
    */
-  raft::handle_t* get_handle_ptr() const noexcept;
+  raft::handle_t* get_handle_ptr() noexcept;
+
+  /**
+   * @brief Get raft handle object containing GPU resource objects
+   * @return Handle object
+   */
+  raft::handle_t const* get_handle_ptr() const noexcept;
 
  private:
   raft::handle_t* handle_ptr_{nullptr};

--- a/cpp/src/routing/data_model_view.cu
+++ b/cpp/src/routing/data_model_view.cu
@@ -732,7 +732,13 @@ raft::device_span<f_t const> data_model_view_t<i_t, f_t>::get_vehicle_fixed_cost
 }
 
 template <typename i_t, typename f_t>
-raft::handle_t* data_model_view_t<i_t, f_t>::get_handle_ptr() const noexcept
+raft::handle_t* data_model_view_t<i_t, f_t>::get_handle_ptr() noexcept
+{
+  return handle_ptr_;
+}
+
+template <typename i_t, typename f_t>
+raft::handle_t const* data_model_view_t<i_t, f_t>::get_handle_ptr() const noexcept
 {
   return handle_ptr_;
 }

--- a/cpp/src/routing/data_model_view.cu
+++ b/cpp/src/routing/data_model_view.cu
@@ -20,7 +20,7 @@ namespace cuopt {
 namespace routing {
 
 template <typename i_t, typename f_t>
-data_model_view_t<i_t, f_t>::data_model_view_t(raft::handle_t const* handle_ptr,
+data_model_view_t<i_t, f_t>::data_model_view_t(raft::handle_t* handle_ptr,
                                                i_t num_locations,
                                                i_t const fleet_size,
                                                i_t num_orders)
@@ -732,7 +732,7 @@ raft::device_span<f_t const> data_model_view_t<i_t, f_t>::get_vehicle_fixed_cost
 }
 
 template <typename i_t, typename f_t>
-raft::handle_t const* data_model_view_t<i_t, f_t>::get_handle_ptr() const noexcept
+raft::handle_t* data_model_view_t<i_t, f_t>::get_handle_ptr() const noexcept
 {
   return handle_ptr_;
 }

--- a/cpp/src/routing/generator/generator.cu
+++ b/cpp/src/routing/generator/generator.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -65,7 +65,7 @@ std::vector<break_dimension_t<i_t>>& dataset_t<i_t, f_t>::get_vehicle_breaks()
 }
 
 template <typename i_t, typename f_t>
-dataset_t<i_t, f_t> generate_dataset(raft::handle_t const& handle,
+dataset_t<i_t, f_t> generate_dataset(raft::handle_t& handle,
                                      dataset_params_t<i_t, f_t> const& params)
 {
   cuopt_expects(params.n_locations >= 2,
@@ -102,7 +102,7 @@ dataset_t<i_t, f_t> generate_dataset(raft::handle_t const& handle,
 }
 template <typename i_t, typename f_t>
 detail::fleet_order_constraints_t<i_t> generate_fleet_order_constraints(
-  raft::handle_t const& handle, dataset_params_t<i_t, f_t> const& params)
+  raft::handle_t& handle, dataset_params_t<i_t, f_t> const& params)
 {
   auto n_orders   = params.n_locations;
   auto n_vehicles = params.n_locations - 1;
@@ -125,7 +125,7 @@ detail::fleet_order_constraints_t<i_t> generate_fleet_order_constraints(
 }
 
 template <typename i_t, typename f_t>
-detail::fleet_info_t<i_t, f_t> generate_fleet_info(raft::handle_t const& handle,
+detail::fleet_info_t<i_t, f_t> generate_fleet_info(raft::handle_t& handle,
                                                    dataset_params_t<i_t, f_t> const& params,
                                                    detail::order_info_t<i_t, f_t> const& order_info)
 {
@@ -147,7 +147,7 @@ detail::fleet_info_t<i_t, f_t> generate_fleet_info(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-detail::order_info_t<i_t, f_t> generate_order_info(raft::handle_t const& handle,
+detail::order_info_t<i_t, f_t> generate_order_info(raft::handle_t& handle,
                                                    dataset_params_t<i_t, f_t> const& params)
 {
   detail::order_info_t<i_t, f_t> order_info(&handle, params.n_locations - 1);
@@ -160,7 +160,7 @@ detail::order_info_t<i_t, f_t> generate_order_info(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-coordinates_t<f_t> generate_coordinates(raft::handle_t const& handle,
+coordinates_t<f_t> generate_coordinates(raft::handle_t& handle,
                                         dataset_params_t<i_t, f_t> const& params)
 {
   rmm::device_uvector<f_t> v_x_pos(params.n_locations, handle.get_stream());
@@ -213,7 +213,7 @@ coordinates_t<f_t> generate_coordinates(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-d_mdarray_t<f_t> generate_matrices(raft::handle_t const& handle,
+d_mdarray_t<f_t> generate_matrices(raft::handle_t& handle,
                                    dataset_params_t<i_t, f_t> const& params,
                                    coordinates_t<f_t> const& coordinates)
 {
@@ -264,7 +264,7 @@ d_mdarray_t<f_t> generate_matrices(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<i_t> generate_random_fleet(raft::handle_t const& handle,
+rmm::device_uvector<i_t> generate_random_fleet(raft::handle_t& handle,
                                                size_t n_splits,
                                                size_t fleet_size)
 {
@@ -283,7 +283,7 @@ rmm::device_uvector<i_t> generate_random_fleet(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t const& handle,
+rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t& handle,
                                                     dataset_params_t<i_t, f_t> const& params,
                                                     size_t fleet_size)
 {
@@ -291,7 +291,7 @@ rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t const& handle
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t const& handle,
+rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t& handle,
                                                          dataset_params_t<i_t, f_t> const& params,
                                                          size_t fleet_size)
 {
@@ -315,7 +315,7 @@ rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t const& h
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t const& handle,
+rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t& handle,
                                                  dataset_params_t<i_t, f_t> const& params)
 {
   std::vector<demand_i_t> h_min_demand(params.dim);
@@ -340,7 +340,7 @@ rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<bool> generate_drop_return_trips(raft::handle_t const& handle,
+rmm::device_uvector<bool> generate_drop_return_trips(raft::handle_t& handle,
                                                      dataset_params_t<i_t, f_t> const& params,
                                                      size_t fleet_size)
 {
@@ -356,7 +356,7 @@ rmm::device_uvector<bool> generate_drop_return_trips(raft::handle_t const& handl
 }
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<bool> generate_skip_first_trips(raft::handle_t const& handle,
+rmm::device_uvector<bool> generate_skip_first_trips(raft::handle_t& handle,
                                                     dataset_params_t<i_t, f_t> const& params,
                                                     size_t fleet_size)
 {
@@ -373,7 +373,7 @@ rmm::device_uvector<bool> generate_skip_first_trips(raft::handle_t const& handle
 
 template <typename i_t, typename f_t>
 std::vector<break_dimension_t<i_t>> generate_vehicle_breaks(
-  raft::handle_t const& handle,
+  raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info,
   size_t fleet_size)
@@ -406,7 +406,7 @@ std::vector<break_dimension_t<i_t>> generate_vehicle_breaks(
 
 template <typename i_t, typename f_t>
 vehicle_time_window_t<i_t> generate_vehicle_time_windows(
-  raft::handle_t const& handle,
+  raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info,
   size_t fleet_size)
@@ -452,7 +452,7 @@ vehicle_time_window_t<i_t> generate_vehicle_time_windows(
 }
 
 template <typename i_t, typename f_t>
-rmm ::device_uvector<i_t> create_service_time(raft::handle_t const& handle,
+rmm ::device_uvector<i_t> create_service_time(raft::handle_t& handle,
                                               dataset_params_t<i_t, f_t> const& params)
 {
   rmm::device_uvector<i_t> v_service_time(params.n_locations, handle.get_stream());
@@ -472,7 +472,7 @@ rmm ::device_uvector<i_t> create_service_time(raft::handle_t const& handle,
 }
 
 template <typename i_t, typename f_t>
-time_window_t<i_t> generate_time_windows(raft::handle_t const& handle,
+time_window_t<i_t> generate_time_windows(raft::handle_t& handle,
                                          dataset_params_t<i_t, f_t> const& params)
 {
   rmm::device_uvector<i_t> v_earliest_time(params.n_locations, handle.get_stream());
@@ -501,10 +501,10 @@ time_window_t<i_t> generate_time_windows(raft::handle_t const& handle,
 }
 
 template class dataset_t<int, float>;
-template dataset_t<int, float> generate_dataset<int, float>(raft::handle_t const&,
+template dataset_t<int, float> generate_dataset<int, float>(raft::handle_t&,
                                                             dataset_params_t<int, float> const&);
 template rmm::device_uvector<uint8_t> generate_vehicle_types<int, float>(
-  raft::handle_t const&, dataset_params_t<int, float> const&, size_t fleet_size);
+  raft::handle_t&, dataset_params_t<int, float> const&, size_t fleet_size);
 }  // namespace generator
 }  // namespace routing
 }  // namespace cuopt

--- a/cpp/src/routing/generator/generator.hpp
+++ b/cpp/src/routing/generator/generator.hpp
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -58,53 +58,53 @@ class dataset_t {
 };
 
 template <typename i_t, typename f_t>
-detail::order_info_t<i_t, f_t> generate_order_info(raft::handle_t const& handle,
+detail::order_info_t<i_t, f_t> generate_order_info(raft::handle_t& handle,
                                                    dataset_params_t<i_t, f_t> const& params);
 
 template <typename i_t, typename f_t>
 detail::fleet_order_constraints_t<i_t> generate_fleet_order_constraints(
-  raft::handle_t const& handle, dataset_params_t<i_t, f_t> const& params);
+  raft::handle_t& handle, dataset_params_t<i_t, f_t> const& params);
 
 template <typename i_t, typename f_t>
 detail::fleet_info_t<i_t, f_t> generate_fleet_info(
-  raft::handle_t const& handle,
+  raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info);
 
 template <typename i_t, typename f_t>
-coordinates_t<f_t> generate_coordinates(raft::handle_t const&, dataset_params_t<i_t, f_t> const&);
+coordinates_t<f_t> generate_coordinates(raft::handle_t&, dataset_params_t<i_t, f_t> const&);
 
 template <typename i_t, typename f_t>
-d_mdarray_t<f_t> generate_matrices(raft::handle_t const&,
+d_mdarray_t<f_t> generate_matrices(raft::handle_t&,
                                    dataset_params_t<i_t, f_t> const&,
                                    coordinates_t<f_t> const&);
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t const& handle,
+rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t& handle,
                                                  dataset_params_t<i_t, f_t> const& params);
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t const& handle,
+rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t& handle,
                                                          dataset_params_t<i_t, f_t> const& params,
                                                          size_t fleet_size);
 
 template <typename i_t, typename f_t>
-time_window_t<i_t> generate_time_windows(raft::handle_t const& handle,
+time_window_t<i_t> generate_time_windows(raft::handle_t& handle,
                                          dataset_params_t<i_t, f_t> const& params);
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<bool> generate_drop_return_trips(raft::handle_t const& handle,
+rmm::device_uvector<bool> generate_drop_return_trips(raft::handle_t& handle,
                                                      dataset_params_t<i_t, f_t> const& params,
                                                      size_t fleet_size);
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<bool> generate_skip_first_trips(raft::handle_t const& handle,
+rmm::device_uvector<bool> generate_skip_first_trips(raft::handle_t& handle,
                                                     dataset_params_t<i_t, f_t> const& params,
                                                     size_t fleet_size);
 
 template <typename i_t, typename f_t>
 vehicle_time_window_t<i_t> generate_vehicle_time_windows(
-  raft::handle_t const& handle,
+  raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info,
   detail::fleet_order_constraints_t<i_t> const& fleet_order_constraints,
@@ -112,13 +112,13 @@ vehicle_time_window_t<i_t> generate_vehicle_time_windows(
 
 template <typename i_t, typename f_t>
 std::vector<break_dimension_t<i_t>> generate_vehicle_breaks(
-  raft::handle_t const& handle,
+  raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info,
   size_t fleet_size);
 
 template <typename i_t, typename f_t>
-rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t const& handle,
+rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t& handle,
                                                     dataset_params_t<i_t, f_t> const& params,
                                                     size_t fleet_size);
 
@@ -131,7 +131,7 @@ rmm::device_uvector<uint8_t> generate_vehicle_types(raft::handle_t const& handle
  * @return dataset_t holding matrices, orders and vehicle info.
  */
 template <typename i_t, typename f_t>
-dataset_t<i_t, f_t> generate_dataset(raft::handle_t const& handle,
+dataset_t<i_t, f_t> generate_dataset(raft::handle_t& handle,
                                      dataset_params_t<i_t, f_t> const& params);
 }  // namespace generator
 }  // namespace routing

--- a/cpp/src/routing/generator/generator.hpp
+++ b/cpp/src/routing/generator/generator.hpp
@@ -107,7 +107,6 @@ vehicle_time_window_t<i_t> generate_vehicle_time_windows(
   raft::handle_t& handle,
   dataset_params_t<i_t, f_t> const& params,
   detail::order_info_t<i_t, f_t> const& order_info,
-  detail::fleet_order_constraints_t<i_t> const& fleet_order_constraints,
   size_t fleet_size);
 
 template <typename i_t, typename f_t>

--- a/cpp/src/routing/utilities/cython.cu
+++ b/cpp/src/routing/utilities/cython.cu
@@ -120,8 +120,7 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
     data_models[i]->get_handle_ptr()->sync_stream();
 
     // Set new non blocking stream for current data model
-    const raft::handle_t handle = *data_models[i]->get_handle_ptr();
-    raft::resource::set_cuda_stream(handle, stream_pool.get_stream(i));
+    raft::resource::set_cuda_stream(*data_models[i]->get_handle_ptr(), stream_pool.get_stream(i));
     auto routing_solution = cuopt::routing::solve(*data_models[i], *settings);
 
     // Make sure current solve is finished

--- a/cpp/src/routing/utilities/cython.cu
+++ b/cpp/src/routing/utilities/cython.cu
@@ -120,7 +120,8 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
     data_models[i]->get_handle_ptr()->sync_stream();
 
     // Set new non blocking stream for current data model
-    raft::resource::set_cuda_stream(*(data_models[i]->get_handle_ptr()), stream_pool.get_stream(i));
+    const raft::handle_t handle = *data_models[i]->get_handle_ptr();
+    raft::resource::set_cuda_stream(handle, stream_pool.get_stream(i));
     auto routing_solution = cuopt::routing::solve(*data_models[i], *settings);
 
     // Make sure current solve is finished

--- a/cpp/src/routing/utilities/cython.cu
+++ b/cpp/src/routing/utilities/cython.cu
@@ -162,7 +162,7 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
  * @param solver Composable solver object
  */
 std::unique_ptr<dataset_ret_t> call_generate_dataset(
-  raft::handle_t const& handle, routing::generator::dataset_params_t<int, float> const& params)
+  raft::handle_t& handle, routing::generator::dataset_params_t<int, float> const& params)
 {
   auto data           = routing::generator::generate_dataset<int, float>(handle, params);
   auto [x_pos, y_pos] = data.get_coordinates();

--- a/python/cuopt/cuopt/routing/structure/routing_utilities.pxd
+++ b/python/cuopt/cuopt/routing/structure/routing_utilities.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved. # noqa
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved. # noqa
 # SPDX-License-Identifier: Apache-2.0
 
 # cython: profile=False
@@ -125,7 +125,7 @@ cdef extern from "cuopt/routing/cython/cython.hpp" namespace "cuopt::cython": # 
         i_t seed) except +
 
     cdef unique_ptr[dataset_ret_t] call_generate_dataset(
-        const handle_t& handle,
+        handle_t& handle,
         const dataset_params_t[int, float]& params
     ) except +
 


### PR DESCRIPTION
Dropped the `const` qualifier for the `raft::handle_t` on the `data_model_view_t` (routing) due to the recent changes in `raft::resources` (https://github.com/rapidsai/raft/pull/3005). 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
