### PR TITLE
Fix mixed-dtype cudf.concat in test_initial_solutions helper

### DIFF
--- a/python/cuopt/cuopt/tests/routing/test_initial_solutions.py
+++ b/python/cuopt/cuopt/tests/routing/test_initial_solutions.py
@@ -22,15 +22,18 @@ class TestOption(Enum):
 def get_initial_solutions(routing_solution, n_initial_sols=5):
     initial_sol = routing_solution.get_route()
     sol_offsets = [0]
-    vehicle_ids = cudf.Series()
-    routes = cudf.Series()
-    types = cudf.Series()
+    vehicle_ids_parts = []
+    routes_parts = []
+    types_parts = []
     # simply expand the same solution for convenience
     for i in range(0, n_initial_sols):
-        vehicle_ids = cudf.concat([vehicle_ids, initial_sol["truck_id"]])
-        routes = cudf.concat([routes, initial_sol["route"]])
-        types = cudf.concat([types, initial_sol["type"]])
+        vehicle_ids_parts.append(initial_sol["truck_id"])
+        routes_parts.append(initial_sol["route"])
+        types_parts.append(initial_sol["type"])
         sol_offsets.append(sol_offsets[i] + initial_sol["route"].shape[0])
+    vehicle_ids = cudf.concat(vehicle_ids_parts)
+    routes = cudf.concat(routes_parts)
+    types = cudf.concat(types_parts)
     sol_offsets = cudf.Series(sol_offsets)
     return vehicle_ids, routes, types, sol_offsets
 


### PR DESCRIPTION
## Summary


The helper `get_initial_solutions` started each output series as a no-dtype `cudf.Series()` (which becomes `dtype=object`), then concatenated typed series into it inside a loop. The first concat (object + typed) upcasts to `object`; the next iteration's concat (object + typed) is now a hard error in current cudf.

Fixed by collecting each column's pieces into a Python list and calling `cudf.concat` once at the end, which preserves the original dtype and avoids the empty-series upcast entirely.