### PR TITLE
grpc fix a race condition with log streaming

### DIFF
--- a/cpp/src/grpc/server/grpc_job_management.cpp
+++ b/cpp/src/grpc/server/grpc_job_management.cpp
@@ -8,6 +8,8 @@
 #include "grpc_pipe_serialization.hpp"
 #include "grpc_server_types.hpp"
 
+#include <fstream>
+
 // write_to_pipe / read_from_pipe are defined in grpc_pipe_io.cpp
 
 bool send_job_data_pipe(int worker_idx, const std::vector<uint8_t>& data)
@@ -83,6 +85,8 @@ std::pair<bool, std::string> submit_job_async(std::vector<uint8_t>&& request_dat
   }
   if (slot < 0) { return {false, "Job queue full"}; }
 
+  create_job_log_file(job_id);
+
   // Populate the slot while we hold the `claimed` flag.
   copy_cstr(job_queue[slot].job_id, job_id);
   job_queue[slot].problem_category = problem_category;
@@ -136,6 +140,8 @@ std::pair<bool, std::string> submit_chunked_job_async(PendingChunkedUpload&& chu
     }
   }
   if (slot < 0) { return {false, "Job queue full"}; }
+
+  create_job_log_file(job_id);
 
   copy_cstr(job_queue[slot].job_id, job_id);
   job_queue[slot].problem_category = problem_category;
@@ -208,6 +214,14 @@ void ensure_log_dir_exists()
 {
   struct stat st;
   if (stat(LOG_DIR.c_str(), &st) != 0) { mkdir(LOG_DIR.c_str(), 0755); }
+}
+
+// Create an empty per-job log file at submit time so StreamLogs can tail it
+// immediately. The worker truncates and repopulates it when the solve starts.
+void create_job_log_file(const std::string& job_id)
+{
+  ensure_log_dir_exists();
+  std::ofstream out(get_log_file_path(job_id), std::ios::out | std::ios::trunc);
 }
 
 void delete_log_file(const std::string& job_id)

--- a/cpp/src/grpc/server/grpc_server_types.hpp
+++ b/cpp/src/grpc/server/grpc_server_types.hpp
@@ -340,6 +340,7 @@ inline void signal_handler(int signal)
 
 std::string generate_job_id();
 void ensure_log_dir_exists();
+void create_job_log_file(const std::string& job_id);
 void delete_log_file(const std::string& job_id);
 void cleanup_shared_memory();
 void spawn_workers();

--- a/cpp/src/grpc/server/grpc_service_impl.cpp
+++ b/cpp/src/grpc/server/grpc_service_impl.cpp
@@ -747,46 +747,45 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
     int64_t from_byte          = request->from_byte();
     const std::string log_path = get_log_file_path(job_id);
 
-    // Phase 1: Wait for the log file to appear on disk.
-    // The worker may not have created it yet, so poll with a short sleep.
-    // Every 2 s, verify the job still exists to avoid waiting forever on
-    // a deleted/unknown job.
-    int waited_ms = 0;
-    while (!context->IsCancelled()) {
-      struct stat st;
-      if (stat(log_path.c_str(), &st) == 0) { break; }
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
-      waited_ms += 50;
-      if (waited_ms >= 2000) {
-        std::string msg;
-        JobStatus s = check_job_status(job_id, msg);
-        if (s == JobStatus::NOT_FOUND) {
-          if (config.verbose) {
-            SERVER_LOG_DEBUG("[gRPC] StreamLogs job not found: %s", job_id.c_str());
-          }
-          return Status(grpc::StatusCode::NOT_FOUND, "Job not found: " + job_id);
-        }
-        if (s == JobStatus::COMPLETED || s == JobStatus::FAILED || s == JobStatus::CANCELLED) {
-          cuopt::remote::LogMessage done;
-          done.set_line("");
-          done.set_byte_offset(from_byte);
-          done.set_job_complete(true);
-          writer->Write(done);
-          return Status::OK;
-        }
-        waited_ms = 0;
+    auto write_log_message =
+      [&](const std::string& line, int64_t offset, bool job_complete = true) -> bool {
+      cuopt::remote::LogMessage m;
+      m.set_line(line);
+      m.set_byte_offset(offset);
+      m.set_job_complete(job_complete);
+      return writer->Write(m);
+    };
+
+    std::string msg;
+    JobStatus s = check_job_status(job_id, msg);
+    if (s == JobStatus::NOT_FOUND) {
+      if (config.verbose) {
+        SERVER_LOG_DEBUG("[gRPC] StreamLogs job not found: %s", job_id.c_str());
       }
+      return Status(grpc::StatusCode::NOT_FOUND, "Job not found: " + job_id);
     }
 
-    // Phase 2: Open the file and seek to the caller's resume point.
+    struct stat st;
+    const bool has_log_file = (stat(log_path.c_str(), &st) == 0);
+
+    // Per-job log files are created at submit time in the main process. If the
+    // file is missing but the job exists (e.g. cancelled and unlinked, or
+    // create failed), stream no log lines and close when the job finishes.
+    if (!has_log_file) {
+      while (!context->IsCancelled()) {
+        s = check_job_status(job_id, msg);
+        if (s != JobStatus::QUEUED && s != JobStatus::PROCESSING) {
+          (void)write_log_message("", from_byte);
+          return Status::OK;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      return Status::OK;
+    }
+
     std::ifstream in(log_path, std::ios::in | std::ios::binary);
     if (!in.is_open()) {
-      cuopt::remote::LogMessage m;
-      m.set_line("Failed to open log file");
-      m.set_byte_offset(from_byte);
-      m.set_job_complete(true);
-      writer->Write(m);
-      return Status::OK;
+      return Status(grpc::StatusCode::INTERNAL, "Failed to open log file: " + log_path);
     }
 
     if (from_byte > 0) { in.seekg(from_byte, std::ios::beg); }
@@ -794,9 +793,9 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
     int64_t current_offset = from_byte;
     std::string line;
 
-    // Phase 3: Tail loop — read available lines, stream each one, then
-    // poll for more.  Each LogMessage carries the byte offset of the *next*
-    // unread byte so the client can resume from that point.
+    // Tail loop — read available lines, stream each one, then poll for more.
+    // Each LogMessage carries the byte offset of the *next* unread byte so
+    // the client can resume from that point.
     while (!context->IsCancelled()) {
       std::streampos before = in.tellg();
       if (before >= 0) { current_offset = static_cast<int64_t>(before); }
@@ -812,11 +811,7 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
           next_offset = current_offset + static_cast<int64_t>(line.size());
         }
 
-        cuopt::remote::LogMessage m;
-        m.set_line(line);
-        m.set_byte_offset(next_offset);
-        m.set_job_complete(false);
-        if (!writer->Write(m)) { break; }
+        if (!write_log_message(line, next_offset, false)) { break; }
         continue;
       }
 
@@ -828,30 +823,31 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
         in.clear();
       }
 
-      // Check whether the job has finished.  If so, drain any final
-      // bytes the solver may have flushed after our last read, then
-      // send the job_complete sentinel and close the stream.
+      // Job finished while we were caught up at EOF. The worker may still flush
+      // the last log line after marking the job complete, so read once more
+      // before closing the stream.
       std::string msg;
       JobStatus s = check_job_status(job_id, msg);
       if (s == JobStatus::COMPLETED || s == JobStatus::FAILED || s == JobStatus::CANCELLED) {
-        std::streampos before2 = in.tellg();
-        if (before2 >= 0) { current_offset = static_cast<int64_t>(before2); }
+        // Resume offset for the final read (same tellg logic as the main loop).
+        std::streampos read_start = in.tellg();
+        if (read_start >= 0) { current_offset = static_cast<int64_t>(read_start); }
+
+        // One last getline: picks up a trailing line written after our previous
+        // EOF poll. If nothing remains, skip straight to the sentinel below.
         if (std::getline(in, line)) {
-          std::streampos after2 = in.tellg();
-          int64_t next_offset2  = current_offset + static_cast<int64_t>(line.size());
-          if (after2 >= 0) { next_offset2 = static_cast<int64_t>(after2); }
-          cuopt::remote::LogMessage m;
-          m.set_line(line);
-          m.set_byte_offset(next_offset2);
-          m.set_job_complete(false);
-          writer->Write(m);
+          std::streampos read_end = in.tellg();
+          // byte_offset on each message is where the client should resume; mirror
+          // the main-loop fallback when tellg() is unavailable after the last line.
+          int64_t next_byte_offset = current_offset + static_cast<int64_t>(line.size());
+          if (read_end >= 0) { next_byte_offset = static_cast<int64_t>(read_end); }
+          (void)write_log_message(line, next_byte_offset, false);
         }
 
-        cuopt::remote::LogMessage done;
-        done.set_line("");
-        done.set_byte_offset(current_offset);
-        done.set_job_complete(true);
-        writer->Write(done);
+        // Empty line + job_complete=true tells the client the log stream is done.
+        // Use current_offset (not next_byte_offset): if we sent a final line above,
+        // the client already got its resume point; this sentinel only marks EOF.
+        (void)write_log_message("", current_offset);
         return Status::OK;
       }
 


### PR DESCRIPTION
For very quickly solved problems, the log file might not exist before the job is marked complete, or the client might start streaming before the file exists. Create the log at submission time to avoid this.