### PR TITLE
Fix accidentally quadratic add_slacks_to_basis in  crossover

### DIFF
--- a/cpp/src/dual_simplex/crossover.cpp
+++ b/cpp/src/dual_simplex/crossover.cpp
@@ -1076,29 +1076,36 @@ i_t find_candidate_columns(const lp_problem_t<i_t, f_t>& lp,
 template <typename i_t, typename f_t>
 i_t add_slacks_to_basis(const lp_problem_t<i_t, f_t>& lp,
                         const std::vector<i_t>& dependent_rows,
-                        f_t start_time,
-                        f_t time_limit,
                         std::vector<variable_status_t>& vstatus)
 {
   const i_t n   = lp.num_cols;
+  const i_t m   = lp.num_rows;
   i_t num_basic = 0;
-  // Add a slack to the basis for each dependent row
-  for (i_t i : dependent_rows) {
-    if (toc(start_time) > time_limit) { return -1; }
 
-    for (i_t j = n - 1; j >= 0; --j) {
-      const i_t col_start = lp.A.col_start[j];
-      const i_t col_end   = lp.A.col_start[j + 1];
-      const i_t nz        = col_end - col_start;
-      if (nz == 1) {
-        if (i == lp.A.i[col_start]) {
-          vstatus[j] = variable_status_t::BASIC;
-          num_basic++;
-          break;
-        }
-      }
+  // O(m) work to create the slack_map
+  // slack_map[i] = j when j is the slack variable for row i
+  std::vector<i_t> slack_map(m, -1);
+  for (i_t j = n - 1; j >= n - m; --j) {
+    const i_t col_start = lp.A.col_start[j];
+    const i_t col_end   = lp.A.col_start[j + 1];
+    const i_t nz        = col_end - col_start;
+    if (nz == 1) {
+      const i_t i  = lp.A.i[col_start];
+      slack_map[i] = j;
     }
   }
+
+  // Add a slack to the basis for each dependent row
+  // O( | dependent_rows | )
+  for (i_t i : dependent_rows) {
+    const i_t j = slack_map[i];
+    if (j >= 0) {
+      vstatus[j] = variable_status_t::BASIC;
+      num_basic++;
+    }
+  }
+
+  // Total work is O(m + | dependent_rows |) = O(m)
   return num_basic;
 }
 
@@ -1246,12 +1253,12 @@ crossover_status_t crossover(const lp_problem_t<i_t, f_t>& lp,
 
   i_t num_basic = 0;
   if (rank < m) {
-    num_basic = add_slacks_to_basis(lp, dependent_rows, start_time, settings.time_limit, vstatus);
-    if (num_basic < 0) {
-      settings.log.printf("Time limit exceeded\n");
-      return crossover_status_t::TIME_LIMIT;
-    }
+    num_basic = add_slacks_to_basis(lp, dependent_rows, vstatus);
     settings.log.debug("num basic %d from slacks\n", num_basic);
+  }
+  if (num_basic + rank != m) {
+    settings.log.printf("Error: could not find a full-rank initial basis\n");
+    return crossover_status_t::NUMERICAL_ISSUES;
   }
 
   for (i_t k = 0; k < candidate_columns.size(); k++) {

--- a/cpp/src/dual_simplex/crossover.cpp
+++ b/cpp/src/dual_simplex/crossover.cpp
@@ -1076,12 +1076,16 @@ i_t find_candidate_columns(const lp_problem_t<i_t, f_t>& lp,
 template <typename i_t, typename f_t>
 i_t add_slacks_to_basis(const lp_problem_t<i_t, f_t>& lp,
                         const std::vector<i_t>& dependent_rows,
+                        f_t start_time,
+                        f_t time_limit,
                         std::vector<variable_status_t>& vstatus)
 {
   const i_t n   = lp.num_cols;
   i_t num_basic = 0;
   // Add a slack to the basis for each dependent row
   for (i_t i : dependent_rows) {
+    if (toc(start_time) > time_limit) { return -1; }
+
     for (i_t j = n - 1; j >= 0; --j) {
       const i_t col_start = lp.A.col_start[j];
       const i_t col_end   = lp.A.col_start[j + 1];
@@ -1242,7 +1246,11 @@ crossover_status_t crossover(const lp_problem_t<i_t, f_t>& lp,
 
   i_t num_basic = 0;
   if (rank < m) {
-    num_basic = add_slacks_to_basis(lp, dependent_rows, vstatus);
+    num_basic = add_slacks_to_basis(lp, dependent_rows, start_time, settings.time_limit, vstatus);
+    if (num_basic < 0) {
+      settings.log.printf("Time limit exceeded\n");
+      return crossover_status_t::TIME_LIMIT;
+    }
     settings.log.debug("num basic %d from slacks\n", num_basic);
   }
 


### PR DESCRIPTION
When the problem is very large and the basis is extremely rank deficient, the crossover needs to add millions of slack variables to compensate. 

This process can take a long time and may violate the time limit set by the user. 

This PR fixes the accidentally quadratic `add_slacks_to_basis` in crossover that was causing the large amount of time. 
