### PR TITLE
Note dual/sensitivity support per problem type in formulation skill

### DIFF
--- a/skills/cuopt-numerical-optimization-formulation/SKILL.md
+++ b/skills/cuopt-numerical-optimization-formulation/SKILL.md
@@ -32,8 +32,11 @@ Concepts and workflow for going from a problem description to a clear formulatio
 | Constraints | Linear | Linear | Linear (no quadratic constraints) |
 | Variables | Continuous | Mixed: continuous + integer/binary | Continuous |
 | Sense | min or max | min or max | **minimize only** (negate to max) |
+| Duals / sensitivity | Shadow prices + reduced costs | **None** (integer optima) | Shadow prices + reduced costs (beta) |
 
 If the objective is purely linear, prefer LP/MILP — do not artificially introduce quadratic terms. If any variable is integer or binary, the problem is MILP regardless of the rest.
+
+**Post-solve sensitivity (LP / QP only).** Continuous LP and QP solutions expose **dual values** (shadow prices — the marginal objective change per unit a binding constraint is relaxed: *where to invest to improve the outcome*) and **reduced costs** (for a variable the optimizer left at zero, how far it must improve to enter the solution: a *near-miss*). **MILP solutions have no duals** — integer optima are not continuous, so cuOpt returns none for them. Read them via the API skills' `lp_duals` asset (`get_dual_solution` / `get_reduced_cost`, or `DualValue` / `ReducedCost` in the modeling API).
 
 ## Required formulation questions
 

--- a/skills/cuopt-numerical-optimization-formulation/SKILL.md
+++ b/skills/cuopt-numerical-optimization-formulation/SKILL.md
@@ -32,11 +32,11 @@ Concepts and workflow for going from a problem description to a clear formulatio
 | Constraints | Linear | Linear | Linear (no quadratic constraints) |
 | Variables | Continuous | Mixed: continuous + integer/binary | Continuous |
 | Sense | min or max | min or max | **minimize only** (negate to max) |
-| Duals / sensitivity | Shadow prices + reduced costs | **None** (integer optima) | Shadow prices + reduced costs (beta) |
+| Duals / sensitivity | Shadow prices + reduced costs | **None** (integer optima) | Shadow prices + reduced costs |
 
 If the objective is purely linear, prefer LP/MILP — do not artificially introduce quadratic terms. If any variable is integer or binary, the problem is MILP regardless of the rest.
 
-**Post-solve sensitivity (LP / QP only).** Continuous LP and QP solutions expose **dual values** (shadow prices — the marginal objective change per unit a binding constraint is relaxed: *where to invest to improve the outcome*) and **reduced costs** (for a variable the optimizer left at zero, how far it must improve to enter the solution: a *near-miss*). **MILP solutions have no duals** — integer optima are not continuous, so cuOpt returns none for them. Read them via the API skills' `lp_duals` asset (`get_dual_solution` / `get_reduced_cost`, or `DualValue` / `ReducedCost` in the modeling API).
+**Post-solve sensitivity (LP / QP only).** Continuous LP and QP solutions expose **dual values** (shadow prices — the marginal objective change per unit a binding constraint is relaxed: *where to invest to improve the outcome*) and **reduced costs** (for a variable the optimizer left at zero, how far it must improve to enter the solution: a *near-miss*). **MILP solutions have no duals** — integer optima are not continuous, so there are none to return. See the language-specific API skills for how to retrieve them after a solve.
 
 ## Required formulation questions
 


### PR DESCRIPTION
## Description

Adds a per-problem-type **dual / sensitivity** capability note to the concepts-only `cuopt-numerical-optimization-formulation` skill, so the agent guides users correctly on what cuOpt exposes after a solve:

- **LP** — shadow prices (constraint duals) + reduced costs
- **MILP** — none (integer optima are not continuous)
- **QP** — shadow prices + reduced costs

Two edits: a `Duals / sensitivity` row in the LP/MILP/QP comparison table, and a short post-solve note giving the decision meaning — **shadow price = where to invest** (marginal objective gain from relaxing a binding constraint) and **reduced cost = near-miss** (how far a left-out option must improve before it enters the solution). As a concepts skill it states *what's supported per type* and *what it means*, and defers *how to read them* to the language-specific API skills (no API symbols inlined).

**Why.** Surfaced from real integration use — wiring solver-exact sensitivity/explainability into a downstream multi-objective decision layer. The formulation skill covered how to *formulate* but not which problem types yield sensitivity information, which is exactly what a user needs before relying on it (e.g. not expecting duals off a MILP).

The note also reflects the review feedback on #1355: a concepts skill carries no maturity ("beta") labels and no specific API symbols — both drift out of date, with no CI to catch the staleness.

**Validation & gating.** `ci/utils/validate_skills.sh` passes (skill structure, marketplace manifest, `AGENTS.md` references). The NVSkills-Eval pipeline — which also (re)generates `BENCHMARK.md`, the skill card, and the signature — is the gate and is **pending**: `skills/**` CI needs a maintainer and cannot be triggered from a fork branch.

**Related.**
- NVIDIA/cuopt-examples#154 — the diet LP duals example: a runnable worked case of the shadow-price / reduced-cost reading this note describes.
- Codebase-side sensitivity gaps (objective/RHS ranging; exposing variable/basis status) are tracked separately as #1394 and #1395.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA
