### PR TITLE
Fix broken sample.mps download link in server LP examples docs

### DIFF
--- a/ci/utils/install_cudss.sh
+++ b/ci/utils/install_cudss.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 # Clean metadata & install cudss
+# Pin to 0.7.x to match the runtime cuDSS (pip/conda only ship 0.7); bump once
+# nvidia-cudss-cuXX 0.8 is on PyPI and libcudss 0.8 is on conda-forge.
 if command -v dnf &> /dev/null; then
     # Adding static library just to please CMAKE requirements
     if [ "$(echo "$CUDA_VERSION" | cut -d. -f1)" -ge 13 ] && [ "$(echo "$CUDA_VERSION" | cut -d. -f1)" -lt 14 ]; then
-        dnf -y install libcudss0-static-cuda-13 libcudss0-devel-cuda-13 libcudss0-cuda-13
+        dnf -y install "libcudss0-static-cuda-13-0.7.*" "libcudss0-devel-cuda-13-0.7.*" "libcudss0-cuda-13-0.7.*"
     else
-        dnf -y install libcudss0-static-cuda-12 libcudss0-devel-cuda-12 libcudss0-cuda-12
+        dnf -y install "libcudss0-static-cuda-12-0.7.*" "libcudss0-devel-cuda-12-0.7.*" "libcudss0-cuda-12-0.7.*"
     fi
 elif command -v apt-get &> /dev/null; then
     apt-get update
-    apt-get install -y libcudss-devel
+    apt-get install -y "libcudss-devel=0.7.*"
 else
     echo "Neither dnf nor apt-get found. Cannot install cudss dependencies."
     exit 1

--- a/docs/cuopt/source/cuopt-server/examples/lp-examples.rst
+++ b/docs/cuopt/source/cuopt-server/examples/lp-examples.rst
@@ -436,7 +436,7 @@ In the case of batch mode, you can send a bunch of ``mps`` files at once, and ac
 .. note::
    Batch mode is not available for MILP problems.
 
-A sample MPS file (:download:`sample.mps <https://people.math.sc.edu/Burkardt/datasets/mps/testprob.mps>`):
+A sample MPS file (:download:`sample.mps <lp/examples/sample.mps>`):
 
 .. literalinclude:: lp/examples/sample.mps
    :language: text


### PR DESCRIPTION
## Description

The `:download:` link for `sample.mps` in `cuopt-server/examples/lp-examples.rst`
pointed at an external host (`people.math.sc.edu`) that is unreachable, breaking
the docs `linkcheck` build:

```
cuopt-server/examples/lp-examples.rst:439: [broken]
https://people.math.sc.edu/Burkardt/datasets/mps/testprob.mps
```

The same `sample.mps` already exists in the repo at
`cuopt-server/examples/lp/examples/sample.mps` and is shown via `literalinclude`
on the next line, so the download now points at that local file.

## Issue

Docs `linkcheck` failure (external host down).

## Checklist

- Testing
   - [x] NA (docs-only; `make linkcheck` no longer reports this URL)
- Documentation
   - [x] NA