### PR TITLE
Replace __constant__ FJ settings with per-instance device_scalar

### DIFF
--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
@@ -41,14 +41,13 @@ static constexpr int iterations_per_graph = 1;
 static constexpr int iterations_per_graph = 50;
 #endif
 
-__constant__ fj_settings_t device_settings;
-
 template <typename i_t, typename f_t>
 fj_t<i_t, f_t>::fj_t(mip_solver_context_t<i_t, f_t>& context_, fj_settings_t in_settings)
   : context(context_),
     pb_ptr(context.problem_ptr),
     handle_ptr(const_cast<raft::handle_t*>(pb_ptr->handle_ptr)),
     settings(in_settings),
+    device_settings(pb_ptr->handle_ptr->get_stream()),
     cstr_weights(pb_ptr->n_constraints, pb_ptr->handle_ptr->get_stream()),
     cstr_right_weights(pb_ptr->n_constraints, pb_ptr->handle_ptr->get_stream()),
     cstr_left_weights(pb_ptr->n_constraints, pb_ptr->handle_ptr->get_stream()),
@@ -226,7 +225,7 @@ fj_t<i_t, f_t>::climber_data_t::view_t fj_t<i_t, f_t>::climber_data_t::view()
   v.stop_threshold                    = fj.stop_threshold;
   v.iterations_until_feasible_counter = iterations_until_feasible_counter.data();
   v.full_refresh_iteration            = full_refresh_iteration.data();
-  RAFT_CUDA_TRY(cudaGetSymbolAddress((void**)&v.settings, device_settings));
+  v.settings                          = fj.device_settings.data();
 
   return v;
 }

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
@@ -632,6 +632,10 @@ class fj_t {
   std::vector<std::unique_ptr<climber_data_t>> climbers;
   rmm::device_uvector<typename climber_data_t::view_t> climber_views;
   fj_settings_t settings;
+  // Device-side mirror of `settings`. `run_step_device` pushes the host
+  // `settings` here before each kernel launch; kernels read it via
+  // `view_t::settings`.
+  rmm::device_scalar<fj_settings_t> device_settings;
 
   fj_improvement_callback_t<f_t> improvement_callback;
   f_t last_reported_objective_{std::numeric_limits<f_t>::infinity()};


### PR DESCRIPTION
  - Fixes #1277. FJ kernels (`handle_local_minimum_kernel`) write through
    `view_t::settings`, but storage was a `__constant__` symbol — illegal
    on device, surfacing as `cudaErrorIllegalAddress` later at a sync.
  - Moves storage to a per-instance `rmm::device_scalar<fj_settings_t>`.
    Also closes the secondary issue of the shared symbol racing across
    concurrent `fj_t` instances.
