### PR TITLE
ci: update nightly run branch from release/26.06 to release/26.08

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         cuopt_branch:
           - "main"
-          - "release/26.06"
+          - "release/26.08"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
Updates the nightly CI matrix in `.github/workflows/nightly.yaml` to run against `release/26.08` instead of `release/26.06`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)