### PR TITLE
Build and test with CUDA 13.3.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -69,7 +69,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -84,7 +84,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-13.3.0
     secrets:
       CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -119,7 +119,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda-13.3.0
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -156,7 +156,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda-13.3.0
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -175,7 +175,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -195,7 +195,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda-13.3.0
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -215,7 +215,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       node_type: "gpu-l4-latest-1"
@@ -235,7 +235,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -256,7 +256,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@cuda-13.3.0
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}

--- a/.github/workflows/build_test_publish_images.yaml
+++ b/.github/workflows/build_test_publish_images.yaml
@@ -20,7 +20,7 @@ on:
         description: 'JSON array of architectures to build for'
       cuda_ver:
         type: string
-        default: '["12.9.0", "13.2.0"]'
+        default: '["12.9.0", "13.3.0"]'
         description: 'JSON array of CUDA versions to build for'
       python_ver:
         type: string

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,7 +36,7 @@ jobs:
       - test-self-hosted-server
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -125,7 +125,7 @@ jobs:
       contents: read
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@cuda-13.3.0
     with:
       files_yaml: |
         build_docs:
@@ -388,7 +388,7 @@ jobs:
   checks:
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
     with:
       enable_check_generated_files: false
   conda-cpp-build:
@@ -405,7 +405,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_cpp.sh
@@ -418,7 +418,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
@@ -444,7 +444,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -457,7 +457,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       run_codecov: false
@@ -480,7 +480,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
       build_type: pull-request
@@ -500,7 +500,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: ${{ needs.compute-matrix-filters.outputs.libcuopt_filter }}
@@ -518,7 +518,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt.sh
@@ -533,7 +533,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -556,7 +556,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt_server.sh
@@ -575,7 +575,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt_sh_client.sh
@@ -593,7 +593,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -57,7 +57,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@cuda-13.3.0
     with:
       run_codecov: false
       build_type: ${{ inputs.build_type }}
@@ -80,7 +80,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -102,7 +102,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -125,7 +125,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -21,7 +21,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@cuda-13.3.0
     secrets:
       slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Please install conda if you don't have it already. You can install [miniforge](h
 # create the conda environment (assuming in base `cuopt` directory)
 # note: cuOpt currently doesn't support `channel_priority: strict`;
 # use `channel_priority: flexible` instead
-conda env create -p ./.cuopt_env --file conda/environments/all_cuda-132_arch-$(uname -m).yaml
+conda env create -p ./.cuopt_env --file conda/environments/all_cuda-133_arch-$(uname -m).yaml
 # activate the environment
 conda activate ./.cuopt_env
 ```

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -18,14 +18,14 @@ dependencies:
 - cuda-nvtx-dev
 - cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
-- cuda-version=13.2
+- cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
 - fastapi
-- gcc_linux-64=14.*
+- gcc_linux-aarch64=14.*
 - ipython
 - jsonref==1.1.0
 - libabseil
@@ -77,7 +77,7 @@ dependencies:
 - sphinx_rtd_theme
 - sphinxcontrib-openapi
 - sphinxcontrib-websupport
-- sysroot_linux-64==2.28
+- sysroot_linux-aarch64==2.28
 - tbb-devel
 - uvicorn==0.34.*
 - zlib
@@ -85,4 +85,4 @@ dependencies:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
   - veroviz
-name: all_cuda-132_arch-x86_64
+name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -18,14 +18,14 @@ dependencies:
 - cuda-nvtx-dev
 - cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
-- cuda-version=13.2
+- cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
 - cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
 - fastapi
-- gcc_linux-aarch64=14.*
+- gcc_linux-64=14.*
 - ipython
 - jsonref==1.1.0
 - libabseil
@@ -77,7 +77,7 @@ dependencies:
 - sphinx_rtd_theme
 - sphinxcontrib-openapi
 - sphinxcontrib-websupport
-- sysroot_linux-aarch64==2.28
+- sysroot_linux-64==2.28
 - tbb-devel
 - uvicorn==0.34.*
 - zlib
@@ -85,4 +85,4 @@ dependencies:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
   - veroviz
-name: all_cuda-132_arch-aarch64
+name: all_cuda-133_arch-x86_64

--- a/cpp/src/pdlp/cusparse_view.cu
+++ b/cpp/src/pdlp/cusparse_view.cu
@@ -270,28 +270,51 @@ void my_cusparsespmm_preprocess(cusparseHandle_t handle,
 }
 #endif
 
-#if CUDA_VER_13_2_UP
-// SpMVOp symbols. Resolved at runtime via dlsym, because the runtime minor version might not match
-// the compiled minor version. We can go back to direct linking once CUDA 14 is adopted
-using cusparseSpMVOp_destroyDescr_sig = cusparse_sig<cusparseSpMVOpDescr_t>;
-using cusparseSpMVOp_destroyPlan_sig  = cusparse_sig<cusparseSpMVOpPlan_t>;
-using cusparseSpMVOp_bufferSize_sig   = cusparse_sig<cusparseHandle_t,
-                                                     cusparseOperation_t,
-                                                     cusparseSpMatDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cudaDataType,
-                                                     size_t*>;
-using cusparseSpMVOp_createDescr_sig  = cusparse_sig<cusparseHandle_t,
-                                                     cusparseSpMVOpDescr_t*,
-                                                     cusparseOperation_t,
-                                                     cusparseSpMatDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cusparseDnVecDescr_t,
-                                                     cudaDataType,
-                                                     void*>;
+#if CUOPT_CUSPARSE_VER_12_7_UP
+// SpMVOp symbols. Resolved at runtime via dlsym, because the runtime cuSPARSE version
+// might not match the headers used at compile time. cuSPARSE 12.7 corresponds to CUDA
+// Toolkit 13.2; cuSPARSE 12.8 corresponds to CUDA Toolkit 13.3. We can go back to
+// direct linking once CUDA 14 is adopted.
+using cusparseSpMVOp_destroyDescr_sig     = cusparse_sig<cusparseSpMVOpDescr_t>;
+using cusparseSpMVOp_destroyPlan_sig      = cusparse_sig<cusparseSpMVOpPlan_t>;
+using cusparseSpMVOp_bufferSize_12_7_sig  = cusparse_sig<cusparseHandle_t,
+                                                         cusparseOperation_t,
+                                                         cusparseSpMatDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cudaDataType,
+                                                         size_t*>;
+using cusparseSpMVOp_createDescr_12_7_sig = cusparse_sig<cusparseHandle_t,
+                                                         cusparseSpMVOpDescr_t*,
+                                                         cusparseOperation_t,
+                                                         cusparseSpMatDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cudaDataType,
+                                                         void*>;
+#if CUOPT_CUSPARSE_VER_12_8_UP
+using cusparseSpMVOp_bufferSize_12_8_sig  = cusparse_sig<cusparseHandle_t,
+                                                         cusparseOperation_t,
+                                                         cusparseConstSpMatDescr_t,
+                                                         cusparseConstDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cudaDataType,
+                                                         cusparseSpMVOpAlg_t,
+                                                         size_t*>;
+using cusparseSpMVOp_createDescr_12_8_sig = cusparse_sig<cusparseHandle_t,
+                                                         cusparseSpMVOpDescr_t*,
+                                                         cusparseOperation_t,
+                                                         cusparseConstSpMatDescr_t,
+                                                         cusparseConstDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cusparseDnVecDescr_t,
+                                                         cudaDataType,
+                                                         cusparseSpMVOpAlg_t,
+                                                         void*>;
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 using cusparseSpMVOp_createPlan_sig =
   cusparse_sig<cusparseHandle_t, cusparseSpMVOpDescr_t, cusparseSpMVOpPlan_t*, char*, size_t>;
 using cusparseSpMVOp_sig = cusparse_sig<cusparseHandle_t,
@@ -301,6 +324,43 @@ using cusparseSpMVOp_sig = cusparse_sig<cusparseHandle_t,
                                         cusparseDnVecDescr_t,
                                         cusparseDnVecDescr_t,
                                         cusparseDnVecDescr_t>;
+
+namespace {
+
+bool is_cusparse_runtime_12_8_or_newer()
+{
+  // cuSPARSE 12.8 is the version shipped with CUDA Toolkit 13.3.
+  int major = 0, minor = 0;
+  auto status = cusparseGetProperty(libraryPropertyType_t::MAJOR_VERSION, &major);
+  if (status != CUSPARSE_STATUS_SUCCESS) { return false; }
+  status = cusparseGetProperty(libraryPropertyType_t::MINOR_VERSION, &minor);
+  if (status != CUSPARSE_STATUS_SUCCESS) { return false; }
+  return (major > 12) || (major == 12 && minor >= 8);
+}
+
+cusparseStatus_t cusparse_spmvop_buffer_size(cusparseHandle_t handle,
+                                             cusparseOperation_t opA,
+                                             cusparseSpMatDescr_t matA,
+                                             cusparseDnVecDescr_t vecX,
+                                             cusparseDnVecDescr_t vecY,
+                                             cusparseDnVecDescr_t vecZ,
+                                             cudaDataType computeType,
+                                             size_t* bufferSize)
+{
+#if CUOPT_CUSPARSE_VER_12_8_UP
+  if (is_cusparse_runtime_12_8_or_newer()) {
+    static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_12_8_sig>(
+      "cusparseSpMVOp_bufferSize");
+    return (*fn)(
+      handle, opA, matA, vecX, vecY, vecZ, computeType, CUSPARSE_SPMVOP_ALG_DEFAULT, bufferSize);
+  }
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
+  static const auto fn =
+    dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_12_7_sig>("cusparseSpMVOp_bufferSize");
+  return (*fn)(handle, opA, matA, vecX, vecY, vecZ, computeType, bufferSize);
+}
+
+}  // namespace
 
 cusparseStatus_t cusparse_spmvop_descr_wrapper_t::dlsym_create(cusparseHandle_t handle,
                                                                cusparseSpMVOpDescr_t* descr,
@@ -312,8 +372,16 @@ cusparseStatus_t cusparse_spmvop_descr_wrapper_t::dlsym_create(cusparseHandle_t 
                                                                cudaDataType computeType,
                                                                void* buffer)
 {
-  static const auto fn =
-    dynamic_load_runtime::function<cusparseSpMVOp_createDescr_sig>("cusparseSpMVOp_createDescr");
+#if CUOPT_CUSPARSE_VER_12_8_UP
+  if (is_cusparse_runtime_12_8_or_newer()) {
+    static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_createDescr_12_8_sig>(
+      "cusparseSpMVOp_createDescr");
+    return (*fn)(
+      handle, descr, opA, matA, vecX, vecY, vecZ, computeType, CUSPARSE_SPMVOP_ALG_DEFAULT, buffer);
+  }
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
+  static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_createDescr_12_7_sig>(
+    "cusparseSpMVOp_createDescr");
   return (*fn)(handle, descr, opA, matA, vecX, vecY, vecZ, computeType, buffer);
 }
 
@@ -436,7 +504,7 @@ void cusparse_spmvop_run(cusparseHandle_t handle,
   RAFT_CUSPARSE_TRY(cusparseSetStream(handle, stream));
   RAFT_CUSPARSE_TRY((*func)(handle, plan, alpha, beta, vecX, vecY, vecZ));
 }
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
 
 // This cstr is used in pdhg, step size strategy and in cuPDLPx infeasible detection
 // A_T is owned by the scaled problem
@@ -1360,35 +1428,38 @@ bool is_cusparse_runtime_mixed_precision_supported()
 
 bool is_cusparse_runtime_spmvop_supported()
 {
-#if CUDA_VER_13_2_UP
-  // Probe the runtimme to ensure cusparseSpMVOp is supported
+#if CUOPT_CUSPARSE_VER_12_7_UP
+#if !CUOPT_CUSPARSE_VER_12_8_UP
+  // Headers older than cuSPARSE 12.8 (CUDA Toolkit 13.3) cannot name the newer SpMVOp
+  // descriptor types, so do not call the older 12.7 signature against a 12.8+ runtime.
+  if (is_cusparse_runtime_12_8_or_newer()) { return false; }
+#endif  // !CUOPT_CUSPARSE_VER_12_8_UP
+  // Probe the runtime to ensure cusparseSpMVOp is supported.
   static const bool supported =
     dynamic_load_runtime::function<cusparseSpMVOp_sig>("cusparseSpMVOp").has_value();
   return supported;
 #else
   return false;
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
 }
 
 // Creates SpMVOp plans. Must be called after scale_problem() so plans use the scaled matrix.
 template <typename i_t, typename f_t>
 void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
 {
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_7_UP
   if (!is_cusparse_runtime_spmvop_supported() || !(std::is_same_v<f_t, double>)) { return; }
-  static const auto buffer_size =
-    dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_sig>("cusparseSpMVOp_bufferSize");
   CUSPARSE_CHECK(cusparseSetStream(handle_ptr_->get_cusparse_handle(), handle_ptr_->get_stream()));
   // Prepare buffers for At_y SpMVOp
   size_t buffer_size_transpose = 0;
-  RAFT_CUSPARSE_TRY((*buffer_size)(handle_ptr_->get_cusparse_handle(),
-                                   CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                   A_T,
-                                   dual_solution,
-                                   current_AtY,
-                                   current_AtY,
-                                   CUDA_R_64F,
-                                   &buffer_size_transpose));
+  RAFT_CUSPARSE_TRY(cusparse_spmvop_buffer_size(handle_ptr_->get_cusparse_handle(),
+                                                CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                                A_T,
+                                                dual_solution,
+                                                current_AtY,
+                                                current_AtY,
+                                                CUDA_R_64F,
+                                                &buffer_size_transpose));
   buffer_transpose_spmvop.resize(buffer_size_transpose, handle_ptr_->get_stream());
 
   spmv_op_descr_A_t_.create(handle_ptr_->get_cusparse_handle(),
@@ -1405,14 +1476,14 @@ void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
   // Only prepare buffers for A_x if we are using reflected_halpern
   if (is_reflected) {
     size_t buffer_size_non_transpose = 0;
-    RAFT_CUSPARSE_TRY((*buffer_size)(handle_ptr_->get_cusparse_handle(),
-                                     CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                     A,
-                                     reflected_primal_solution,
-                                     dual_gradient,
-                                     dual_gradient,
-                                     CUDA_R_64F,
-                                     &buffer_size_non_transpose));
+    RAFT_CUSPARSE_TRY(cusparse_spmvop_buffer_size(handle_ptr_->get_cusparse_handle(),
+                                                  CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                                  A,
+                                                  reflected_primal_solution,
+                                                  dual_gradient,
+                                                  dual_gradient,
+                                                  CUDA_R_64F,
+                                                  &buffer_size_non_transpose));
     buffer_non_transpose_spmvop.resize(buffer_size_non_transpose, handle_ptr_->get_stream());
 
     spmv_op_descr_A_.create(handle_ptr_->get_cusparse_handle(),
@@ -1426,7 +1497,7 @@ void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
 
     spmv_op_plan_A_.create(handle_ptr_->get_cusparse_handle(), spmv_op_descr_A_);
   }
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
 }
 
 #if MIP_INSTANTIATE_FLOAT || PDLP_INSTANTIATE_FLOAT

--- a/cpp/src/pdlp/cusparse_view.hpp
+++ b/cpp/src/pdlp/cusparse_view.hpp
@@ -20,7 +20,10 @@
 
 #include <cusparse_v2.h>
 
-#define CUDA_VER_13_2_UP (CUDART_VERSION >= 13020)
+// cuSPARSE 12.7 ships with CUDA Toolkit 13.2
+#define CUOPT_CUSPARSE_VER_12_7_UP (CUSPARSE_VERSION >= 12700)
+// cuSPARSE 12.8 ships with CUDA Toolkit 13.3
+#define CUOPT_CUSPARSE_VER_12_8_UP (CUSPARSE_VERSION >= 12800)
 
 namespace cuopt::linear_programming::detail {
 
@@ -81,7 +84,7 @@ class cusparse_dn_mat_descr_wrapper_t {
   bool need_destruction_;
 };
 
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_7_UP
 // RAII wrapper around cusparse SpMVOp objects. All the buffers are owned by the cusparse_view_t.
 class cusparse_spmvop_descr_wrapper_t {
  public:
@@ -149,7 +152,7 @@ class cusparse_spmvop_plan_wrapper_t {
   cusparseSpMVOpPlan_t plan_;
   bool need_destruction_;
 };
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
 
 template <typename i_t, typename f_t>
 class cusparse_view_t {
@@ -248,13 +251,13 @@ class cusparse_view_t {
   rmm::device_uvector<uint8_t> buffer_non_transpose_spmvop{0, handle_ptr_->get_stream()};
   rmm::device_uvector<uint8_t> buffer_transpose_spmvop{0, handle_ptr_->get_stream()};
 
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_7_UP
   // SpMVOp descriptors and plans for A and A_T (descr before plan so dtor destroys plan first)
   cusparse_spmvop_descr_wrapper_t spmv_op_descr_A_;
   cusparse_spmvop_plan_wrapper_t spmv_op_plan_A_;
   cusparse_spmvop_descr_wrapper_t spmv_op_descr_A_t_;
   cusparse_spmvop_plan_wrapper_t spmv_op_plan_A_t_;
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
   // reuse buffers for cusparse spmm
   rmm::device_uvector<uint8_t> buffer_transpose_batch;
   rmm::device_uvector<uint8_t> buffer_non_transpose_batch;
@@ -353,10 +356,10 @@ void my_cusparsespmm_preprocess(cusparseHandle_t handle,
 
 bool is_cusparse_runtime_mixed_precision_supported();
 
-// False if cuda version < 13.2 or runtime cuSPARSE does not export SpMVOp symbols. True otherwise.
+// False if the cuSPARSE headers/runtime do not support SpMVOp symbols. True otherwise.
 bool is_cusparse_runtime_spmvop_supported();
 
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_7_UP
 // Dispatches to the runtime cusparseSpMVOp via dlsym so callers (e.g., pdhg.cu) never
 // reference the symbol statically. Caller must have verified
 // is_cusparse_runtime_spmvop_supported().
@@ -368,6 +371,6 @@ void cusparse_spmvop_run(cusparseHandle_t handle,
                          cusparseDnVecDescr_t vecY,
                          cusparseDnVecDescr_t vecZ,
                          cudaStream_t stream);
-#endif
+#endif  // CUOPT_CUSPARSE_VER_12_7_UP
 
 }  // namespace cuopt::linear_programming::detail

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -184,7 +184,7 @@ std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico
   auto stream          = sol.sol_handle->get_stream();
   i_t TPB              = 32;
   const i_t zero       = 0;
-  const auto value_max = std::numeric_limits<uint32_t>::max();
+  const uint32_t value_max = std::numeric_limits<uint32_t>::max();
   sol.d_lock.set_value_async(zero, stream);
   rmm::device_uvector<i_t> global_sequence(2 * b_k_max + lexico_result_buffer_size, stream);
   rmm::device_scalar<uint32_t> global_min_p(value_max, stream);

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -184,7 +184,7 @@ std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico
   auto stream          = sol.sol_handle->get_stream();
   i_t TPB              = 32;
   const i_t zero       = 0;
-  const auto value_max = std::numeric_limits<typename decltype(global_min_p_)::value_type>::max();
+  const auto value_max = std::numeric_limits<uint32_t>::max();
   sol.d_lock.set_value_async(zero, stream);
   rmm::device_uvector<i_t> global_sequence(2 * b_k_max + lexico_result_buffer_size, stream);
   rmm::device_scalar<uint32_t> global_min_p(value_max, stream);

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -181,9 +181,9 @@ template <typename i_t, typename f_t, request_t REQUEST>
 std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico(
   solution_t<i_t, f_t, REQUEST>& sol, request_info_t<i_t, REQUEST>* __restrict__ req)
 {
-  auto stream          = sol.sol_handle->get_stream();
-  i_t TPB              = 32;
-  const i_t zero       = 0;
+  auto stream              = sol.sol_handle->get_stream();
+  i_t TPB                  = 32;
+  const i_t zero           = 0;
   const uint32_t value_max = std::numeric_limits<uint32_t>::max();
   sol.d_lock.set_value_async(zero, stream);
   rmm::device_uvector<i_t> global_sequence(2 * b_k_max + lexico_result_buffer_size, stream);

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -707,7 +707,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
   }
 
   // Init global min before call to lexicographic
-  const auto max = std::numeric_limits<typename decltype(global_min_p_)::value_type>::max();
+  const auto max = std::numeric_limits<uint32_t>::max();
   const i_t zero = 0;
   global_min_p_.set_value_async(max, stream);
   solution_ptr->d_lock.set_value_async(zero, stream);

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -707,7 +707,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
   }
 
   // Init global min before call to lexicographic
-  const auto max = std::numeric_limits<uint32_t>::max();
+  const uint32_t max = std::numeric_limits<uint32_t>::max();
   const i_t zero = 0;
   global_min_p_.set_value_async(max, stream);
   solution_ptr->d_lock.set_value_async(zero, stream);

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -708,7 +708,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
 
   // Init global min before call to lexicographic
   const uint32_t max = std::numeric_limits<uint32_t>::max();
-  const i_t zero = 0;
+  const i_t zero     = 0;
   global_min_p_.set_value_async(max, stream);
   solution_ptr->d_lock.set_value_async(zero, stream);
   global_random_counter_.set_value_async(zero, stream);

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.9", "13.2"]
+      cuda: ["12.9", "13.3"]
       arch: [x86_64, aarch64]
     includes:
       - build_common
@@ -644,6 +644,10 @@ dependencies:
               cuda: "13.2"
             packages:
               - cuda-version=13.2
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-version=13.3
       - output_types: requirements
         matrices:
           # if use_cuda_wheels=false is provided, do not add dependencies on any CUDA wheels
@@ -694,6 +698,11 @@ dependencies:
               use_cuda_wheels: "true"
             packages:
               - cuda-toolkit==13.2.*
+          - matrix:
+              cuda: "13.3"
+              use_cuda_wheels: "true"
+            packages:
+              - cuda-toolkit==13.3.*
   cuda:
     common:
       - output_types: [conda]


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

* uses CUDA 13.3.0 to build and test
* updates to CUDA 13.3.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.3.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/574

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.

