### PR TITLE
Fix for maximization problems with quadratic constraints

### DIFF
--- a/cpp/src/pdlp/translate.hpp
+++ b/cpp/src/pdlp/translate.hpp
@@ -219,7 +219,7 @@ static dual_simplex::user_problem_t<i_t, f_t> cuopt_optimization_problem_to_user
   // Note: get_sense() returns true when the problem is a maximization problem.
   const bool maximize = model.get_sense();
   if (maximize) {
-    for (auto& c : user_problem.objective) {
+    for (f_t& c : user_problem.objective) {
       c = -c;
     }
   }

--- a/cpp/src/pdlp/translate.hpp
+++ b/cpp/src/pdlp/translate.hpp
@@ -295,9 +295,8 @@ static dual_simplex::user_problem_t<i_t, f_t> cuopt_optimization_problem_to_user
   }
 
   user_problem.obj_constant = model.get_objective_offset();
-  user_problem.obj_scale    = maximize
-                                ? -model.get_objective_scaling_factor()
-                                : model.get_objective_scaling_factor();
+  user_problem.obj_scale =
+    maximize ? -model.get_objective_scaling_factor() : model.get_objective_scaling_factor();
 
   user_problem.var_types.resize(n);
   auto model_variable_types = model.get_variable_types_host();

--- a/cpp/src/pdlp/translate.hpp
+++ b/cpp/src/pdlp/translate.hpp
@@ -214,6 +214,16 @@ static dual_simplex::user_problem_t<i_t, f_t> cuopt_optimization_problem_to_user
   user_problem.num_cols  = n;
   user_problem.objective = model.get_objective_coefficients_host();
 
+  // For maximization, negate the objective so the barrier (which always minimizes)
+  // finds the maximizer.  obj_scale = -1 ensures the reported objective is correct.
+  // Note: get_sense() returns true when the problem is a maximization problem.
+  const bool maximize = model.get_sense();
+  if (maximize) {
+    for (auto& c : user_problem.objective) {
+      c = -c;
+    }
+  }
+
   dual_simplex::csr_matrix_t<i_t, f_t> csr_A(m, n, nz);
   csr_A.x         = model.get_constraint_matrix_values_host();
   csr_A.j         = model.get_constraint_matrix_indices_host();
@@ -285,7 +295,9 @@ static dual_simplex::user_problem_t<i_t, f_t> cuopt_optimization_problem_to_user
   }
 
   user_problem.obj_constant = model.get_objective_offset();
-  user_problem.obj_scale    = model.get_objective_scaling_factor();
+  user_problem.obj_scale    = maximize
+                                ? -model.get_objective_scaling_factor()
+                                : model.get_objective_scaling_factor();
 
   user_problem.var_types.resize(n);
   auto model_variable_types = model.get_variable_types_host();

--- a/python/cuopt/cuopt/tests/socp/test_socp.py
+++ b/python/cuopt/cuopt/tests/socp/test_socp.py
@@ -196,3 +196,50 @@ def test_general_quadratic_unsymmetric():
     assert problem.ObjValue == pytest.approx(expected_obj, abs=OBJ_TOL)
     assert x0.Value == pytest.approx(expected_x, abs=PRIMAL_TOL)
     assert x1.Value == pytest.approx(expected_x, abs=PRIMAL_TOL)
+
+
+def test_maximize_with_quadratic_constraint():
+    """
+    Maximize x + y
+    s.t.  x + y <= 10
+          2*x^2 + 2*x*y + 2*y^2 <= 6
+
+    The quadratic constraint is the binding one.
+    With x = y = t: 2t^2 + 2t^2 + 2t^2 = 6t^2 <= 6 => t in [-1, 1].
+    Maximizing 2t gives t = 1, obj = 2.
+
+    Minimizing gives t = -1, obj = -2.
+
+    This test verifies that MAXIMIZE is respected when quadratic constraints
+    are present (regression for a bug where the QCQP path ignored the
+    objective sense).
+    """
+    from cuopt.linear_programming.problem import MAXIMIZE, MINIMIZE
+
+    # Solve as MINIMIZE first to establish baseline
+    prob_min = Problem("qc_maximize_min")
+    x = prob_min.addVariable(lb=-np.inf, name="x")
+    y = prob_min.addVariable(lb=-np.inf, name="y")
+    prob_min.addConstraint(x + y <= 10)
+    prob_min.addConstraint(2 * x * x + 2 * x * y + 2 * y * y <= 6)
+    prob_min.setObjective(x + y, sense=MINIMIZE)
+    _solve(prob_min)
+    _assert_feasible(prob_min)
+
+    assert prob_min.ObjValue == pytest.approx(-2.0, abs=OBJ_TOL)
+    assert x.Value == pytest.approx(-1.0, abs=PRIMAL_TOL)
+    assert y.Value == pytest.approx(-1.0, abs=PRIMAL_TOL)
+
+    # Solve as MAXIMIZE - should give the opposite optimum
+    prob_max = Problem("qc_maximize_max")
+    x = prob_max.addVariable(lb=-np.inf, name="x")
+    y = prob_max.addVariable(lb=-np.inf, name="y")
+    prob_max.addConstraint(x + y <= 10)
+    prob_max.addConstraint(2 * x * x + 2 * x * y + 2 * y * y <= 6)
+    prob_max.setObjective(x + y, sense=MAXIMIZE)
+    _solve(prob_max)
+    _assert_feasible(prob_max)
+
+    assert prob_max.ObjValue == pytest.approx(2.0, abs=OBJ_TOL)
+    assert x.Value == pytest.approx(1.0, abs=PRIMAL_TOL)
+    assert y.Value == pytest.approx(1.0, abs=PRIMAL_TOL)


### PR DESCRIPTION
The QCQP solve path translates the optimization_problem_t into the user_problem_t format consumed by Barrier via
cuopt_optimization_problem_to_user_problem(). Barrier always minimizes; it does not inspect obj_scale to determine optimization direction. In the non-QCQP paths the objective coefficients are already negated by convert_to_maximization_problem() before reaching Barrier, but in the QCQP path the optimization_problem_t is passed directly without that conversion, so the objective was never negated for maximization. This caused the solver to silently return the minimizer when maximize was requested.

Fix:
- Negate the objective coefficients in cuopt_optimization_problem_to_user_problem() when the problem is a maximization problem, so Barrier finds the maximizer.
- Set obj_scale = -objective_scaling_factor for maximization, so the reported objective value has the correct sign.

Add test_maximize_with_quadratic_constraint to verify both minimize and maximize give the correct optimal solution and objective value for a problem with a quadratic constraint.

Fixes #1375.