### PR TITLE
Use rapids_cmake_support_conda_env so executables link in any conda env

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,16 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
+# Expose $CONDA_PREFIX/lib to all executables in this build so ld can resolve
+# libcuopt.so's PRIVATE transitive deps (gRPC/Protobuf/Abseil) at link time
+# without relying on conda-forge compiler activation scripts setting LDFLAGS.
+# BUILD_INTERFACE keeps this out of the installed cuopt CMake config.
+include("${rapids-cmake-dir}/cmake/support_conda_env.cmake")
+rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
+if (TARGET conda_env)
+    link_libraries($<BUILD_INTERFACE:conda_env>)
+endif ()
+
 rapids_cuda_init_architectures(CUOPT)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,15 +18,11 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
-# Expose $CONDA_PREFIX/lib to all executables in this build so ld can resolve
-# libcuopt.so's PRIVATE transitive deps (gRPC/Protobuf/Abseil) at link time
-# without relying on conda-forge compiler activation scripts setting LDFLAGS.
-# BUILD_INTERFACE keeps this out of the installed cuopt CMake config.
-include("${rapids-cmake-dir}/cmake/support_conda_env.cmake")
+# Conda env support: ensures $CONDA_PREFIX include/lib paths are visible to
+# the build so libcuopt.so's PRIVATE transitive deps (gRPC/Protobuf/Abseil)
+# resolve when linking executables, without depending on conda-forge compiler
+# activation scripts setting LDFLAGS.
 rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
-if (TARGET conda_env)
-    link_libraries($<BUILD_INTERFACE:conda_env>)
-endif ()
 
 rapids_cuda_init_architectures(CUOPT)
 
@@ -573,6 +569,7 @@ target_link_libraries(cuopt
         ${CUOPT_PRIVATE_CUDA_LIBS}
         $<$<BOOL:${CUOPT_ENABLE_GRPC}>:protobuf::libprotobuf>
         $<$<BOOL:${CUOPT_ENABLE_GRPC}>:gRPC::grpc++>
+        $<TARGET_NAME_IF_EXISTS:conda_env>
 )
 
 
@@ -602,6 +599,10 @@ else ()
     set(_BIN_DEST "${CMAKE_INSTALL_BINDIR}")
     set(_LIB_DEST "${lib_dir}")
     set(_INCLUDE_DEST include/cuopt/)
+endif ()
+
+if (TARGET conda_env)
+    install(TARGETS conda_env EXPORT cuopt-exports)
 endif ()
 
 # adds the .so files to the runtime deb package
@@ -717,6 +718,7 @@ if (NOT BUILD_LP_ONLY)
             TBB::tbb
             PRIVATE
             argparse::argparse
+            $<TARGET_NAME_IF_EXISTS:conda_env>
     )
     # Use RUNPATH when building locally in order to allow LD_LIBRARY_PATH to override the conda env path
     if (NOT DEFINED INSTALL_TARGET OR "${INSTALL_TARGET}" STREQUAL "")
@@ -842,6 +844,7 @@ if (NOT SKIP_GRPC_BUILD)
             gRPC::grpc++
             ${UUID_LIBRARY}
             argparse::argparse
+            $<TARGET_NAME_IF_EXISTS:conda_env>
     )
 
     # Use RUNPATH when building locally

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
         GTest::gtest
         GTest::gtest_main
         ${CUOPT_PRIVATE_CUDA_LIBS}
+        $<TARGET_NAME_IF_EXISTS:conda_env>
     )
     if(NOT DEFINED INSTALL_TARGET OR "${INSTALL_TARGET}" STREQUAL "")
       target_link_options(${CMAKE_TEST_NAME} PRIVATE -Wl,--enable-new-dtags)


### PR DESCRIPTION
`libcuopt.so` links gRPC/Protobuf/Abseil as PRIVATE, so their SONAMEs end up in `libcuopt.so`'s `DT_NEEDED` but aren't propagated to consumers (`cuopt_cli`, `cuopt_grpc_server`, all tests). When `ld` links those targets it walks `libcuopt.so`'s `DT_NEEDED` to resolve transitive symbols and needs `$CONDA_PREFIX/lib` on its search path. Today this only works when the conda env was created with the conda-forge compiler shims (`cxx-compiler` / `gxx_linux-64` / `gcc_linux-64`), whose activation scripts export `LDFLAGS=... -Wl,-rpath-link,$CONDA_PREFIX/lib -Wl,--allow-shlib-undefined ...`. Envs without those packages fail at link time on `cuopt_cli` and ~30 test executables, even though `libcuopt.so` itself builds in the same `build.sh` run.

Adopts the standard RAPIDS pattern (`rapids_cmake_support_conda_env`, already used by cudf/cuml/raft/rmm). `$<BUILD_INTERFACE:>` keeps `conda_env` out of the installed cuopt CMake config; no-op when `$CONDA_PREFIX` is unset (wheel CI).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
  - [ ] New or existing tests cover these changes
  - [ ] Added tests
  - [ ] Created an issue to follow-up
  - [x] NA
- Documentation
  - [ ] The documentation is up to date with these changes
  - [ ] Added new documentation
  - [x] NA