### PR TITLE
Fix vehicle fixed cost accounting in fragment-vs-route deltas

### DIFF
--- a/cpp/src/routing/crossovers/ox_kernels.cuh
+++ b/cpp/src/routing/crossovers/ox_kernels.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/routing/crossovers/ox_kernels.cuh
+++ b/cpp/src/routing/crossovers/ox_kernels.cuh
@@ -174,8 +174,6 @@ __global__ void calculate_edge_costs_kernel(
     const auto& dimensions_info = solution.problem.dimensions_info;
 
     double cost = 0.;
-    double optimal_vehicle_fixed_cost =
-      dimensions_info.has_dimension(dim_t::VEHICLE_FIXED_COST) ? vehicle_info.fixed_cost : 0.;
 
     node_t<i_t, f_t, REQUEST> helper_nodes[3] = {node_t<i_t, f_t, REQUEST>(dimensions_info),
                                                  node_t<i_t, f_t, REQUEST>(dimensions_info),
@@ -198,7 +196,8 @@ __global__ void calculate_edge_costs_kernel(
       cost = node_t<i_t, f_t, REQUEST>::cost_combine(
         helper_nodes[b], helper_nodes[2], vehicle_info, true, weights, d_zero_cost, d_zero_cost);
 
-      row_value[row_n_edges] = optimal_vehicle_fixed_cost + cost;
+      // cost includes vehicle_info.fixed_cost via vehicle_fixed_cost_node_t::get_cost
+      row_value[row_n_edges] = cost;
       row_edge[row_n_edges]  = j;
       ++row_n_edges;
 

--- a/cpp/src/routing/crossovers/ox_recombiner.cuh
+++ b/cpp/src/routing/crossovers/ox_recombiner.cuh
@@ -841,8 +841,6 @@ struct OX {
       auto start_depot_node_info  = A.problem->start_depot_node_infos_h[vehicle_id];
       auto return_depot_node_info = A.problem->return_depot_node_infos_h[vehicle_id];
       auto cuopt_weights          = get_cuopt_cost(weights);
-      double optimal_vehicle_fixed_cost =
-        dimensions_info.has_dimension(dim_t::VEHICLE_FIXED_COST) ? vehicle_info.fixed_cost : 0.;
 
       // Here we have to use the vehicle type 'veh'
       HelperNodes[2] =
@@ -868,7 +866,8 @@ struct OX {
                                                                           cuopt_weights,
                                                                           objective_cost_t{},
                                                                           infeasible_cost_t{});
-          graph[i].emplace_back(j, optimal_vehicle_fixed_cost + cost, veh);
+          // cost includes vehicle_info.fixed_cost via vehicle_fixed_cost_node_t::get_cost
+          graph[i].emplace_back(j, cost, veh);
           if (j + 1 == offspring.size()) break;
 
           HelperNodes[!b] =

--- a/cpp/src/routing/local_search/local_search.cu
+++ b/cpp/src/routing/local_search/local_search.cu
@@ -308,12 +308,11 @@ void local_search_t<i_t, f_t, REQUEST>::run_best_local_search(solution_t<i_t, f_
       perform_moves(sol, move_candidates);
       cuopt_func_call(sol.check_cost_coherence(move_candidates.weights));
       sol.global_runtime_checks(should_all_nodes_be_served, false, "run_best_local_search_end");
-      // with very big weights 1. epsilon is not enough
       cuopt_func_call(sol.compute_cost());
       cuopt_func_call(cost_after =
                         sol.get_cost(move_candidates.include_objective, move_candidates.weights));
-      // cuopt_assert((cost_after - cost_before) - move_candidates.cycles.total_cycle_cost < 1.,
-      //             "Cost mismatch after a move");
+      cuopt_assert((cost_after - cost_before) - move_candidates.cycles.total_cycle_cost < 1.,
+                   "Cost mismatch after a move");
       sol.sol_handle->sync_stream();
     }
 

--- a/cpp/src/routing/local_search/vrp/vrp_search.cu
+++ b/cpp/src/routing/local_search/vrp/vrp_search.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/routing/local_search/vrp/vrp_search.cu
+++ b/cpp/src/routing/local_search/vrp/vrp_search.cu
@@ -253,9 +253,9 @@ DI thrust::pair<double, double> evaluate_2_opt_route(
                                               route_1.get_objective_cost(),
                                               route_1.get_infeasibility_cost());
 
-  auto vehicle_fixed_cost_delta = vehicle_info.fixed_cost - route_1.vehicle_info().fixed_cost;
-
-  return {delta + vehicle_fixed_cost_delta, selection_delta + vehicle_fixed_cost_delta};
+  // delta includes (F_new - F_old): vehicle_fixed_cost_node_t::get_cost contributes F_new in
+  // the fragment, and route_1.get_objective_cost() supplies F_old in old_obj_cost.
+  return {delta, selection_delta};
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>

--- a/cpp/src/routing/node/node.cuh
+++ b/cpp/src/routing/node/node.cuh
@@ -95,13 +95,8 @@ class node_t {
     double delta =
       infeasible_cost_t::dot(weights, infeasible_cost_t::nominal_diff(new_inf_cost, old_inf_cost));
     if (include_objective) {
-      // it's a copy
-      auto obj_weights = dimensions_info.objective_weights;
-      // In moves evalutation this function compares fragments (nodes) with routes. Resulting
-      // in a corrupted delta because fragments do not have a vehicle cost. This leads to non
-      // improving moves being picked.
-      obj_weights[objective_t::VEHICLE_FIXED_COST] = 0.;
-      delta += objective_cost_t::dot(obj_weights, new_obj_cost - old_obj_cost);
+      delta += objective_cost_t::dot(
+        dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
     }
 
     return delta;
@@ -140,13 +135,8 @@ class node_t {
     double delta =
       infeasible_cost_t::dot(weights, infeasible_cost_t::nominal_diff(new_inf_cost, old_inf_cost));
     if (include_objective) {
-      // it's a copy
-      auto obj_weights = dimensions_info.objective_weights;
-      // In moves evalutation this function compares fragments (nodes) with routes. Resulting
-      // in a corrupted delta because fragments do not have a vehicle cost. This leads to non
-      // improving moves being picked.
-      obj_weights[objective_t::VEHICLE_FIXED_COST] = 0.;
-      delta += objective_cost_t::dot(obj_weights, new_obj_cost - old_obj_cost);
+      delta += objective_cost_t::dot(
+        dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
     }
 
     return delta;

--- a/cpp/src/routing/node/node.cuh
+++ b/cpp/src/routing/node/node.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -95,8 +95,8 @@ class node_t {
     double delta =
       infeasible_cost_t::dot(weights, infeasible_cost_t::nominal_diff(new_inf_cost, old_inf_cost));
     if (include_objective) {
-      delta += objective_cost_t::dot(
-        dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
+      delta +=
+        objective_cost_t::dot(dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
     }
 
     return delta;
@@ -135,8 +135,8 @@ class node_t {
     double delta =
       infeasible_cost_t::dot(weights, infeasible_cost_t::nominal_diff(new_inf_cost, old_inf_cost));
     if (include_objective) {
-      delta += objective_cost_t::dot(
-        dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
+      delta +=
+        objective_cost_t::dot(dimensions_info.objective_weights, new_obj_cost - old_obj_cost);
     }
 
     return delta;

--- a/cpp/src/routing/node/vehicle_fixed_cost_node.cuh
+++ b/cpp/src/routing/node/vehicle_fixed_cost_node.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/routing/node/vehicle_fixed_cost_node.cuh
+++ b/cpp/src/routing/node/vehicle_fixed_cost_node.cuh
@@ -62,11 +62,16 @@ class vehicle_fixed_cost_node_t {
 
   template <bool is_device = true>
   HDI void get_cost([[maybe_unused]] const vehicle_fixed_cost_node_t& prev_node,
-                    [[maybe_unused]] const VehicleInfo<f_t, is_device>& vehicle_info,
+                    const VehicleInfo<f_t, is_device>& vehicle_info,
                     [[maybe_unused]] const vehicle_fixed_cost_dimension_info_t& dim_info,
-                    [[maybe_unused]] objective_cost_t& obj_cost,
+                    objective_cost_t& obj_cost,
                     [[maybe_unused]] infeasible_cost_t& inf_cost) const noexcept
   {
+    // This get_cost is only invoked when the VEHICLE_FIXED_COST dimension is enabled (via
+    // loop_over_dimensions). A fragment that has reached this point represents a route that
+    // will be active after the move (at least one service node), so it carries this vehicle's
+    // fixed cost — mirroring vehicle_fixed_cost_route_t::compute_cost on a populated route.
+    obj_cost[objective_t::VEHICLE_FIXED_COST] = vehicle_info.fixed_cost;
   }
 };
 


### PR DESCRIPTION
(Claude-discovered fix.)

The cycle-finder's `total_cycle_cost` was systematically under-counting vehicle fixed cost when a cycle activated a previously-empty route via the SPECIAL (unrouted) pseudo-node. The realized post-move cost included the activation, the predicted total didn't — manifesting as flaky `cost_after - cost_before - total_cycle_cost < 1.` aborts in `level0_retail/retail_float_test_t.CVRPTW_Retail/18`.

Root cause: `vehicle_fixed_cost_node_t::get_cost` was a no-op. When `node_t::calculate_forward_all_and_delta` aggregated the fragment's per-dimension costs, the VEHICLE_FIXED_COST dimension contributed 0 from the new (fragment) side while `old_obj_cost` carried the route's actual fixed cost. A defensive `obj_weights[VEHICLE_FIXED_COST] = 0` line stripped both sides symmetrically, which kept same-route same- vehicle moves correct but silently dropped the activation cost any time a cycle changed a route's occupancy.

Fix: have the fragment-side `get_cost` contribute `vehicle_info.fixed_cost` so the fragment correctly represents an active route. With the fragment correct, several caller-side workarounds become redundant:

- `node.cuh`: drop the `obj_weights[VEHICLE_FIXED_COST] = 0` zero-out in both forward and backward delta paths.
- `vrp_search.cu::evaluate_2_opt_route`: drop the manual `(F_new − F_old)` add for HVRP vehicle swaps; the fragment cost now carries the swap delta directly.
- `ox_kernels.cuh` and `ox_recombiner.cuh`: drop the manual `optimal_vehicle_fixed_cost +` in OX edge weights; `cost_combine` now returns the full edge cost.
- `local_search.cu`: re-enable the `Cost mismatch after a move` assertion at the strict `< 1.` bound.

Verified by running CVRPTW_Retail/18 for 300 iterations under ASSERT_MODE: 0 aborts and 0 near-misses (residual >= 0.1), versus a pre-fix ~1.7% per-iteration abort rate. Full ROUTING_TEST suite passes.

Closes #845