### PR TITLE
Stabilize logger config in LP BatchSolve and version logging

### DIFF
--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -1739,9 +1739,9 @@ optimization_problem_solution_t<i_t, f_t> solve_qp(optimization_problem_t<i_t, f
                                                    bool problem_checking)
 {
   try {
-    print_version_info();
     // Create log stream for file logging and add it to default logger
     init_logger_t log(settings.log_file, settings.log_to_console);
+    print_version_info();
 
     // Init libraries before to not include it in solve time
     init_handler(op_problem.get_handle_ptr());
@@ -1793,11 +1793,11 @@ optimization_problem_solution_t<i_t, f_t> solve_lp(
   }
 
   try {
-    if (!settings_const.inside_mip) print_version_info();
-
     pdlp_solver_settings_t<i_t, f_t> settings(settings_const);
     // Create log stream for file logging and add it to default logger
     init_logger_t log(settings.log_file, settings.log_to_console);
+
+    if (!settings_const.inside_mip) print_version_info();
 
     // Init libraries before to not include it in solve time
     // This needs to be called before pdlp is initialized

--- a/cpp/src/pdlp/utilities/cython_solve.cu
+++ b/cpp/src/pdlp/utilities/cython_solve.cu
@@ -20,6 +20,7 @@
 #include <cuopt/linear_programming/utilities/cython_solve.hpp>
 #include <mip_heuristics/logger.hpp>
 #include <utilities/copy_helpers.hpp>
+#include <utilities/logger.hpp>
 
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
@@ -257,6 +258,11 @@ std::pair<std::vector<std::unique_ptr<solver_ret_t>>, double> call_batch_solve(
   if (cuopt::linear_programming::is_remote_execution_enabled()) {
     return solve_batch_remote(data_models, solver_settings);
   }
+
+  // Hold the logger configuration for the whole batch so that worker-local
+  // init_logger_t instances inside solve_lp() reuse it.
+  init_logger_t batch_log(solver_settings->get_pdlp_settings().log_file,
+                          solver_settings->get_pdlp_settings().log_to_console);
 
   const std::size_t size = data_models.size();
 


### PR DESCRIPTION
(Claude-driven bug fix, potentially fixing the crash in https://github.com/NVIDIA/cuopt/actions/runs/26249434727/job/77262219725?pr=1103. The issue seems rare enough that I wasn't able to reliably reproduce locally to confirm the fix.)

`init_logger_t` reconfigures the process-global `cuopt::default_logger()` sinks under `g_guard_mutex`, but `CUOPT_LOG_*` calls go through that same global logger without holding the mutex. Three risky entry points existed:

- `call_batch_solve()` ran an OpenMP loop where every worker constructed its own `init_logger_t` inside `solve_lp()`. When workers finished at different times the last guard's destructor reset sinks while siblings were still logging — a likely source of rare `pure virtual method called -> std::terminate -> SIGABRT` aborts.
- `solve_lp()` and `solve_qp()` called `print_version_info()` (which uses `CUOPT_LOG_*`) before constructing their `init_logger_t`, so version logging ran through whatever global sink configuration happened to be active at that moment.

Fix:

- Construct an outer `init_logger_t` at the top of `call_batch_solve()` before any `CUOPT_LOG_*` and before the OpenMP region. Worker-local `init_logger_t` instances now ref-count onto it and never tear down global sinks.
- Reorder `solve_lp()` and `solve_qp()` so `init_logger_t` is constructed before `print_version_info()`.

Verified by running `test_parser_and_batch_solver` 300x in one process and 2x300 in concurrent processes without any abort signature.

The changes to `solve_lp` and `solve_qp` are incidental and probably not related to the original crash. They're preventing a potential similar issue if `solve_lp` or `solve_qp` are called from multiple threads.