### PR TITLE
ci: fix mangled python image tag on release/26.06

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -312,7 +312,7 @@ jobs:
       contents: read
     runs-on: linux-amd64-cpu4
     container:
-      image: python:26.06-slim
+      image: python:3.14-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nightly-summary.yaml
+++ b/.github/workflows/nightly-summary.yaml
@@ -60,7 +60,7 @@ jobs:
       contents: read
     runs-on: linux-amd64-cpu4
     container:
-      image: python:26.06-slim
+      image: python:3.14-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -138,8 +138,9 @@ sed_runner 's/\(version: \)[0-9][0-9]\.[0-9]\+\.[0-9]\+/\1'${DOCKER_TAG}'/g' hel
 # CI files - context-aware branch references and version updates
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s|@.*|@${RAPIDS_BRANCH_NAME}|g" "${FILE}"
-  # CI image tags of the form {rapids_version}-{something}
-  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
+  # CI image tags of the form rapidsai/<image>:{rapids_version}-{something}.
+  # Scoped to rapidsai/ so unrelated images like python:3.14-slim aren't rewritten.
+  sed_runner "/rapidsai\// s|:[0-9]*\\.[0-9]*-|:${NEXT_SHORT_TAG}-|g" "${FILE}"
 done
 
 # Documentation references - context-aware

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -150,7 +150,6 @@ if [[ "${RUN_CONTEXT}" == "main" ]]; then
 elif [[ "${RUN_CONTEXT}" == "release" ]]; then
   # In release context, use release branch for external documentation links (word boundaries to avoid partial matches)
   sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" docs/cuopt/source/faq.rst
-  sed_runner "s|\\bmain\\b|release/${NEXT_SHORT_TAG}|g" docs/cuopt/source/cuopt-python/routing/routing-example.ipynb
 fi
 
 # Update docs version switcher to include the new version


### PR DESCRIPTION
Three fixes for the `release/26.06` release-prep regression:

**1. Restore the python image tag** — `nightly-summary.yaml:63` and `build.yaml:315` had `python:26.06-slim`, which doesn't exist on Docker Hub. Reverted to `python:3.14-slim` (matches `main`). Unblocks the nightly-summary and build-summary jobs.

**2. Scope the version-bump regex** — `ci/release/update-version.sh:142` was matching any `:N.N-` in workflow files, which is what mangled the python image during release prep. Scoped to lines containing `rapidsai/` so unrelated images are left alone.

**3. Drop dead routing-example.ipynb sed call** — `ci/release/update-version.sh` was sed-ing a file that no longer exists, erroring on every release-prep run. The routing docs currently have no `main`-branch links so the line was a no-op even before the file was removed.

Verified by running `./ci/release/update-version.sh --run-context=release 99.99.00` in a throwaway worktree — only the four `rapidsai/ci-conda:NN.NN-latest` lines bump, `python:3.14-slim` is untouched, and no errors are emitted.

Same regex bug exists on `main`; this PR carries the fix on `release/26.06` so patch releases off this branch won't re-mangle. A separate cherry-pick to `main` is straightforward.
