### PR TITLE
add mip start attribute

### DIFF
--- a/python/cuopt/cuopt/linear_programming/problem.py
+++ b/python/cuopt/cuopt/linear_programming/problem.py
@@ -106,6 +106,9 @@ class Variable:
         Value of the variable after solving.
     ReducedCost : float
         Reduced Cost after solving an LP problem.
+    MIPStart : float
+        Initial value (warm-start hint) for the variable. Defaults to NaN
+        (unset). Only used for a MIP problem.
     """
 
     def __init__(
@@ -124,6 +127,7 @@ class Variable:
         self.ReducedCost = float("nan")
         self.VariableType = vtype
         self.VariableName = vname
+        self.MIPStart = float("nan")
 
     def getIndex(self):
         """
@@ -198,6 +202,20 @@ class Variable:
         Returns the name of the variable.
         """
         return self.VariableName
+
+    def setMIPStart(self, val):
+        """
+        Sets the MIP start (initial primal solution hint) value for the
+        variable. Use ``float("nan")`` to unset.
+        """
+        self.MIPStart = float(val)
+
+    def getMIPStart(self):
+        """
+        Returns the MIP start (initial primal solution hint) value of the
+        variable. Defaults to NaN when unset.
+        """
+        return self.MIPStart
 
     def __neg__(self):
         return LinearExpression([self], [-1.0], 0.0)
@@ -1428,6 +1446,7 @@ class Problem:
         self.lower_bound, self.upper_bound = np.zeros(n), np.zeros(n)
         self.var_type = np.empty(n, dtype="S1")
         self.var_names = []
+        self.mip_start = np.empty(n, dtype=np.float64)
 
         for j in range(n):
             self.objective[j] = self.vars[j].getObjectiveCoefficient()
@@ -1438,6 +1457,7 @@ class Problem:
             if var_name == "":
                 var_name = "C" + str(self.vars[j].index)
             self.var_names.append(var_name)
+            self.mip_start[j] = self.vars[j].MIPStart
 
         # Initialize datamodel
         dm.set_csr_constraint_matrix(
@@ -1463,6 +1483,9 @@ class Problem:
         dm.set_variable_names(self.var_names)
         dm.set_row_names(self.row_names)
         dm.set_problem_name(self.Name)
+
+        if self.mip_start.size > 0 and not np.all(np.isnan(self.mip_start)):
+            dm.set_initial_primal_solution(self.mip_start)
 
         self.model = dm
 

--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -482,6 +482,47 @@ def test_warm_start():
     )
 
 
+def test_mip_start():
+    # Build a small MIP and feed it an (already-optimal) MIP start through
+    # the new Variable.MIPStart attribute. We verify:
+    #   - the attribute defaults to NaN
+    #   - setMIPStart / direct assignment both work
+    #   - the values reach the data model via set_initial_primal_solution
+    #   - solving still produces the optimal result
+    #   - leaving every MIPStart as NaN does not set an initial primal sol
+    prob = Problem("MIP_start")
+    x = prob.addVariable(lb=0, ub=10, vtype=INTEGER, name="x")
+    y = prob.addVariable(lb=0, ub=10, vtype=INTEGER, name="y")
+
+    assert math.isnan(x.getMIPStart())
+    assert math.isnan(y.MIPStart)
+
+    prob.addConstraint(x + y <= 10, name="c1")
+    prob.addConstraint(x - y >= 0, name="c2")
+    prob.setObjective(x + 2 * y, sense=MAXIMIZE)
+
+    x.setMIPStart(5)
+    y.MIPStart = 5.0
+
+    assert x.getMIPStart() == 5.0
+    assert y.getMIPStart() == 5.0
+
+    prob._to_data_model()
+    initial_primal = prob.model.get_initial_primal_solution()
+    assert len(initial_primal) == 2
+    assert initial_primal[0] == pytest.approx(5.0)
+    assert initial_primal[1] == pytest.approx(5.0)
+
+    settings = SolverSettings()
+    settings.set_parameter("time_limit", 5)
+    prob.solve(settings)
+
+    assert prob.Status.name == "Optimal"
+    assert prob.ObjValue == pytest.approx(15)
+    assert x.Value == pytest.approx(5)
+    assert y.Value == pytest.approx(5)
+
+
 def test_problem_update():
     prob = Problem()
     x1 = prob.addVariable(vtype=INTEGER, lb=0, name="x1")


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
This PR adds a per-variable attribute `MIPStart` that a user can set to specify the initial variable(primal) values for the problem.

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [x] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA
