### PR TITLE
fix(mip): resolve SIGSEGV from OpenMP runtime conflict during MIP teardown (#1219)

### DIFF
--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -440,6 +440,12 @@ class iteration_data_t {
     }
   }
 
+  ~iteration_data_t()
+  {
+    chol.reset();
+    handle_ptr->sync_stream();
+  }
+
   void form_augmented(bool first_call = false)
   {
     i_t n                    = A.n;

--- a/python/cuopt/cuopt/linear_programming/__init__.py
+++ b/python/cuopt/cuopt/linear_programming/__init__.py
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import ctypes
+import os
+
+_gomp_path = os.path.join(os.path.dirname(__file__), "_libs", "libgomp-855c301a.so.1.0.0")
+if os.path.exists(_gomp_path):
+    ctypes.CDLL(_gomp_path, mode=ctypes.RTLD_GLOBAL)
+
 from cuopt.linear_programming import internals
 from cuopt.linear_programming.data_model import DataModel
 from cuopt.linear_programming.io import ParseMps, Read


### PR DESCRIPTION
## Description
Fixes the SIGSEGV crash that occurs after "Optimal solution found" during MIP teardown.

Two-part fix:

**Fix 1 (root cause):** Preload bundled libgomp as `RTLD_GLOBAL` so cuDSS threading layer resolves to the same instance as libcuopt and libraft, eliminating the three conflicting libgomp instances.

**Fix 2 (destruction order):** Add explicit destructor to `iteration_data_t` that calls `chol.reset()` before `handle_ptr->sync_stream()`, preventing `cudssDestroy` from racing with active GPU streams and OpenMP workers.

## Issue
Closes #1219

## Changes
- `python/cuopt/cuopt/linear_programming/__init__.py` — preload bundled libgomp as RTLD_GLOBAL
- `cpp/src/barrier/barrier.cu` — add explicit destructor to `iteration_data_t`

## Testing
Tested with `OMP_NUM_THREADS=8` on the attached MPS file from the issue — no crash.