### PR TITLE
Add new solver setting CUOPT_MIP_PROBING and separate it from presolve

### DIFF
--- a/cpp/include/cuopt/linear_programming/constants.h
+++ b/cpp/include/cuopt/linear_programming/constants.h
@@ -51,7 +51,7 @@
 #define CUOPT_ELIMINATE_DENSE_COLUMNS              "eliminate_dense_columns"
 #define CUOPT_CUDSS_DETERMINISTIC                  "cudss_deterministic"
 #define CUOPT_PRESOLVE                             "presolve"
-#define CUOPT_PROBING                              "probing"
+#define CUOPT_MIP_PROBING                          "mip_probing"
 #define CUOPT_DUAL_POSTSOLVE                       "dual_postsolve"
 #define CUOPT_MIP_DETERMINISM_MODE                 "mip_determinism_mode"
 #define CUOPT_MIP_ABSOLUTE_TOLERANCE               "mip_absolute_tolerance"

--- a/cpp/include/cuopt/linear_programming/constants.h
+++ b/cpp/include/cuopt/linear_programming/constants.h
@@ -51,6 +51,7 @@
 #define CUOPT_ELIMINATE_DENSE_COLUMNS              "eliminate_dense_columns"
 #define CUOPT_CUDSS_DETERMINISTIC                  "cudss_deterministic"
 #define CUOPT_PRESOLVE                             "presolve"
+#define CUOPT_PROBING                              "probing"
 #define CUOPT_DUAL_POSTSOLVE                       "dual_postsolve"
 #define CUOPT_MIP_DETERMINISM_MODE                 "mip_determinism_mode"
 #define CUOPT_MIP_ABSOLUTE_TOLERANCE               "mip_absolute_tolerance"

--- a/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
+++ b/cpp/include/cuopt/linear_programming/mip/solver_settings.hpp
@@ -128,6 +128,14 @@ class mip_solver_settings_t {
   int mip_scaling = CUOPT_MIP_SCALING_NO_OBJECTIVE;
   presolver_t presolver{presolver_t::Default};
   /**
+   * @brief Enable the cuOpt internal probing-cache step of presolve (MIP only).
+   *
+   * Probing is part of cuOpt's internal MIP presolve and runs only when the
+   * higher-level presolve is enabled (i.e. `presolver != presolver_t::None`).
+   * When this is `false`, probing is skipped even if presolve is otherwise on.
+   */
+  bool probing{true};
+  /**
    * @brief Determinism mode for MIP solver.
    *
    * Controls the determinism behavior of the MIP solver:

--- a/cpp/src/grpc/cuopt_remote.proto
+++ b/cpp/src/grpc/cuopt_remote.proto
@@ -200,6 +200,9 @@ message MIPSolverSettings {
   // Determinism and reproducibility
   int32 determinism_mode = 27;
   int32 seed = 28;
+
+  // Presolve sub-steps
+  bool probing = 29;  // default true on the C++ side; see grpc_settings_mapper.cpp
 }
 
 // LP solve request

--- a/cpp/src/grpc/grpc_settings_mapper.cpp
+++ b/cpp/src/grpc/grpc_settings_mapper.cpp
@@ -229,6 +229,9 @@ void map_mip_settings_to_proto(const mip_solver_settings_t<i_t, f_t>& settings,
   // Determinism and reproducibility
   pb_settings->set_determinism_mode(settings.determinism_mode);
   pb_settings->set_seed(settings.seed);
+
+  // Presolve sub-steps
+  pb_settings->set_probing(settings.probing);
 }
 
 template <typename i_t, typename f_t>
@@ -288,6 +291,9 @@ void map_proto_to_mip_settings(const cuopt::remote::MIPSolverSettings& pb_settin
   // Determinism and reproducibility
   settings.determinism_mode = pb_settings.determinism_mode();
   settings.seed             = pb_settings.seed();
+
+  // Presolve sub-steps
+  settings.probing = pb_settings.probing();
 }
 
 // Explicit template instantiations

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -174,6 +174,7 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
     {CUOPT_CUDSS_DETERMINISTIC, &pdlp_settings.cudss_deterministic, false},
     {CUOPT_DUAL_POSTSOLVE, &pdlp_settings.dual_postsolve, true},
     {CUOPT_BARRIER_ITERATIVE_REFINEMENT, &pdlp_settings.barrier_iterative_refinement, true},
+    {CUOPT_PROBING, &mip_settings.probing, true},
   };
   // String parameters
   string_parameters = {

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -174,7 +174,7 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
     {CUOPT_CUDSS_DETERMINISTIC, &pdlp_settings.cudss_deterministic, false},
     {CUOPT_DUAL_POSTSOLVE, &pdlp_settings.dual_postsolve, true},
     {CUOPT_BARRIER_ITERATIVE_REFINEMENT, &pdlp_settings.barrier_iterative_refinement, true},
-    {CUOPT_PROBING, &mip_settings.probing, true},
+    {CUOPT_MIP_PROBING, &mip_settings.probing, true},
   };
   // String parameters
   string_parameters = {

--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -241,7 +241,7 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit, timer_t global_
   // Allow the user to disable the probing-cache step of cuOpt's internal presolve
   // independently of the higher-level presolver setting.
   if (!context.settings.probing) {
-    CUOPT_LOG_INFO("Probing-cache step disabled via %s=false", CUOPT_PROBING);
+    CUOPT_LOG_INFO("Probing-cache step disabled via %s=false", CUOPT_MIP_PROBING);
     run_probing_cache = false;
   }
   if (run_probing_cache) {

--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -238,6 +238,12 @@ bool diversity_manager_t<i_t, f_t>::run_presolve(f_t time_limit, timer_t global_
   // Don't run probing cache in deterministic mode yet as neither B&B nor CPUFJ need it
   // and it doesn't make use of work units yet
   if (context.settings.determinism_mode == CUOPT_MODE_DETERMINISTIC) { run_probing_cache = false; }
+  // Allow the user to disable the probing-cache step of cuOpt's internal presolve
+  // independently of the higher-level presolver setting.
+  if (!context.settings.probing) {
+    CUOPT_LOG_INFO("Probing-cache step disabled via %s=false", CUOPT_PROBING);
+    run_probing_cache = false;
+  }
   if (run_probing_cache) {
     // Run probing cache before trivial presolve to discover variable implications
     const f_t max_time_on_probing = diversity_config.max_time_on_probing;

--- a/docs/cuopt/source/cuopt-c/lp-qp-milp/lp-qp-milp-c-api.rst
+++ b/docs/cuopt/source/cuopt-c/lp-qp-milp/lp-qp-milp-c-api.rst
@@ -175,6 +175,7 @@ These constants are used as parameter names in the :c:func:`cuOptSetParameter`, 
 .. doxygendefine:: CUOPT_MIP_HEURISTICS_ONLY
 .. doxygendefine:: CUOPT_MIP_PRESOLVE
 .. doxygendefine:: CUOPT_PRESOLVE
+.. doxygendefine:: CUOPT_PROBING
 .. doxygendefine:: CUOPT_LOG_TO_CONSOLE
 .. doxygendefine:: CUOPT_CROSSOVER
 .. doxygendefine:: CUOPT_FOLDING

--- a/docs/cuopt/source/cuopt-c/lp-qp-milp/lp-qp-milp-c-api.rst
+++ b/docs/cuopt/source/cuopt-c/lp-qp-milp/lp-qp-milp-c-api.rst
@@ -175,7 +175,7 @@ These constants are used as parameter names in the :c:func:`cuOptSetParameter`, 
 .. doxygendefine:: CUOPT_MIP_HEURISTICS_ONLY
 .. doxygendefine:: CUOPT_MIP_PRESOLVE
 .. doxygendefine:: CUOPT_PRESOLVE
-.. doxygendefine:: CUOPT_PROBING
+.. doxygendefine:: CUOPT_MIP_PROBING
 .. doxygendefine:: CUOPT_LOG_TO_CONSOLE
 .. doxygendefine:: CUOPT_CROSSOVER
 .. doxygendefine:: CUOPT_FOLDING

--- a/docs/cuopt/source/lp-qp-milp-settings.rst
+++ b/docs/cuopt/source/lp-qp-milp-settings.rst
@@ -66,6 +66,10 @@ Presolve
 ``CUOPT_PRESOLVE`` controls which presolver to use for presolve reductions.
 cuOpt provides presolve reductions for linear programming (LP) problems using either PSLP or Papilo, and for mixed-integer programming (MIP) problems using Papilo. By default, Papilo presolve is always enabled for MIP problems. For LP problems, PSLP presolve is always enabled by default. You can explicitly control the presolver by setting this parameter to 0 (disable presolve), 1 (Papilo), or 2 (PSLP).
 
+Probing
+^^^^^^^
+``CUOPT_PROBING`` toggles the probing-cache step of cuOpt's internal MIP presolve. The probing pass evaluates variable fixings to discover implications used later by branch-and-bound and the rounding heuristics. It is enabled by default (``true``); set it to ``false`` to skip probing while leaving the rest of presolve in place. Setting ``CUOPT_PRESOLVE=0`` already turns off the entire presolve pipeline, so ``CUOPT_PROBING`` only matters when presolve is otherwise enabled. Probing is also skipped in deterministic mode and on LP-only solves.
+
 Dual Postsolve
 ^^^^^^^^^^^^^^
 ``CUOPT_DUAL_POSTSOLVE`` controls whether dual postsolve is enabled when using Papilo presolver for LP problems. Disabling dual postsolve can improve solve time at the expense of not having

--- a/docs/cuopt/source/lp-qp-milp-settings.rst
+++ b/docs/cuopt/source/lp-qp-milp-settings.rst
@@ -68,7 +68,7 @@ cuOpt provides presolve reductions for linear programming (LP) problems using ei
 
 Probing
 ^^^^^^^
-``CUOPT_PROBING`` toggles the probing-cache step of cuOpt's internal MIP presolve. The probing pass evaluates variable fixings to discover implications used later by branch-and-bound and the rounding heuristics. It is enabled by default (``true``); set it to ``false`` to skip probing while leaving the rest of presolve in place. Setting ``CUOPT_PRESOLVE=0`` already turns off the entire presolve pipeline, so ``CUOPT_PROBING`` only matters when presolve is otherwise enabled. Probing is also skipped in deterministic mode and on LP-only solves.
+``CUOPT_MIP_PROBING`` toggles the probing-cache step of cuOpt's internal MIP presolve. The probing pass evaluates variable fixings to discover implications used later by branch-and-bound and the rounding heuristics. It is enabled by default (``true``); set it to ``false`` to skip probing while leaving the rest of presolve in place. Setting ``CUOPT_PRESOLVE=0`` already turns off the entire presolve pipeline, so ``CUOPT_MIP_PROBING`` only matters when presolve is otherwise enabled. Probing is also skipped in deterministic mode and on LP-only solves.
 
 Dual Postsolve
 ^^^^^^^^^^^^^^

--- a/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
+++ b/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
@@ -524,7 +524,7 @@ class SolverConfig(BaseModel):
         "2 for PSLP LP presolve. Presolve can reduce problem size and improve solve time. "  # noqa
         "Default is 1 for MIP problems and 2 for LP problems.",
     )
-    probing: Optional[bool] = Field(
+    mip_probing: Optional[bool] = Field(
         default=None,
         description="Enable or disable the cuOpt-internal probing-cache step of "  # noqa
         "MIP presolve. True (default) runs probing as part of presolve; False "  # noqa

--- a/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
+++ b/python/cuopt_server/cuopt_server/utils/linear_programming/data_definition.py
@@ -524,6 +524,15 @@ class SolverConfig(BaseModel):
         "2 for PSLP LP presolve. Presolve can reduce problem size and improve solve time. "  # noqa
         "Default is 1 for MIP problems and 2 for LP problems.",
     )
+    probing: Optional[bool] = Field(
+        default=None,
+        description="Enable or disable the cuOpt-internal probing-cache step of "  # noqa
+        "MIP presolve. True (default) runs probing as part of presolve; False "  # noqa
+        "skips probing while leaving the rest of presolve untouched. Has no "  # noqa
+        "effect if presolve is disabled (presolve=0) or when running in "  # noqa
+        "deterministic mode (probing is already skipped). LP-only solves "  # noqa
+        "ignore this setting.",
+    )
     dual_postsolve: Optional[bool] = Field(
         default=None,
         description="Set True to enable dual postsolve, False to disable dual postsolve. "  # noqa


### PR DESCRIPTION
Add CUOPT_MIP_PROBING setting (default true) to let users disable the probing-cache step of cuOpt's internal MIP presolve without disabling the rest of presolve. Existing CUOPT_PRESOLVE=0 still turns the whole pipeline off, so CUOPT_MIP_PROBING only matters when presolve is otherwise enabled. 