### PR TITLE
Validate cuOptGetErrorString buffer size

### DIFF
--- a/cpp/include/cuopt/linear_programming/cuopt_c.h
+++ b/cpp/include/cuopt/linear_programming/cuopt_c.h
@@ -959,7 +959,7 @@ cuopt_int_t cuOptGetErrorStatus(cuOptSolution solution, cuopt_int_t* error_statu
  * @param[out] error_string_ptr - A pointer to a char that on output will contain the
  *  error string.
  *
- * @param[in] error_string_size - Size of the char buffer/
+ * @param[in] error_string_size - Size of the char buffer. Must be positive.
  *
  * @return A status code indicating success or failure.
  */

--- a/cpp/src/pdlp/cuopt_c.cpp
+++ b/cpp/src/pdlp/cuopt_c.cpp
@@ -1174,6 +1174,7 @@ cuopt_int_t cuOptGetErrorString(cuOptSolution solution,
 {
   if (solution == nullptr) { return CUOPT_INVALID_ARGUMENT; }
   if (error_string_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
+  if (error_string_size <= 0) { return CUOPT_INVALID_ARGUMENT; }
   solution_and_stream_view_t* solution_and_stream_view =
     static_cast<solution_and_stream_view_t*>(solution);
   std::string error_string = solution_and_stream_view->get_solution()->get_error_status().what();

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -14,6 +14,8 @@
 #include <string>
 
 #include <cuopt/linear_programming/cuopt_c.h>
+#include <cuopt/error.hpp>
+#include <cuopt/linear_programming/cpu_optimization_problem_solution.hpp>
 #include <pdlp/cuopt_c_internal.hpp>
 
 #include <utilities/common_utils.hpp>
@@ -106,6 +108,28 @@ TEST(c_api, solve_time_bb_preemption)
 }
 
 TEST(c_api, bad_parameter_name) { EXPECT_EQ(test_bad_parameter_name(), CUOPT_INVALID_ARGUMENT); }
+
+TEST(c_api, error_string_invalid_buffer_size)
+{
+  using cuopt::linear_programming::cpu_lp_solution_t;
+  using cuopt::linear_programming::memory_backend_t;
+  using cuopt::linear_programming::pdlp_termination_status_t;
+  using cuopt::linear_programming::solution_and_stream_view_t;
+
+  constexpr const char* error_message = "validation failed";
+
+  solution_and_stream_view_t solution_handle(false, memory_backend_t::CPU);
+  solution_handle.lp_solution_interface_ptr = new cpu_lp_solution_t<cuopt_int_t, cuopt_float_t>(
+    pdlp_termination_status_t::NumericalError,
+    cuopt::logic_error(error_message, cuopt::error_type_t::ValidationError));
+
+  char error_string[32] = {};
+  EXPECT_EQ(cuOptGetErrorString(&solution_handle, error_string, 0), CUOPT_INVALID_ARGUMENT);
+  EXPECT_EQ(cuOptGetErrorString(&solution_handle, error_string, -1), CUOPT_INVALID_ARGUMENT);
+  EXPECT_EQ(cuOptGetErrorString(&solution_handle, error_string, sizeof(error_string)),
+            CUOPT_SUCCESS);
+  EXPECT_STREQ(error_string, error_message);
+}
 
 TEST(c_api, mip_get_callbacks_only) { EXPECT_EQ(test_mip_get_callbacks_only(), CUOPT_SUCCESS); }
 


### PR DESCRIPTION
This tightens one C API edge case and adds a small regression test for it.

What changed:
- reject non-positive buffer sizes in `cuOptGetErrorString`
- add a focused C API test that checks `0` and `-1` buffer sizes

Why:
`cuOptGetParameter` already rejects `<= 0` output buffer sizes, but `cuOptGetErrorString` was still passing its signed size straight into `snprintf`. This just makes the behavior consistent and keeps the validation on the API boundary.

Testing:
- `git diff --check`
- not run here: this machine does not have `nvcc` or a configured cuOpt build environment, so I could not build `libcuopt` / run `C_API_TEST` locally

Closes #1311.
