### PR TITLE
Use LP format reader throughout unit tests

### DIFF
--- a/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
@@ -915,7 +915,7 @@ namespace {
 
 cpu_optimization_problem_t<int32_t, double> create_test_lp_problem()
 {
-  auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto data = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: x
 Subject To
@@ -931,7 +931,7 @@ End
 
 cpu_optimization_problem_t<int32_t, double> create_test_mip_problem()
 {
-  auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto data = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: x
 Subject To

--- a/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
@@ -16,6 +16,8 @@
 
 #include "grpc_client_test_helper.hpp"
 
+#include <utilities/inline_lp_test_utils.hpp>
+
 #include <cuopt/linear_programming/cpu_optimization_problem.hpp>
 #include <cuopt/linear_programming/cpu_optimization_problem_solution.hpp>
 #include <cuopt/linear_programming/mip/solver_settings.hpp>
@@ -913,53 +915,37 @@ namespace {
 
 cpu_optimization_problem_t<int32_t, double> create_test_lp_problem()
 {
+  // minimize x  subject to x >= 1, 0 <= x <= 10
+  auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: x
+Subject To
+  c1: x >= 1
+Bounds
+  0 <= x <= 10
+End
+)LP");
   cpu_optimization_problem_t<int32_t, double> problem;
-
-  // minimize x  subject to x >= 1
-  std::vector<double> obj    = {1.0};
-  std::vector<double> var_lb = {0.0};
-  std::vector<double> var_ub = {10.0};
-  std::vector<double> con_lb = {1.0};
-  std::vector<double> con_ub = {1e20};
-  std::vector<double> A_vals = {1.0};
-  std::vector<int32_t> A_idx = {0};
-  std::vector<int32_t> A_off = {0, 1};
-
-  problem.set_objective_coefficients(obj.data(), 1);
-  problem.set_maximize(false);
-  problem.set_variable_lower_bounds(var_lb.data(), 1);
-  problem.set_variable_upper_bounds(var_ub.data(), 1);
-  problem.set_csr_constraint_matrix(A_vals.data(), 1, A_idx.data(), 1, A_off.data(), 2);
-  problem.set_constraint_lower_bounds(con_lb.data(), 1);
-  problem.set_constraint_upper_bounds(con_ub.data(), 1);
-
+  populate_from_mps_data_model(&problem, data);
   return problem;
 }
 
 cpu_optimization_problem_t<int32_t, double> create_test_mip_problem()
 {
+  // minimize x  subject to x >= 1, x integer in [0, 10]
+  auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: x
+Subject To
+  c1: x >= 1
+Bounds
+  0 <= x <= 10
+Generals
+  x
+End
+)LP");
   cpu_optimization_problem_t<int32_t, double> problem;
-
-  // minimize x  subject to x >= 1, x integer
-  std::vector<double> obj    = {1.0};
-  std::vector<double> var_lb = {0.0};
-  std::vector<double> var_ub = {10.0};
-  std::vector<var_t> var_ty  = {var_t::INTEGER};
-  std::vector<double> con_lb = {1.0};
-  std::vector<double> con_ub = {1e20};
-  std::vector<double> A_vals = {1.0};
-  std::vector<int32_t> A_idx = {0};
-  std::vector<int32_t> A_off = {0, 1};
-
-  problem.set_objective_coefficients(obj.data(), 1);
-  problem.set_maximize(false);
-  problem.set_variable_lower_bounds(var_lb.data(), 1);
-  problem.set_variable_upper_bounds(var_ub.data(), 1);
-  problem.set_variable_types(var_ty.data(), 1);
-  problem.set_csr_constraint_matrix(A_vals.data(), 1, A_idx.data(), 1, A_off.data(), 2);
-  problem.set_constraint_lower_bounds(con_lb.data(), 1);
-  problem.set_constraint_upper_bounds(con_ub.data(), 1);
-
+  populate_from_mps_data_model(&problem, data);
   return problem;
 }
 

--- a/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
@@ -915,7 +915,6 @@ namespace {
 
 cpu_optimization_problem_t<int32_t, double> create_test_lp_problem()
 {
-  // minimize x  subject to x >= 1, 0 <= x <= 10
   auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: x
@@ -932,7 +931,6 @@ End
 
 cpu_optimization_problem_t<int32_t, double> create_test_mip_problem()
 {
-  // minimize x  subject to x >= 1, x integer in [0, 10]
   auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: x

--- a/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
@@ -37,12 +37,12 @@
 
 #include <cuopt/linear_programming/cpu_optimization_problem.hpp>
 #include <cuopt/linear_programming/io/parser.hpp>
-#include <utilities/inline_lp_test_utils.hpp>
 #include <cuopt/linear_programming/mip/solver_settings.hpp>
 #include <cuopt/linear_programming/optimization_problem.hpp>
 #include <cuopt/linear_programming/optimization_problem_interface.hpp>
 #include <cuopt/linear_programming/optimization_problem_utils.hpp>
 #include <cuopt/linear_programming/pdlp/solver_settings.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 #include "grpc_client.hpp"
 
 #include "grpc_test_log_capture.hpp"

--- a/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
@@ -392,7 +392,6 @@ class GrpcIntegrationTestBase : public ::testing::Test {
 
   cpu_optimization_problem_t<int32_t, double> create_simple_mip()
   {
-    // minimize x0 + 2 x1  s.t. x0 + x1 >= 1, x0, x1 binary
     auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: x0 + 2 x1

--- a/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
@@ -392,7 +392,7 @@ class GrpcIntegrationTestBase : public ::testing::Test {
 
   cpu_optimization_problem_t<int32_t, double> create_simple_mip()
   {
-    auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+    auto data = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: x0 + 2 x1
 Subject To

--- a/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
@@ -37,6 +37,7 @@
 
 #include <cuopt/linear_programming/cpu_optimization_problem.hpp>
 #include <cuopt/linear_programming/io/parser.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 #include <cuopt/linear_programming/mip/solver_settings.hpp>
 #include <cuopt/linear_programming/optimization_problem.hpp>
 #include <cuopt/linear_programming/optimization_problem_interface.hpp>
@@ -391,30 +392,19 @@ class GrpcIntegrationTestBase : public ::testing::Test {
 
   cpu_optimization_problem_t<int32_t, double> create_simple_mip()
   {
+    // minimize x0 + 2 x1  s.t. x0 + x1 >= 1, x0, x1 binary
+    auto data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: x0 + 2 x1
+Subject To
+  c1: x0 + x1 >= 1
+Binaries
+  x0
+  x1
+End
+)LP");
     cpu_optimization_problem_t<int32_t, double> problem;
-
-    std::vector<double> c = {1.0, 2.0};
-    problem.set_objective_coefficients(c.data(), 2);
-    problem.set_maximize(false);
-
-    std::vector<double> A_values   = {1.0, 1.0};
-    std::vector<int32_t> A_indices = {0, 1};
-    std::vector<int32_t> A_offsets = {0, 2};
-    problem.set_csr_constraint_matrix(A_values.data(), 2, A_indices.data(), 2, A_offsets.data(), 2);
-
-    std::vector<double> var_lb = {0.0, 0.0};
-    std::vector<double> var_ub = {1.0, 1.0};
-    problem.set_variable_lower_bounds(var_lb.data(), 2);
-    problem.set_variable_upper_bounds(var_ub.data(), 2);
-
-    std::vector<var_t> var_types = {var_t::INTEGER, var_t::INTEGER};
-    problem.set_variable_types(var_types.data(), 2);
-
-    std::vector<double> con_lb = {1.0};
-    std::vector<double> con_ub = {std::numeric_limits<double>::infinity()};
-    problem.set_constraint_lower_bounds(con_lb.data(), 1);
-    problem.set_constraint_upper_bounds(con_ub.data(), 1);
-
+    populate_from_mps_data_model(&problem, data);
     return problem;
   }
 

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -837,7 +837,7 @@ TEST(pdlp_class, per_constraint_test)
    * will be 0.1009
    */
   raft::handle_t handle;
-  auto mps_data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto mps_data = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x1 + 0 x2 + 0 x3
 Subject To

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -837,7 +837,7 @@ TEST(pdlp_class, per_constraint_test)
    * will be 0.1009
    */
   raft::handle_t handle;
-  auto mps_data = cuopt::test::parse_inline_lp(R"LP(
+  auto mps_data   = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x1 + 0 x2 + 0 x3
 Subject To

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -20,6 +20,7 @@
 
 #include <utilities/base_fixture.hpp>
 #include <utilities/common_utils.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
 #include <cuopt/linear_programming/constants.h>
 #include <cuopt/linear_programming/io/parser.hpp>
@@ -836,26 +837,21 @@ TEST(pdlp_class, per_constraint_test)
    * will be 0.1009
    */
   raft::handle_t handle;
-  auto op_problem = optimization_problem_t<int, double>(&handle);
+  auto mps_data = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 0 x1 + 0 x2 + 0 x3
+Subject To
+  c1: x1 = 0
+  c2: x2 = 0
+  c3: x3 = 0
+End
+)LP");
+  auto op_problem = mps_data_model_to_optimization_problem(&handle, mps_data);
 
-  std::vector<double> A_host           = {1.0, 1.0, 1.0};
-  std::vector<int> indices_host        = {0, 1, 2};
-  std::vector<int> offset_host         = {0, 1, 2, 3};
-  std::vector<double> b_host           = {0.0, 0.0, 0.0};
   std::vector<double> h_initial_primal = {0.02, 0.03, 0.1};
   rmm::device_uvector<double> d_initial_primal(3, handle.get_stream());
   raft::copy(
     d_initial_primal.data(), h_initial_primal.data(), h_initial_primal.size(), handle.get_stream());
-
-  op_problem.set_csr_constraint_matrix(A_host.data(),
-                                       A_host.size(),
-                                       indices_host.data(),
-                                       indices_host.size(),
-                                       offset_host.data(),
-                                       offset_host.size());
-  op_problem.set_constraint_lower_bounds(b_host.data(), b_host.size());
-  op_problem.set_constraint_upper_bounds(b_host.data(), b_host.size());
-  op_problem.set_objective_coefficients(b_host.data(), b_host.size());
 
   auto problem = cuopt::linear_programming::detail::problem_t<int, double>(op_problem);
 

--- a/cpp/tests/mip/cuts_test.cu
+++ b/cpp/tests/mip/cuts_test.cu
@@ -48,7 +48,7 @@ constexpr double kCliqueTestTol = 1e-6;
 // Pairwise binary conflicts forming a triangle.
 io::mps_data_model_t<int, double> create_pairwise_triangle_set_packing_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -x0 - x1 - x2
 Subject To
@@ -66,7 +66,7 @@ End
 // Same triangle conflicts plus an isolated binary x3 with no conflict rows.
 io::mps_data_model_t<int, double> create_pairwise_triangle_with_isolated_variable_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -x0 - x1 - x2
 Subject To
@@ -86,7 +86,7 @@ End
 // x0 + x2 <= 1  (must generate a conflict edge)
 io::mps_data_model_t<int, double> create_binary_continuous_mixed_conflict_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x0 + 0 y1 + 0 x2
 Subject To
@@ -105,7 +105,7 @@ End
 // treated as a binary conflict row.
 io::mps_data_model_t<int, double> create_near_binary_bound_conflict_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x0 + 0 x1
 Subject To
@@ -123,7 +123,7 @@ End
 // Creates base clique {x2, x3} and additional clique inducing conflict {x1, x3}.
 io::mps_data_model_t<int, double> create_weighted_addtl_conflict_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x0 + 0 x1 + 0 x2 + 0 x3
 Subject To
@@ -770,7 +770,7 @@ std::optional<size_t> isolate_first_lp_infeasible_literal_cut_by_bisection(
 
 io::mps_data_model_t<int, double> create_cuts_problem_1()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -7 x1 - 2 x2
 Subject To
@@ -810,7 +810,7 @@ TEST(cuts, test_cuts_1)
 
 io::mps_data_model_t<int, double> create_cuts_problem_2()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -86 y1 - 4 y2 - 40 y3
 Subject To
@@ -1325,7 +1325,7 @@ TEST(cuts, clique_neos8_phase4_lp_infeasibility_binary_search)
 // flows. Keep the variable order matching that layout.
 io::mps_data_model_t<int, double> create_small_single_node_flow_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 0 x0 + 0 x1 + 0 x2 + 0 y0 + 0 y1 + 0 y2
 Subject To

--- a/cpp/tests/mip/cuts_test.cu
+++ b/cpp/tests/mip/cuts_test.cu
@@ -18,6 +18,7 @@
 #include <utilities/common_utils.hpp>
 #include <utilities/copy_helpers.hpp>
 #include <utilities/error.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 #include <utilities/timer.hpp>
 
 #include <raft/core/handle.hpp>
@@ -44,138 +45,99 @@ namespace {
 
 constexpr double kCliqueTestTol = 1e-6;
 
+// Maximize x0 + x1 + x2 via minimizing -x0 - x1 - x2, with pairwise binary
+// conflicts forming a triangle.
 io::mps_data_model_t<int, double> create_pairwise_triangle_set_packing_problem()
 {
-  // Maximize x0 + x1 + x2 via minimizing -x0 - x1 - x2.
-  // Pairwise conflicts:
-  //   x0 + x1 <= 1
-  //   x1 + x2 <= 1
-  //   x0 + x2 <= 1
-  io::mps_data_model_t<int, double> problem;
-  std::vector<int> offsets         = {0, 2, 4, 6};
-  std::vector<int> indices         = {0, 1, 1, 2, 0, 2};
-  std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-  std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-  std::vector<double> objective_coefficients = {-1.0, -1.0, -1.0};
-  problem.set_objective_coefficients(objective_coefficients);
-  std::vector<char> variable_types = {'I', 'I', 'I'};
-  problem.set_variable_types(variable_types);
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -x0 - x1 - x2
+Subject To
+  c1: x0 + x1 <= 1
+  c2: x1 + x2 <= 1
+  c3: x0 + x2 <= 1
+Binaries
+  x0
+  x1
+  x2
+End
+)LP");
 }
 
+// Same triangle conflicts plus an isolated binary x3 with no conflict rows.
 io::mps_data_model_t<int, double> create_pairwise_triangle_with_isolated_variable_problem()
 {
-  // Same triangle conflicts as create_pairwise_triangle_set_packing_problem(),
-  // plus an isolated binary variable x3 with no conflict rows.
-  io::mps_data_model_t<int, double> problem;
-  std::vector<int> offsets         = {0, 2, 4, 6};
-  std::vector<int> indices         = {0, 1, 1, 2, 0, 2};
-  std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-  std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-  std::vector<double> objective_coefficients = {-1.0, -1.0, -1.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients);
-  std::vector<char> variable_types = {'I', 'I', 'I', 'I'};
-  problem.set_variable_types(variable_types);
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -x0 - x1 - x2
+Subject To
+  c1: x0 + x1 <= 1
+  c2: x1 + x2 <= 1
+  c3: x0 + x2 <= 1
+Binaries
+  x0
+  x1
+  x2
+  x3
+End
+)LP");
 }
 
+// x0 + y1 <= 1  (must be ignored for clique graph because y1 is continuous)
+// x0 + x2 <= 1  (must generate a conflict edge)
 io::mps_data_model_t<int, double> create_binary_continuous_mixed_conflict_problem()
 {
-  // x0 + y1 <= 1  (must be ignored for clique graph because y1 is continuous)
-  // x0 + x2 <= 1  (must generate a conflict edge)
-  io::mps_data_model_t<int, double> problem;
-  std::vector<int> offsets         = {0, 2, 4};
-  std::vector<int> indices         = {0, 1, 0, 2};
-  std::vector<double> coefficients = {1.0, 1.0, 1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {1.0, 1.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-  std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-  std::vector<double> objective_coefficients = {0.0, 0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients);
-  std::vector<char> variable_types = {'I', 'C', 'I'};
-  problem.set_variable_types(variable_types);
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 0 x0 + 0 y1 + 0 x2
+Subject To
+  c1: x0 + y1 <= 1
+  c2: x0 + x2 <= 1
+Bounds
+  0 <= y1 <= 1
+Binaries
+  x0
+  x2
+End
+)LP");
 }
 
+// x0 + x1 <= 1 but x1 has upper bound 0.9999999, so this row should not be
+// treated as a binary conflict row.
 io::mps_data_model_t<int, double> create_near_binary_bound_conflict_problem()
 {
-  // x0 + x1 <= 1 but x1 has upper bound 0.9999999, so this row should not be
-  // treated as a binary conflict row.
-  io::mps_data_model_t<int, double> problem;
-  std::vector<int> offsets         = {0, 2};
-  std::vector<int> indices         = {0, 1};
-  std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {1.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-  std::vector<double> var_lower_bounds = {0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 0.9999999};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-  std::vector<double> objective_coefficients = {0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients);
-  std::vector<char> variable_types = {'I', 'I'};
-  problem.set_variable_types(variable_types);
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 0 x0 + 0 x1
+Subject To
+  c1: x0 + x1 <= 1
+Bounds
+  0 <= x0 <= 1
+  0 <= x1 <= 0.9999999
+Generals
+  x0
+  x1
+End
+)LP");
 }
 
+// One weighted binary knapsack row:
+//   1*x0 + 2*x1 + 3*x2 + 4*x3 <= 5
+// This creates base clique {x2, x3} and additional clique inducing conflict {x1, x3}.
 io::mps_data_model_t<int, double> create_weighted_addtl_conflict_problem()
 {
-  // One weighted binary knapsack row:
-  //   1*x0 + 2*x1 + 3*x2 + 4*x3 <= 5
-  // This creates base clique {x2, x3} and additional clique inducing conflict {x1, x3}.
-  io::mps_data_model_t<int, double> problem;
-  std::vector<int> offsets         = {0, 4};
-  std::vector<int> indices         = {0, 1, 2, 3};
-  std::vector<double> coefficients = {1.0, 2.0, 3.0, 4.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {5.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-  std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-  std::vector<double> objective_coefficients = {0.0, 0.0, 0.0, 0.0};
-  problem.set_objective_coefficients(objective_coefficients);
-  std::vector<char> variable_types = {'I', 'I', 'I', 'I'};
-  problem.set_variable_types(variable_types);
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 0 x0 + 0 x1 + 0 x2 + 0 x3
+Subject To
+  c1: x0 + 2 x1 + 3 x2 + 4 x3 <= 5
+Binaries
+  x0
+  x1
+  x2
+  x3
+End
+)LP");
 }
 
 detail::clique_table_t<int, double> build_clique_table_for_model_with_min_size(
@@ -809,47 +771,28 @@ std::optional<size_t> isolate_first_lp_infeasible_literal_cut_by_bisection(
 
 }  // namespace
 
-// Problem data for the mixed integer linear programming problem
+// minimize -7*x1 -2*x2
+// subject to -x1 + 2*x2 <= 4
+//            5*x1 +  x2 <= 20
+//           -2*x1 - 2*x2 <= -7
+// x1, x2 integer in [0, 10]
 io::mps_data_model_t<int, double> create_cuts_problem_1()
 {
-  // Create problem instance
-  io::mps_data_model_t<int, double> problem;
-
-  // Solve the problem
-  // minimize -7*x1 -2*x2
-  // subject to -1*x1 + 2*x2 <= 4
-  //            5*x1 + 1*x2 <= 20
-  //            -2*x1 -2*x2 <= -7
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 2, 4, 6};
-  std::vector<int> indices         = {0, 1, 0, 1, 0, 1};
-  std::vector<double> coefficients = {-1.0, 2.0, 5.0, 1.0, -2.0, -2.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {4.0, 20.0, -7.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower_bounds = {0.0, 0.0};
-  std::vector<double> var_upper_bounds = {10.0, 10.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-
-  // Set objective coefficients (minimize -7*x1 -2*x2)
-  std::vector<double> objective_coefficients = {-7.0, -2.0};
-  problem.set_objective_coefficients(objective_coefficients);
-
-  // Set variable types
-  std::vector<char> variable_types = {'I', 'I'};
-  problem.set_variable_types(variable_types);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -7 x1 - 2 x2
+Subject To
+  c1: -x1 + 2 x2 <= 4
+  c2: 5 x1 + x2 <= 20
+  c3: -2 x1 - 2 x2 <= -7
+Bounds
+  0 <= x1 <= 10
+  0 <= x2 <= 10
+Generals
+  x1
+  x2
+End
+)LP");
 }
 
 TEST(cuts, test_cuts_1)
@@ -873,46 +816,24 @@ TEST(cuts, test_cuts_1)
   EXPECT_LE(solution.get_num_nodes(), 2);
 }
 
-// Problem data for the mixed integer linear programming problem
+// minimize -86*y1 -4*y2 -40*y3
+// subject to 774*y1 + 76*y2 + 42*y3 <= 875
+//             67*y1 + 27*y2 + 53*y3 <= 875
+//             y1, y2, y3 binary
 io::mps_data_model_t<int, double> create_cuts_problem_2()
 {
-  // Create problem instance
-  io::mps_data_model_t<int, double> problem;
-
-  // Solve the problem
-  // minimize -86*y1 -4*y2 -40*y3
-  // subject to 774*y1 + 76*y2 + 42*y3 <= 875
-  //            67*y1 + 27*y2 + 53*y3 <= 875
-  //            y1, y2, y3 in {0, 1}
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 3, 6};
-  std::vector<int> indices         = {0, 1, 2, 0, 1, 2};
-  std::vector<double> coefficients = {774.0, 76.0, 42.0, 67.0, 27.0, 53.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {-std::numeric_limits<double>::infinity(),
-                                      -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {875.0, 875.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower_bounds = {0.0, 0.0, 0.0};
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-
-  // Set objective coefficients (minimize -86*y1 -4*y2 -40*y3)
-  std::vector<double> objective_coefficients = {-86.0, -4.0, -40.0};
-  problem.set_objective_coefficients(objective_coefficients);
-
-  // Set variable types
-  std::vector<char> variable_types = {'I', 'I', 'I'};
-  problem.set_variable_types(variable_types);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -86 y1 - 4 y2 - 40 y3
+Subject To
+  c1: 774 y1 + 76 y2 + 42 y3 <= 875
+  c2: 67 y1 + 27 y2 + 53 y3 <= 875
+Binaries
+  y1
+  y2
+  y3
+End
+)LP");
 }
 
 TEST(cuts, test_cuts_2)
@@ -1411,35 +1332,29 @@ TEST(cuts, clique_neos8_phase4_lp_infeasibility_binary_search)
 // but violates the generated c-MIR flow-cover cut. This is a reduced version of a
 // standard flow-cover example; the test checks validity instead of exact coefficients
 // because the approximate single-node-flow selection may choose a different valid cut.
+// Index layout (x0,x1,x2,y0,y1,y2 → 0..5) is load-bearing — downstream test
+// helpers index into the primal via point[j] for binaries and point[3+j] for
+// flows. Keep the variable order matching that layout.
 io::mps_data_model_t<int, double> create_small_single_node_flow_problem()
 {
-  io::mps_data_model_t<int, double> problem;
-
-  std::vector<int> offsets         = {0, 3, 5, 7, 9};
-  std::vector<int> indices         = {3, 4, 5, 0, 3, 1, 4, 2, 5};
-  std::vector<double> coefficients = {1.0, 1.0, -1.0, -3.0, 1.0, -6.0, 1.0, -3.0, 1.0};
-  problem.set_csr_constraint_matrix(std::span<const double>{coefficients},
-                                    std::span<const int>{indices},
-                                    std::span<const int>{offsets});
-
-  std::vector<double> lower_bounds(4, -std::numeric_limits<double>::infinity());
-  std::vector<double> upper_bounds = {4.0, 0.0, 0.0, 0.0};
-  problem.set_constraint_lower_bounds(std::span<const double>{lower_bounds});
-  problem.set_constraint_upper_bounds(std::span<const double>{upper_bounds});
-
-  std::vector<double> var_lower_bounds(6, 0.0);
-  std::vector<double> var_upper_bounds = {1.0, 1.0, 1.0, 3.0, 6.0, 3.0};
-  problem.set_variable_lower_bounds(std::span<const double>{var_lower_bounds});
-  problem.set_variable_upper_bounds(std::span<const double>{var_upper_bounds});
-
-  std::vector<double> objective_coefficients(6, 0.0);
-  problem.set_objective_coefficients(std::span<const double>{objective_coefficients});
-
-  std::vector<char> variable_types = {'I', 'I', 'I', 'C', 'C', 'C'};
-  problem.set_variable_types(variable_types);
-
-  problem.set_maximize(false);
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 0 x0 + 0 x1 + 0 x2 + 0 y0 + 0 y1 + 0 y2
+Subject To
+  c1: y0 + y1 - y2 <= 4
+  c2: -3 x0 + y0 <= 0
+  c3: -6 x1 + y1 <= 0
+  c4: -3 x2 + y2 <= 0
+Bounds
+  0 <= y0 <= 3
+  0 <= y1 <= 6
+  0 <= y2 <= 3
+Binaries
+  x0
+  x1
+  x2
+End
+)LP");
 }
 
 struct flow_cover_test_problem_t {

--- a/cpp/tests/mip/cuts_test.cu
+++ b/cpp/tests/mip/cuts_test.cu
@@ -45,8 +45,7 @@ namespace {
 
 constexpr double kCliqueTestTol = 1e-6;
 
-// Maximize x0 + x1 + x2 via minimizing -x0 - x1 - x2, with pairwise binary
-// conflicts forming a triangle.
+// Pairwise binary conflicts forming a triangle.
 io::mps_data_model_t<int, double> create_pairwise_triangle_set_packing_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -121,9 +120,7 @@ End
 )LP");
 }
 
-// One weighted binary knapsack row:
-//   1*x0 + 2*x1 + 3*x2 + 4*x3 <= 5
-// This creates base clique {x2, x3} and additional clique inducing conflict {x1, x3}.
+// Creates base clique {x2, x3} and additional clique inducing conflict {x1, x3}.
 io::mps_data_model_t<int, double> create_weighted_addtl_conflict_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -771,11 +768,6 @@ std::optional<size_t> isolate_first_lp_infeasible_literal_cut_by_bisection(
 
 }  // namespace
 
-// minimize -7*x1 -2*x2
-// subject to -x1 + 2*x2 <= 4
-//            5*x1 +  x2 <= 20
-//           -2*x1 - 2*x2 <= -7
-// x1, x2 integer in [0, 10]
 io::mps_data_model_t<int, double> create_cuts_problem_1()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -816,10 +808,6 @@ TEST(cuts, test_cuts_1)
   EXPECT_LE(solution.get_num_nodes(), 2);
 }
 
-// minimize -86*y1 -4*y2 -40*y3
-// subject to 774*y1 + 76*y2 + 42*y3 <= 875
-//             67*y1 + 27*y2 + 53*y3 <= 875
-//             y1, y2, y3 binary
 io::mps_data_model_t<int, double> create_cuts_problem_2()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(

--- a/cpp/tests/mip/doc_example_test.cu
+++ b/cpp/tests/mip/doc_example_test.cu
@@ -11,61 +11,33 @@
 #include <cuopt/linear_programming/io/parser.hpp>
 #include <cuopt/linear_programming/solve.hpp>
 #include <utilities/common_utils.hpp>
-#include <utilities/error.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
 #include <filesystem>
-#include <sstream>
-#include <string>
-#include <vector>
 
 namespace cuopt::linear_programming::test {
 
-// Problem data for the mixed integer linear programming example from documentation
+// Mixed integer linear programming example from documentation:
+//   maximize  5x + 3y
+//   s.t.      2x + 4y >= 230
+//             3x + 2y <= 190
+//             x integer, y continuous, x, y >= 0
 io::mps_data_model_t<int, double> create_doc_example_problem()
 {
-  // Create problem instance
-  io::mps_data_model_t<int, double> problem;
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 2, 4};
-  std::vector<int> indices         = {0, 1, 0, 1};
-  std::vector<double> coefficients = {2.0, 4.0, 3.0, 2.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {230.0, -std::numeric_limits<double>::infinity()};
-  std::vector<double> upper_bounds = {std::numeric_limits<double>::infinity(), 190.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower_bounds = {0.0, 0.0};
-  std::vector<double> var_upper_bounds = {std::numeric_limits<double>::infinity(),
-                                          std::numeric_limits<double>::infinity()};
-  problem.set_variable_lower_bounds(var_lower_bounds);
-  problem.set_variable_upper_bounds(var_upper_bounds);
-
-  // Set objective coefficients (maximize 5x + 3y)
-  std::vector<double> objective_coefficients = {5.0, 3.0};
-  problem.set_objective_coefficients(objective_coefficients);
-
-  // Set variable types (x is integer, y is continuous)
-  std::vector<char> variable_types = {'I', 'C'};  // 'I' for Integer, 'C' for Continuous
-  problem.set_variable_types(variable_types);
-
-  // Set to maximize
-  problem.set_maximize(true);
-
-  // Optional: Set variable names for better debugging
-  problem.set_variable_names({"x", "y"});
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Maximize
+  obj: 5 x + 3 y
+Subject To
+  c1: 2 x + 4 y >= 230
+  c2: 3 x + 2 y <= 190
+Generals
+  x
+End
+)LP");
 }
 
 struct result_map_t {

--- a/cpp/tests/mip/doc_example_test.cu
+++ b/cpp/tests/mip/doc_example_test.cu
@@ -23,7 +23,7 @@ namespace cuopt::linear_programming::test {
 
 io::mps_data_model_t<int, double> create_doc_example_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Maximize
   obj: 5 x + 3 y
 Subject To

--- a/cpp/tests/mip/doc_example_test.cu
+++ b/cpp/tests/mip/doc_example_test.cu
@@ -21,11 +21,6 @@
 
 namespace cuopt::linear_programming::test {
 
-// Mixed integer linear programming example from documentation:
-//   maximize  5x + 3y
-//   s.t.      2x + 4y >= 230
-//             3x + 2y <= 190
-//             x integer, y continuous, x, y >= 0
 io::mps_data_model_t<int, double> create_doc_example_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(

--- a/cpp/tests/mip/semi_continuous_test.cu
+++ b/cpp/tests/mip/semi_continuous_test.cu
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <sstream>
+#include <format>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,19 +38,20 @@ optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle
                                                     double aux_lb  = 0.0,
                                                     double aux_ub  = 1.0)
 {
-  std::ostringstream lp;
-  lp << "Minimize\n"
-     << "  obj: x\n"
-     << "Subject To\n"
-     << "  c1: x + y = " << row_rhs << "\n"
-     << "Bounds\n"
-     << "  " << sc_lb << " <= x <= " << sc_ub << "\n"
-     << "  " << aux_lb << " <= y <= " << aux_ub << "\n"
-     << "Semi-Continuous\n"
-     << "  x\n"
-     << "End\n";
+  auto lp = std::format(
+    "Minimize\n"
+    "  obj: x\n"
+    "Subject To\n"
+    "  c1: x + y = {}\n"
+    "Bounds\n"
+    "  {} <= x <= {}\n"
+    "  {} <= y <= {}\n"
+    "Semi-Continuous\n"
+    "  x\n"
+    "End\n",
+    row_rhs, sc_lb, sc_ub, aux_lb, aux_ub);
 
-  auto data = cuopt::test::inline_lp::parse_inline_lp(lp.str());
+  auto data = cuopt::test::inline_lp::parse_inline_lp(lp);
   return mps_data_model_to_optimization_problem(handle, data);
 }
 

--- a/cpp/tests/mip/semi_continuous_test.cu
+++ b/cpp/tests/mip/semi_continuous_test.cu
@@ -7,19 +7,17 @@
 
 #include "cuopt/linear_programming/mip/solver_settings.hpp"
 
+#include "../utilities/inline_lp_test_utils.hpp"
 #include "../utilities/inline_mps_test_utils.hpp"
 
-#include <cuopt/linear_programming/io/parser.hpp>
 #include <cuopt/linear_programming/solve.hpp>
 #include <utilities/copy_helpers.hpp>
-#include <utilities/error.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
 
-#include <stdexcept>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -33,6 +31,8 @@ struct sc_result_t {
   double sc_value;
 };
 
+// Parameterized SC test problem: minimize x s.t. x + y = row_rhs, with x
+// semi-continuous on [sc_lb, sc_ub] and y continuous on [aux_lb, aux_ub].
 optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle,
                                                     double sc_lb,
                                                     double sc_ub,
@@ -40,32 +40,20 @@ optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle
                                                     double aux_lb  = 0.0,
                                                     double aux_ub  = 1.0)
 {
-  optimization_problem_t<int, double> problem(handle);
+  std::ostringstream lp;
+  lp << "Minimize\n"
+     << "  obj: x\n"
+     << "Subject To\n"
+     << "  c1: x + y = " << row_rhs << "\n"
+     << "Bounds\n"
+     << "  " << sc_lb << " <= x <= " << sc_ub << "\n"
+     << "  " << aux_lb << " <= y <= " << aux_ub << "\n"
+     << "Semi-Continuous\n"
+     << "  x\n"
+     << "End\n";
 
-  const std::vector<double> coefficients = {1.0, 1.0};
-  const std::vector<int> indices         = {0, 1};
-  const std::vector<int> offsets         = {0, 2};
-  const std::vector<double> row_lower    = {row_rhs};
-  const std::vector<double> row_upper    = {row_rhs};
-  const std::vector<double> obj          = {1.0, 0.0};
-  const std::vector<double> var_lower    = {sc_lb, aux_lb};
-  const std::vector<double> var_upper    = {sc_ub, aux_ub};
-  const std::vector<var_t> var_types     = {var_t::SEMI_CONTINUOUS, var_t::CONTINUOUS};
-
-  problem.set_csr_constraint_matrix(coefficients.data(),
-                                    coefficients.size(),
-                                    indices.data(),
-                                    indices.size(),
-                                    offsets.data(),
-                                    offsets.size());
-  problem.set_constraint_lower_bounds(row_lower.data(), row_lower.size());
-  problem.set_constraint_upper_bounds(row_upper.data(), row_upper.size());
-  problem.set_objective_coefficients(obj.data(), obj.size());
-  problem.set_variable_lower_bounds(var_lower.data(), var_lower.size());
-  problem.set_variable_upper_bounds(var_upper.data(), var_upper.size());
-  problem.set_variable_types(var_types.data(), var_types.size());
-
-  return problem;
+  auto data = cuopt::test::inline_lp::parse_inline_lp(lp.str());
+  return mps_data_model_to_optimization_problem(handle, data);
 }
 
 TEST(mip_solve, semi_continuous_regressions)

--- a/cpp/tests/mip/semi_continuous_test.cu
+++ b/cpp/tests/mip/semi_continuous_test.cu
@@ -31,8 +31,6 @@ struct sc_result_t {
   double sc_value;
 };
 
-// Parameterized SC test problem: minimize x s.t. x + y = row_rhs, with x
-// semi-continuous on [sc_lb, sc_ub] and y continuous on [aux_lb, aux_ub].
 optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle,
                                                     double sc_lb,
                                                     double sc_ub,

--- a/cpp/tests/mip/semi_continuous_test.cu
+++ b/cpp/tests/mip/semi_continuous_test.cu
@@ -49,7 +49,11 @@ optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle
     "Semi-Continuous\n"
     "  x\n"
     "End\n",
-    row_rhs, sc_lb, sc_ub, aux_lb, aux_ub);
+    row_rhs,
+    sc_lb,
+    sc_ub,
+    aux_lb,
+    aux_ub);
 
   auto data = cuopt::test::parse_inline_lp(lp);
   return mps_data_model_to_optimization_problem(handle, data);

--- a/cpp/tests/mip/semi_continuous_test.cu
+++ b/cpp/tests/mip/semi_continuous_test.cu
@@ -51,7 +51,7 @@ optimization_problem_t<int, double> make_sc_problem(raft::handle_t const* handle
     "End\n",
     row_rhs, sc_lb, sc_ub, aux_lb, aux_ub);
 
-  auto data = cuopt::test::inline_lp::parse_inline_lp(lp);
+  auto data = cuopt::test::parse_inline_lp(lp);
   return mps_data_model_to_optimization_problem(handle, data);
 }
 

--- a/cpp/tests/mip/server_test.cu
+++ b/cpp/tests/mip/server_test.cu
@@ -8,64 +8,39 @@
 #include "../linear_programming/utilities/pdlp_test_utilities.cuh"
 #include "mip_utils.cuh"
 
-#include <cuopt/linear_programming/io/parser.hpp>
 #include <cuopt/linear_programming/solve.hpp>
 #include <utilities/common_utils.hpp>
-#include <utilities/error.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
-#include <sstream>
-#include <string>
-#include <vector>
-
 namespace cuopt::linear_programming::test {
 
-// Create standard LP test problem matching Python test
+// Standard LP test problem matching the Python test.
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
-  io::mps_data_model_t<int, double> problem;
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 2};
-  std::vector<int> indices         = {0, 1};
-  std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {0.0};
-  std::vector<double> upper_bounds = {5000.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower = {0.0, 0.0};
-  std::vector<double> var_upper = {3000.0, 5000.0};
-  problem.set_variable_lower_bounds(var_lower);
-  problem.set_variable_upper_bounds(var_upper);
-
-  // Set objective coefficients
-  std::vector<double> obj_coeffs = {1.2, 1.7};
-  problem.set_objective_coefficients(obj_coeffs);
-  problem.set_maximize(false);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 1.2 x1 + 1.7 x2
+Subject To
+  c1_ub: x1 + x2 <= 5000
+  c1_lb: x1 + x2 >= 0
+Bounds
+  0 <= x1 <= 3000
+  0 <= x2 <= 5000
+End
+)LP");
 }
 
-// Create standard MILP test problem matching Python test
+// Standard MILP test problem matching the Python test (x1 integer, x2 continuous).
 io::mps_data_model_t<int, double> create_std_milp_problem(bool maximize)
 {
   auto problem = create_std_lp_problem();
-
-  // Set variable types for MILP
+  problem.set_maximize(maximize);
   std::vector<char> var_types = {'I', 'C'};
   problem.set_variable_types(var_types);
-  problem.set_maximize(maximize);
-
   return problem;
 }
 

--- a/cpp/tests/mip/server_test.cu
+++ b/cpp/tests/mip/server_test.cu
@@ -20,7 +20,7 @@ namespace cuopt::linear_programming::test {
 
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 1.2 x1 + 1.7 x2
 Subject To

--- a/cpp/tests/mip/server_test.cu
+++ b/cpp/tests/mip/server_test.cu
@@ -18,7 +18,6 @@
 
 namespace cuopt::linear_programming::test {
 
-// Standard LP test problem matching the Python test.
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -34,7 +33,6 @@ End
 )LP");
 }
 
-// Standard MILP test problem matching the Python test (x1 integer, x2 continuous).
 io::mps_data_model_t<int, double> create_std_milp_problem(bool maximize)
 {
   auto problem = create_std_lp_problem();

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -14,104 +14,61 @@
 #include <pdlp/utilities/problem_checking.cuh>
 #include <utilities/common_utils.hpp>
 #include <utilities/copy_helpers.hpp>
-#include <utilities/error.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
-#include <sstream>
-#include <string>
-#include <vector>
-
 namespace cuopt::linear_programming::test {
 
-// Create standard LP test problem matching Python test
+// Standard LP test problem matching the Python test.
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
-  io::mps_data_model_t<int, double> problem;
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 2};
-  std::vector<int> indices         = {0, 1};
-  std::vector<double> coefficients = {1.0, 1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {0.0};
-  std::vector<double> upper_bounds = {5000.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower = {0.0, 0.0};
-  std::vector<double> var_upper = {3000.0, 5000.0};
-  problem.set_variable_lower_bounds(var_lower);
-  problem.set_variable_upper_bounds(var_upper);
-
-  // Set objective coefficients
-  std::vector<double> obj_coeffs = {1.2, 1.7};
-  problem.set_objective_coefficients(obj_coeffs);
-  problem.set_maximize(false);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: 1.2 x1 + 1.7 x2
+Subject To
+  c1_ub: x1 + x2 <= 5000
+  c1_lb: x1 + x2 >= 0
+Bounds
+  0 <= x1 <= 3000
+  0 <= x2 <= 5000
+End
+)LP");
 }
 
+// Degenerate single-variable LP with x fixed at 0.
 io::mps_data_model_t<int, double> create_single_var_lp_problem()
 {
-  io::mps_data_model_t<int, double> problem;
-
-  // Set up constraint matrix in CSR format
-  std::vector<int> offsets         = {0, 1};
-  std::vector<int> indices         = {0};
-  std::vector<double> coefficients = {1.0};
-  problem.set_csr_constraint_matrix(coefficients, indices, offsets);
-
-  // Set constraint bounds
-  std::vector<double> lower_bounds = {0.0};
-  std::vector<double> upper_bounds = {0.0};
-  problem.set_constraint_lower_bounds(lower_bounds);
-  problem.set_constraint_upper_bounds(upper_bounds);
-
-  // Set variable bounds
-  std::vector<double> var_lower = {0.0};
-  std::vector<double> var_upper = {0.0};
-  problem.set_variable_lower_bounds(var_lower);
-  problem.set_variable_upper_bounds(var_upper);
-
-  // Set objective coefficients
-  std::vector<double> obj_coeffs = {-0.23};
-  problem.set_objective_coefficients(obj_coeffs);
-  problem.set_maximize(false);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -0.23 x
+Subject To
+  c1: x = 0
+Bounds
+  x = 0
+End
+)LP");
 }
 
-// Create standard MILP test problem matching Python test
+// Standard MILP test problem (x1 integer, x2 continuous).
 io::mps_data_model_t<int, double> create_std_milp_problem(bool maximize)
 {
   auto problem = create_std_lp_problem();
-
-  // Set variable types for MILP
+  problem.set_maximize(maximize);
   std::vector<char> var_types = {'I', 'C'};
   problem.set_variable_types(var_types);
-  problem.set_maximize(maximize);
-
   return problem;
 }
 
-// Create standard MILP test problem matching Python test
+// Single-variable MILP wrapping create_single_var_lp_problem.
 io::mps_data_model_t<int, double> create_single_var_milp_problem(bool maximize)
 {
   auto problem = create_single_var_lp_problem();
-
-  // Set variable types for MILP
+  problem.set_maximize(maximize);
   std::vector<char> var_types = {'I'};
   problem.set_variable_types(var_types);
-  problem.set_maximize(maximize);
-
   return problem;
 }
 
@@ -119,40 +76,17 @@ TEST(LPTest, TestSampleLP2)
 {
   raft::handle_t handle;
 
-  // Construct a simple LP problem:
-  // Minimize:    x
-  // Subject to:  x <= 1
-  //              x <= 1
-  //              x >= 0
+  // Minimize x s.t. x <= 1, x <= 1, x >= 0. Two identical row constraints
+  // exercise duplicate-row handling.
+  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: x
+Subject To
+  c1: x <= 1
+  c2: x <= 1
+End
+)LP");
 
-  // One variable, two constraints (both x <= 1)
-  std::vector<double> A_values = {1.0, 1.0};
-  std::vector<int> A_indices   = {0, 0};
-  std::vector<int> A_offsets   = {0, 1, 2};  // CSR: 2 constraints, 1 variable
-
-  std::vector<double> b       = {1.0, 1.0};  // RHS for both constraints
-  std::vector<double> b_lower = {-std::numeric_limits<double>::infinity(),
-                                 -std::numeric_limits<double>::infinity()};
-
-  std::vector<double> c = {1.0};  // Objective: Minimize x
-
-  std::vector<char> row_types = {'L', 'L'};  // Both constraints are <=
-
-  // Build the problem
-  io::mps_data_model_t<int, double> problem;
-  problem.set_csr_constraint_matrix(A_values, A_indices, A_offsets);
-  problem.set_constraint_upper_bounds(b);
-  problem.set_constraint_lower_bounds(b_lower);
-
-  // Set variable bounds (x >= 0)
-  std::vector<double> var_lower = {0.0};
-  std::vector<double> var_upper = {std::numeric_limits<double>::infinity()};
-  problem.set_variable_lower_bounds(var_lower);
-  problem.set_variable_upper_bounds(var_upper);
-
-  problem.set_objective_coefficients(c);
-  problem.set_maximize(false);
-  // Set up solver settings
   cuopt::linear_programming::pdlp_solver_settings_t<int, double> settings{};
   settings.set_optimality_tolerance(1e-2);
   settings.method     = cuopt::linear_programming::method_t::PDLP;
@@ -282,45 +216,32 @@ INSTANTIATE_TEST_SUITE_P(
 // Scaling integrality preservation test
 // ---------------------------------------------------------------------------
 
+// 6 rows × 4 vars (x0=INT, x1=INT, x2=INT, x3=CONT). The coefficient spread
+// (~log2(100000/1) ≈ 17) exceeds the scaler's 12-threshold so the scaling
+// path is exercised; row 4 omits x3 so the integer-only row stays integer.
 static io::mps_data_model_t<int, double> create_wide_spread_milp()
 {
-  io::mps_data_model_t<int, double> problem;
-
-  // 6 rows, 4 variables (x0=INT, x1=INT, x2=INT, x3=CONT)
-  // Coefficient spread: ~log2(100000/1) ≈ 17, well above the 12-threshold.
-  // clang-format off
-  std::vector<double> values = {
-    3.0, 7.0, 2.0, 1.5,          // row 0: small ints + cont
-    100000.0, 50000.0, 25000.0, 999.9, // row 1: large ints + cont
-    5.0, 11.0, 13.0, 0.3,        // row 2: small primes + cont
-    60000.0, 30000.0, 9000.0, 42.42,   // row 3: large + cont
-    1.0, 1.0, 1.0, 0.0,          // row 4: unit row (no cont)
-    8.0, 4.0, 6.0, 3.14          // row 5: small ints + cont
-  };
-  // clang-format on
-  std::vector<int> indices = {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
-                              0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3};
-  std::vector<int> offsets = {0, 4, 8, 12, 16, 20, 24};
-  problem.set_csr_constraint_matrix(values, indices, offsets);
-
-  std::vector<double> cl = {0, 0, 0, 0, 0, 0};
-  std::vector<double> cu = {1e6, 1e8, 1e4, 1e8, 100, 1e4};
-  problem.set_constraint_lower_bounds(cl);
-  problem.set_constraint_upper_bounds(cu);
-
-  std::vector<double> vl = {0, 0, 0, 0};
-  std::vector<double> vu = {1000, 1000, 1000, 1e6};
-  problem.set_variable_lower_bounds(vl);
-  problem.set_variable_upper_bounds(vu);
-
-  std::vector<double> obj = {1.0, 2.0, 3.0, 0.5};
-  problem.set_objective_coefficients(obj);
-  problem.set_maximize(false);
-
-  std::vector<char> var_types = {'I', 'I', 'I', 'C'};
-  problem.set_variable_types(var_types);
-
-  return problem;
+  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: x0 + 2 x1 + 3 x2 + 0.5 x3
+Subject To
+  c0: 3 x0 + 7 x1 + 2 x2 + 1.5 x3 <= 1e6
+  c1: 100000 x0 + 50000 x1 + 25000 x2 + 999.9 x3 <= 1e8
+  c2: 5 x0 + 11 x1 + 13 x2 + 0.3 x3 <= 1e4
+  c3: 60000 x0 + 30000 x1 + 9000 x2 + 42.42 x3 <= 1e8
+  c4: x0 + x1 + x2 <= 100
+  c5: 8 x0 + 4 x1 + 6 x2 + 3.14 x3 <= 1e4
+Bounds
+  0 <= x0 <= 1000
+  0 <= x1 <= 1000
+  0 <= x2 <= 1000
+  0 <= x3 <= 1e6
+Generals
+  x0
+  x1
+  x2
+End
+)LP");
 }
 
 TEST(ScalingIntegrity, IntegerCoefficientsPreservedAfterScaling)

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -24,7 +24,7 @@ namespace cuopt::linear_programming::test {
 
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: 1.2 x1 + 1.7 x2
 Subject To
@@ -39,7 +39,7 @@ End
 
 io::mps_data_model_t<int, double> create_single_var_lp_problem()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -0.23 x
 Subject To
@@ -73,7 +73,7 @@ TEST(LPTest, TestSampleLP2)
   raft::handle_t handle;
 
   // Two identical row constraints exercise duplicate-row handling.
-  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto problem = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: x
 Subject To
@@ -216,7 +216,7 @@ INSTANTIATE_TEST_SUITE_P(
 // stays integer.
 static io::mps_data_model_t<int, double> create_wide_spread_milp()
 {
-  return cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  return cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: x0 + 2 x1 + 3 x2 + 0.5 x3
 Subject To

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -22,7 +22,6 @@
 
 namespace cuopt::linear_programming::test {
 
-// Standard LP test problem matching the Python test.
 io::mps_data_model_t<int, double> create_std_lp_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -38,7 +37,6 @@ End
 )LP");
 }
 
-// Degenerate single-variable LP with x fixed at 0.
 io::mps_data_model_t<int, double> create_single_var_lp_problem()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(
@@ -52,7 +50,6 @@ End
 )LP");
 }
 
-// Standard MILP test problem (x1 integer, x2 continuous).
 io::mps_data_model_t<int, double> create_std_milp_problem(bool maximize)
 {
   auto problem = create_std_lp_problem();
@@ -62,7 +59,6 @@ io::mps_data_model_t<int, double> create_std_milp_problem(bool maximize)
   return problem;
 }
 
-// Single-variable MILP wrapping create_single_var_lp_problem.
 io::mps_data_model_t<int, double> create_single_var_milp_problem(bool maximize)
 {
   auto problem = create_single_var_lp_problem();
@@ -76,8 +72,7 @@ TEST(LPTest, TestSampleLP2)
 {
   raft::handle_t handle;
 
-  // Minimize x s.t. x <= 1, x <= 1, x >= 0. Two identical row constraints
-  // exercise duplicate-row handling.
+  // Two identical row constraints exercise duplicate-row handling.
   auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: x
@@ -216,9 +211,9 @@ INSTANTIATE_TEST_SUITE_P(
 // Scaling integrality preservation test
 // ---------------------------------------------------------------------------
 
-// 6 rows × 4 vars (x0=INT, x1=INT, x2=INT, x3=CONT). The coefficient spread
-// (~log2(100000/1) ≈ 17) exceeds the scaler's 12-threshold so the scaling
-// path is exercised; row 4 omits x3 so the integer-only row stays integer.
+// Coefficient spread (~log2(100000/1) ≈ 17) exceeds the scaler's 12-threshold
+// so the scaling path is exercised; row 4 omits x3 so the integer-only row
+// stays integer.
 static io::mps_data_model_t<int, double> create_wide_spread_milp()
 {
   return cuopt::test::inline_lp::parse_inline_lp(R"LP(

--- a/cpp/tests/qp/unit_tests/no_constraints.cu
+++ b/cpp/tests/qp/unit_tests/no_constraints.cu
@@ -20,7 +20,7 @@ TEST(no_constraints_test, simple_test)
 {
   raft::handle_t handle;
 
-  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto problem = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: [ 2 x1 ^ 2 + 2 x2 ^ 2 ] / 2
 Bounds

--- a/cpp/tests/qp/unit_tests/no_constraints.cu
+++ b/cpp/tests/qp/unit_tests/no_constraints.cu
@@ -4,23 +4,15 @@
  */
 
 #include <utilities/common_utils.hpp>
+#include <utilities/copy_helpers.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
-#include <cuopt/linear_programming/io/parser.hpp>
-#include <cuopt/linear_programming/optimization_problem.hpp>
 #include <cuopt/linear_programming/pdlp/solver_settings.hpp>
 #include <cuopt/linear_programming/solve.hpp>
-#include <mip_heuristics/problem/problem.cuh>
-#include <utilities/error.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
-
-#include <cstdint>
-#include <sstream>
-#include <string>
-#include <vector>
 
 namespace cuopt::linear_programming {
 
@@ -28,40 +20,25 @@ TEST(no_constraints_test, simple_test)
 {
   raft::handle_t handle;
 
-  // optimize: x1^2 + x2^2
-  // Constraints set through row types
-  auto op_problem = optimization_problem_t<int, double>(&handle);
+  // Minimize x1^2 + x2^2 over R^2; optimum at (0, 0) with value 0.
+  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: [ 2 x1 ^ 2 + 2 x2 ^ 2 ] / 2
+Bounds
+  x1 free
+  x2 free
+End
+)LP");
 
-  double A_values_host[] = {};
-  int A_indices_host[]   = {};
-  int A_offsets_host[]   = {0};
-  op_problem.set_csr_constraint_matrix(A_values_host, 0, A_indices_host, 0, A_offsets_host, 1);
+  auto settings = pdlp_solver_settings_t<int, double>();
+  auto solution = solve_lp(&handle, problem, settings);
 
-  double lb_host[] = {-std::numeric_limits<double>::infinity(),
-                      -std::numeric_limits<double>::infinity()};
-  double ub_host[] = {std::numeric_limits<double>::infinity(),
-                      std::numeric_limits<double>::infinity()};
-  op_problem.set_variable_lower_bounds(lb_host, 2);
-  op_problem.set_variable_upper_bounds(ub_host, 2);
-
-  double c_host[] = {0.0, 0.0};
-  op_problem.set_objective_coefficients(c_host, 2);
-
-  double Q_values_host[] = {1.0, 1.0};
-  int Q_indices_host[]   = {0, 1};
-  int Q_offsets_host[]   = {0, 1, 2};
-  op_problem.set_quadratic_objective_matrix(Q_values_host, 2, Q_indices_host, 2, Q_offsets_host, 3);
-
-  auto settings = cuopt::linear_programming::pdlp_solver_settings_t<int, double>();
-  auto solution = cuopt::linear_programming::solve_lp(op_problem, settings);
-
-  EXPECT_EQ(solution.get_termination_status(),
-            cuopt::linear_programming::pdlp_termination_status_t::Optimal);
+  EXPECT_EQ(solution.get_termination_status(), pdlp_termination_status_t::Optimal);
   EXPECT_NEAR(solution.get_objective_value(), 0.0, 1e-6);
 
   auto sol_vec = cuopt::host_copy(solution.get_primal_solution(), handle.get_stream());
-
   EXPECT_NEAR(sol_vec[0], 0.0, 1e-6);
   EXPECT_NEAR(sol_vec[1], 0.0, 1e-6);
 }
+
 }  // namespace cuopt::linear_programming

--- a/cpp/tests/qp/unit_tests/no_constraints.cu
+++ b/cpp/tests/qp/unit_tests/no_constraints.cu
@@ -20,7 +20,6 @@ TEST(no_constraints_test, simple_test)
 {
   raft::handle_t handle;
 
-  // Minimize x1^2 + x2^2 over R^2; optimum at (0, 0) with value 0.
   auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: [ 2 x1 ^ 2 + 2 x2 ^ 2 ] / 2

--- a/cpp/tests/qp/unit_tests/two_variable_test.cu
+++ b/cpp/tests/qp/unit_tests/two_variable_test.cu
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights
  * reserved. SPDX-License-Identifier: Apache-2.0
  */
+/* clang-format on */
 
 #include <utilities/common_utils.hpp>
 #include <utilities/copy_helpers.hpp>

--- a/cpp/tests/qp/unit_tests/two_variable_test.cu
+++ b/cpp/tests/qp/unit_tests/two_variable_test.cu
@@ -20,8 +20,7 @@ TEST(two_variable_test, simple_test)
 {
   raft::handle_t handle;
 
-  // Minimize x1^2 + 4 x2^2 - 8 x1 - 16 x2 s.t. x1 + x2 >= 5, 0 <= xi <= 10.
-  // Unconstrained optimum (4, 2) satisfies the constraint with slack; obj = -32.
+  // Unconstrained optimum (4, 2) satisfies the constraint with slack.
   auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
 Minimize
   obj: -8 x1 - 16 x2 + [ 2 x1 ^ 2 + 8 x2 ^ 2 ] / 2

--- a/cpp/tests/qp/unit_tests/two_variable_test.cu
+++ b/cpp/tests/qp/unit_tests/two_variable_test.cu
@@ -2,26 +2,17 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights
  * reserved. SPDX-License-Identifier: Apache-2.0
  */
-/* clang-format on */
 
 #include <utilities/common_utils.hpp>
+#include <utilities/copy_helpers.hpp>
+#include <utilities/inline_lp_test_utils.hpp>
 
-#include <cuopt/linear_programming/io/parser.hpp>
-#include <cuopt/linear_programming/optimization_problem.hpp>
 #include <cuopt/linear_programming/pdlp/solver_settings.hpp>
 #include <cuopt/linear_programming/solve.hpp>
-#include <mip_heuristics/problem/problem.cuh>
-#include <utilities/error.hpp>
 
 #include <raft/core/handle.hpp>
-#include <raft/util/cudart_utils.hpp>
 
 #include <gtest/gtest.h>
-
-#include <cstdint>
-#include <sstream>
-#include <string>
-#include <vector>
 
 namespace cuopt::linear_programming {
 
@@ -29,44 +20,28 @@ TEST(two_variable_test, simple_test)
 {
   raft::handle_t handle;
 
-  // optimize: -8x1 - 16x2 + x1^2 + 4x1x2 + x2^2
+  // Minimize x1^2 + 4 x2^2 - 8 x1 - 16 x2 s.t. x1 + x2 >= 5, 0 <= xi <= 10.
+  // Unconstrained optimum (4, 2) satisfies the constraint with slack; obj = -32.
+  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+Minimize
+  obj: -8 x1 - 16 x2 + [ 2 x1 ^ 2 + 8 x2 ^ 2 ] / 2
+Subject To
+  c1: x1 + x2 >= 5
+Bounds
+  0 <= x1 <= 10
+  0 <= x2 <= 10
+End
+)LP");
 
-  // Constraints set through row types
-  auto op_problem    = optimization_problem_t<int, double>(&handle);
-  double A_host[]    = {1.0, 1.0};
-  int indices_host[] = {0, 1};
-  int offset_host[]  = {0, 2};
+  auto settings = pdlp_solver_settings_t<int, double>();
+  auto solution = solve_lp(&handle, problem, settings);
 
-  op_problem.set_csr_constraint_matrix(A_host, 2, indices_host, 2, offset_host, 2);
-
-  double cnstr_lb_host[] = {5.0};
-  // double cnstr_ub_host[] = {1000.0};
-  double cnstr_ub_host[] = {std::numeric_limits<double>::infinity()};
-  op_problem.set_constraint_lower_bounds(cnstr_lb_host, 1);
-  op_problem.set_constraint_upper_bounds(cnstr_ub_host, 1);
-
-  double lb_host[] = {0.0, 0.0};
-  double ub_host[] = {10.0, 10.0};
-  op_problem.set_variable_lower_bounds(lb_host, 2);
-  op_problem.set_variable_upper_bounds(ub_host, 2);
-
-  double c_host[] = {-8.0, -16.0};
-  op_problem.set_objective_coefficients(c_host, 2);
-
-  double Q_values_host[] = {1.0, 4.0};
-  int Q_indices_host[]   = {0, 1};
-  int Q_offsets_host[]   = {0, 1, 2};
-  op_problem.set_quadratic_objective_matrix(Q_values_host, 2, Q_indices_host, 2, Q_offsets_host, 3);
-
-  auto settings = cuopt::linear_programming::pdlp_solver_settings_t<int, double>();
-  auto solution = cuopt::linear_programming::solve_lp(op_problem, settings);
-
-  EXPECT_EQ(solution.get_termination_status(),
-            cuopt::linear_programming::pdlp_termination_status_t::Optimal);
+  EXPECT_EQ(solution.get_termination_status(), pdlp_termination_status_t::Optimal);
   EXPECT_NEAR(solution.get_objective_value(), -32.0, 1e-6);
 
   auto sol_vec = cuopt::host_copy(solution.get_primal_solution(), handle.get_stream());
   EXPECT_NEAR(sol_vec[0], 4.0, 1e-6);
   EXPECT_NEAR(sol_vec[1], 2.0, 1e-6);
 }
+
 }  // namespace cuopt::linear_programming

--- a/cpp/tests/qp/unit_tests/two_variable_test.cu
+++ b/cpp/tests/qp/unit_tests/two_variable_test.cu
@@ -22,7 +22,7 @@ TEST(two_variable_test, simple_test)
   raft::handle_t handle;
 
   // Unconstrained optimum (4, 2) satisfies the constraint with slack.
-  auto problem = cuopt::test::inline_lp::parse_inline_lp(R"LP(
+  auto problem = cuopt::test::parse_inline_lp(R"LP(
 Minimize
   obj: -8 x1 - 16 x2 + [ 2 x1 ^ 2 + 8 x2 ^ 2 ] / 2
 Subject To

--- a/cpp/tests/utilities/inline_lp_test_utils.hpp
+++ b/cpp/tests/utilities/inline_lp_test_utils.hpp
@@ -1,0 +1,22 @@
+/* clang-format off */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* clang-format on */
+
+#pragma once
+
+#include <cuopt/linear_programming/io/parser.hpp>
+
+#include <string_view>
+
+namespace cuopt::test::inline_lp {
+
+inline cuopt::linear_programming::io::mps_data_model_t<int, double> parse_inline_lp(
+  std::string_view lp_text)
+{
+  return cuopt::linear_programming::io::read_lp_from_string<int, double>(lp_text);
+}
+
+}  // namespace cuopt::test::inline_lp

--- a/cpp/tests/utilities/inline_lp_test_utils.hpp
+++ b/cpp/tests/utilities/inline_lp_test_utils.hpp
@@ -11,7 +11,7 @@
 
 #include <string_view>
 
-namespace cuopt::test::inline_lp {
+namespace cuopt::test {
 
 inline cuopt::linear_programming::io::mps_data_model_t<int, double> parse_inline_lp(
   std::string_view lp_text)
@@ -19,4 +19,4 @@ inline cuopt::linear_programming::io::mps_data_model_t<int, double> parse_inline
   return cuopt::linear_programming::io::read_lp_from_string<int, double>(lp_text);
 }
 
-}  // namespace cuopt::test::inline_lp
+}  // namespace cuopt::test


### PR DESCRIPTION
Specify test problems in LP format instead of manually constructing the data structures. This is a big win for readability