### PR TITLE
fix(qcqp): canonical QC COO ingestion without symmetrization && reject nonconvex general-path constraints

### DIFF
--- a/cpp/include/cuopt/linear_programming/io/data_model_view.hpp
+++ b/cpp/include/cuopt/linear_programming/io/data_model_view.hpp
@@ -418,9 +418,15 @@ class data_model_view_t {
 
   /**
    * @brief Quadratic constraints (MPS QCMATRIX); owned copy for writers when not using spans.
+   *
+   * Q COO is stored as supplied (not canonicalized here). Canonicalization runs when
+   * constraints are copied into the solver (populate_from_data_model_view) or written
+   * to MPS (mps_writer QCMATRIX emission).
    */
   void set_quadratic_constraints(
     std::vector<typename mps_data_model_t<i_t, f_t>::quadratic_constraint_t> constraints);
+  /** @copydoc set_quadratic_constraints(std::vector<typename mps_data_model_t<i_t,
+   * f_t>::quadratic_constraint_t>) */
   template <typename qc_t>
   void set_quadratic_constraints(const std::vector<qc_t>& constraints)
   {

--- a/cpp/include/cuopt/linear_programming/io/mps_data_model.hpp
+++ b/cpp/include/cuopt/linear_programming/io/mps_data_model.hpp
@@ -239,7 +239,9 @@ class mps_data_model_t {
    * - row identity and type (from ROWS),
    * - sparse linear coefficients (from COLUMNS),
    * - RHS value (from RHS),
-   * - quadratic matrix Q in COO (SoA: row, col, value) from QCMATRIX — one triplet per nonzero.
+   * - quadratic matrix Q in canonical COO (SoA: row, col, value): one triplet per variable pair,
+   *   sorted by (row, col). Off-diagonal cross terms store the full coefficient on x_i*x_j
+   *   (e.g. -2*d for rotated SOC), not as symmetric halves.
    */
   struct quadratic_constraint_t {
     /** ROWS declaration index (among all constraint rows), not an index into the linear CSR. */
@@ -251,7 +253,8 @@ class mps_data_model_t {
     std::vector<f_t> linear_values{};
     std::vector<i_t> linear_indices{};
     f_t rhs_value{f_t(0)};
-    /** Q nonzeros: parallel arrays, same length (COO / SoA). Sorted by (row, col) in append. */
+    /** Q in canonical COO: parallel arrays, same length, sorted by (row, col);
+     * one entry per variable pair (full cross coefficient, not MPS symmetric halves). */
     std::vector<i_t> rows{};
     std::vector<i_t> cols{};
     std::vector<f_t> vals{};
@@ -262,7 +265,9 @@ class mps_data_model_t {
    * @note All span inputs are host memory; the model copies this data.
    * @param linear_values, linear_indices Same nnz; can be empty for a purely quadratic row (rare).
    * @param vals, rows, cols COO triplets for Q; same length; may all be empty if Q is empty.
-   *        Stored sorted by (row, col).
+   *        Stored sorted by (row, col) in canonical form (one entry per variable pair).
+   * @param require_symmetric_q_offdiagonal When true (MPS QCMATRIX), each off-diagonal pair must
+   *        appear symmetrically in the input before canonicalization.
    * @param constraint_row_type MPS ROWS type: 'L' (<=) or 'G' (>=). Stored as given; 'G' rows are
    *        converted to '<=' form when building the SOCP for the barrier solver. Equality ('E') is
    *        not supported.
@@ -275,7 +280,8 @@ class mps_data_model_t {
                                    f_t rhs_value,
                                    std::span<const f_t> vals,
                                    std::span<const i_t> rows,
-                                   std::span<const i_t> cols);
+                                   std::span<const i_t> cols,
+                                   bool require_symmetric_q_offdiagonal = false);
 
   const std::vector<quadratic_constraint_t>& get_quadratic_constraints() const;
 
@@ -384,5 +390,14 @@ class mps_data_model_t {
   std::vector<quadratic_constraint_t> quadratic_constraints_;
 
 };  // class mps_data_model_t
+
+/**
+ * @brief Canonicalize Q COO on each quadratic constraint in place (merge duplicates, collapse
+ * symmetric MPS halves when requested). Implemented in mps_data_model.cpp.
+ */
+template <typename i_t, typename f_t>
+void canonicalize_quadratic_constraints(
+  std::vector<typename mps_data_model_t<i_t, f_t>::quadratic_constraint_t>& constraints,
+  bool require_symmetric_q_offdiagonal = false);
 
 }  // namespace cuopt::linear_programming::io

--- a/cpp/include/cuopt/linear_programming/optimization_problem_interface.hpp
+++ b/cpp/include/cuopt/linear_programming/optimization_problem_interface.hpp
@@ -75,6 +75,10 @@ class optimization_problem_interface_t {
 
   /**
    * @brief Store quadratic constraints for MPS round-trip (linear + Q parts per QC row).
+   *
+   * Q COO must already be in canonical form (one entry per variable pair). Callers that ingest
+   * raw API/MPS data should canonicalize before calling this (see append_quadratic_constraint,
+   * add_quadratic_constraint, populate_from_data_model_view, or gRPC decode).
    */
   virtual void set_quadratic_constraints(std::vector<quadratic_constraint_t> constraints) = 0;
 
@@ -84,6 +88,7 @@ class optimization_problem_interface_t {
    * Quadratic matrix Q is COO (row_index, col_index, coeff spans). Linear term d uses parallel
    * linear_values and linear_indices (empty allowed). constraint_row_index is assigned
    * automatically as n_linear_constraints + n_existing_quadratic_constraints.
+   * Q is canonicalized on ingest (merge duplicates, collapse matching symmetric pairs).
    */
   virtual void add_quadratic_constraint(char constraint_row_type,
                                         f_t rhs_value,

--- a/cpp/include/cuopt/linear_programming/optimization_problem_utils.hpp
+++ b/cpp/include/cuopt/linear_programming/optimization_problem_utils.hpp
@@ -134,7 +134,7 @@ void populate_from_mps_data_model(optimization_problem_interface_t<i_t, f_t>* pr
                                             q_offsets.data(),
                                             n_vars + 1);
   }
-  // Handle quadratic constraints if present
+  // Quadratic constraints from mps_data_model are already canonical (append_quadratic_constraint).
   if (data_model.has_quadratic_constraints()) {
     problem->set_quadratic_constraints(data_model.get_quadratic_constraints());
   }
@@ -295,8 +295,11 @@ void populate_from_data_model_view(
     problem->set_row_names(data_model->get_row_names());
   }
 
+  // Raw Q COO from data_model_view is canonicalized here before solver storage.
   if (data_model->has_quadratic_constraints()) {
-    problem->set_quadratic_constraints(data_model->get_quadratic_constraints());
+    auto qcs = data_model->get_quadratic_constraints();
+    io::canonicalize_quadratic_constraints<i_t, f_t>(qcs);
+    problem->set_quadratic_constraints(std::move(qcs));
   }
 }
 

--- a/cpp/src/barrier/translate_soc.hpp
+++ b/cpp/src/barrier/translate_soc.hpp
@@ -645,9 +645,15 @@ void convert_quadratic_constraints_to_second_order_cones(
                     "Quadratic constraint '%s' is non-convex (Q matrix is indefinite)",
                     qc.constraint_row_name.c_str());
 
-      // Since q_nnz >= 1 is enforced above, Q is nonzero and rank must be >= 1.
-      // (A nonzero Q entry produces a nonzero H diagonal or off-diagonal, guaranteeing rank > 0.)
-      assert(rank >= 1);
+      // q_nnz >= 1 implies H is nonzero, but diagonal LDLT may still return rank 0 (e.g. cross-only
+      // indefinite H with zero diagonals). Reject before building a degenerate r=0 SOC lift.
+      cuopt_expects(rank >= 1,
+                    error_type_t::ValidationError,
+                    "Quadratic constraint '%s' is non-convex or could not be converted to a "
+                    "second-order cone (LDLT rank %d; Q may be indefinite or have zero diagonal "
+                    "with cross terms)",
+                    qc.constraint_row_name.c_str(),
+                    static_cast<int>(rank));
 
       // Step 4: Build standard SOC of dimension rank + 2.
       // New variables: y_0,...,y_{r-1}, s_0 (head), s_{r+1} (tail)

--- a/cpp/src/barrier/translate_soc.hpp
+++ b/cpp/src/barrier/translate_soc.hpp
@@ -92,8 +92,7 @@ void convert_quadratic_constraints_to_second_order_cones(
   //        -s*x_head^2 + sum_i s*x_tail_i^2 <= 0   (any common s > 0; divide by s to normalize)
   //   2) rotated SOC rows:
   //        -2*d*x_head0*x_head1 + sum_i s*x_tail_i^2 <= 0   (d>0, s>0; canonical d=s)
-  //      symmetric Q off-diagonals (-d,-d) give x^T Q x cross term -2*d*x0*x1, i.e. a*x0*x1
-  //      in the inequality 2*d*x0*x1 >= s*||tail||^2 with a = 2*d. Lift uses sqrt(d/s) on heads.
+  //      stored as one Q cross term (head0, head1, -2*d). Lift uses sqrt(d/s) on heads.
   //   3) quadratic rows with linear part:
   //        sum_i s*x_tail_i^2 + a^T x <= 0
   //      represented as diagonal +s QCMATRIX entries plus linear terms in COLUMNS.
@@ -108,7 +107,8 @@ void convert_quadratic_constraints_to_second_order_cones(
     i_t head1{};
     std::vector<i_t> tails{};
     bool head1_is_constant_half{false};
-    /// For two-head rotated SOC: sqrt(d/s) where Q_off = -d and tail diagonals +s (canonical 1).
+    /// For two-head rotated SOC: sqrt(d/s) where Q cross = -2*d and tail diagonals +s (canonical
+    /// 1).
     f_t head_lift_sqrt_ratio{1};
   };
   // This is the index of the auxiliary variable for the linear part of the quadratic constraint.
@@ -188,7 +188,7 @@ void convert_quadratic_constraints_to_second_order_cones(
 
     // Verify Q as either:
     // - standard SOC: one diagonal -s (head), tail diagonals +s for a common s > 0,
-    // - rotated SOC: symmetric (-s,-s) off-diagonal pair on the two heads, tails +s,
+    // - rotated SOC: one off-diagonal cross term (-2*d) on the two heads, tails +s,
     // - affine SOC: tail diagonals +s and linear terms (no Q off-diagonals).
     // Feasibility is unchanged after dividing the quadratic row by s; affine rows also scale
     // linear coefficients when forming the auxiliary t = -(1/s) a^T x.
@@ -274,11 +274,21 @@ void convert_quadratic_constraints_to_second_order_cones(
         }
       }
     }
-    const bool use_general_path = has_duplicate_rows || has_near_zero_diag || has_nonzero_rhs ||
-                                  has_nonuniform_diag || offdiag_entries.size() > 2 ||
-                                  (offdiag_entries.size() == 1) || (neg_diag_rows.size() > 1) ||
-                                  (!neg_diag_rows.empty() && has_linear_part) ||
-                                  (!neg_diag_rows.empty() && !offdiag_entries.empty());
+    const bool rotated_soc_cross_eligible = [&]() {
+      if (offdiag_entries.size() != 1 || has_linear_part || !neg_diag_rows.empty()) {
+        return false;
+      }
+      const i_t a = std::get<0>(offdiag_entries[0]);
+      const i_t b = std::get<1>(offdiag_entries[0]);
+      const f_t v = std::get<2>(offdiag_entries[0]);
+      // Match cross_d = -v/2 > tol validated on the rotated SOC fast path below.
+      return a != b && (-v / f_t(2)) > tol;
+    }();
+    const bool use_general_path =
+      has_duplicate_rows || has_near_zero_diag || has_nonzero_rhs || has_nonuniform_diag ||
+      offdiag_entries.size() > 1 || (offdiag_entries.size() == 1 && !rotated_soc_cross_eligible) ||
+      (neg_diag_rows.size() > 1) || (!neg_diag_rows.empty() && has_linear_part) ||
+      (!neg_diag_rows.empty() && !offdiag_entries.empty());
 
     f_t uniform_s        = 0;
     bool have_uniform_s  = false;
@@ -456,52 +466,28 @@ void convert_quadratic_constraints_to_second_order_cones(
                       "Quadratic constraint '%s' rotated SOC Q: could not infer uniform scale s",
                       qc.constraint_row_name.c_str());
         cuopt_expects(
-          offdiag_entries.size() == 2,
+          offdiag_entries.size() == 1,
           error_type_t::ValidationError,
-          "Quadratic constraint '%s' rotated SOC Q must contain exactly one symmetric off-diagonal "
-          "pair (-d,-d); found %zu off-diagonal entries",
+          "Quadratic constraint '%s' rotated SOC Q must contain exactly one cross term with "
+          "coefficient -2*d on the head variable pair; found %zu off-diagonal entries",
           qc.constraint_row_name.c_str(),
           offdiag_entries.size());
 
         const i_t a  = std::get<0>(offdiag_entries[0]);
         const i_t b  = std::get<1>(offdiag_entries[0]);
         const f_t v0 = std::get<2>(offdiag_entries[0]);
-        cuopt_expects(
-          v0 < -tol,
-          error_type_t::ValidationError,
-          "Quadratic constraint '%s' rotated SOC Q off-diagonal must be negative; got %.17g",
-          qc.constraint_row_name.c_str(),
-          static_cast<double>(v0));
+
         cuopt_expects(a != b,
                       error_type_t::ValidationError,
-                      "Quadratic constraint '%s' rotated SOC Q off-diagonal pair must use distinct "
+                      "Quadratic constraint '%s' rotated SOC Q cross term must use distinct head "
                       "variables",
                       qc.constraint_row_name.c_str());
-        cuopt_expects(std::get<0>(offdiag_entries[1]) == b && std::get<1>(offdiag_entries[1]) == a,
-                      error_type_t::ValidationError,
-                      "Quadratic constraint '%s' rotated SOC Q must have symmetric entries (a,b) "
-                      "and (b,a) with the same value",
-                      qc.constraint_row_name.c_str());
-        const f_t v1 = std::get<2>(offdiag_entries[1]);
-        cuopt_expects(
-          v1 < -tol,
-          error_type_t::ValidationError,
-          "Quadratic constraint '%s' rotated SOC Q off-diagonal must be negative; got %.17g",
-          qc.constraint_row_name.c_str(),
-          static_cast<double>(v1));
-        cuopt_expects(
-          approx_eq_scaled(v0, v1),
-          error_type_t::ValidationError,
-          "Quadratic constraint '%s' rotated SOC Q symmetric off-diagonals must match; got %.17g "
-          "and %.17g",
-          qc.constraint_row_name.c_str(),
-          static_cast<double>(v0),
-          static_cast<double>(v1));
-        const f_t cross_d = -v0;
+        const f_t cross_d = -v0 / f_t(2);
         cuopt_expects(
           cross_d > tol,
           error_type_t::ValidationError,
-          "Quadratic constraint '%s' rotated SOC Q cross coefficient d = -Q_off must be positive",
+          "Quadratic constraint '%s' rotated SOC Q cross coefficient d = -Q_cross/2 must be "
+          "positive",
           qc.constraint_row_name.c_str());
         const f_t head_lift_sqrt_ratio = std::sqrt(cross_d / uniform_s);
         cuopt_expects(std::isfinite(static_cast<double>(head_lift_sqrt_ratio)),
@@ -511,12 +497,12 @@ void convert_quadratic_constraints_to_second_order_cones(
                       qc.constraint_row_name.c_str(),
                       static_cast<double>(cross_d),
                       static_cast<double>(uniform_s));
-        cuopt_expects(static_cast<i_t>(tail_vars.size()) == q_nnz - 2,
+        cuopt_expects(static_cast<i_t>(tail_vars.size()) == q_nnz - 1,
                       error_type_t::ValidationError,
                       "Quadratic constraint '%s' rotated SOC Q: expected %d diagonal +s entries "
                       "(tails), found %zu",
                       qc.constraint_row_name.c_str(),
-                      static_cast<int>(q_nnz - 2),
+                      static_cast<int>(q_nnz - 1),
                       tail_vars.size());
         cuopt_expects(q_nnz >= 3,
                       error_type_t::ValidationError,

--- a/cpp/src/dual_simplex/right_looking_lu.cpp
+++ b/cpp/src/dual_simplex/right_looking_lu.cpp
@@ -13,7 +13,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <cstdio>
 
 using cuopt::ins_vector;
 
@@ -1684,7 +1683,8 @@ i_t right_looking_ldlt(const csc_matrix_t<i_t, f_t>& A,
                        f_t& work_estimate)
 {
   raft::common::nvtx::range scope("LU::right_looking_ldlt");
-  const i_t n = A.n;
+  const i_t n         = A.n;
+  const i_t input_nnz = A.nnz();
   assert(A.m == n);
 
   symmetric_trailing_matrix_t<i_t, f_t> trailing_matrix(A);
@@ -1720,7 +1720,12 @@ i_t right_looking_ldlt(const csc_matrix_t<i_t, f_t>& A,
     f_t pivot_val = 0;
     trailing_matrix.symmetric_markowitz_search(pivot_tol, pivot_p, pivot_val);
 
-    if (pivot_p == -1) { break; }  // No acceptable pivot found (remaining diagonals are zero/tiny)
+    if (pivot_p == -1) {
+      // No acceptable diagonal pivot. Zero matrix is rank 0; nonzero cross-only indefinite
+      // matrices (e.g. [[0, a]; [a, 0]]) also stall here and must not be treated as PSD.
+      if (pivots == 0 && input_nnz > 0) { return INDEFINITE_MATRIX_RETURN; }
+      break;
+    }
 
     // Check for indefiniteness: a negative pivot means the matrix is not PSD
     if (pivot_val < 0) { return INDEFINITE_MATRIX_RETURN; }

--- a/cpp/src/dual_simplex/right_looking_lu.hpp
+++ b/cpp/src/dual_simplex/right_looking_lu.hpp
@@ -43,7 +43,8 @@ i_t right_looking_lu_row_permutation_only(const csc_matrix_t<i_t, f_t>& A,
 //   D = diagonal factor (length = rank)
 // Returns:
 //   rank >= 0: number of successful pivots with D(k,k) >= pivot_tol (PSD case).
-//   INDEFINITE_MATRIX_RETURN (-4): a negative pivot was encountered (matrix is not PSD).
+//   INDEFINITE_MATRIX_RETURN (-4): a negative pivot was encountered, or the matrix is nonzero
+//     but no acceptable diagonal pivot was found (matrix is not PSD).
 //   CONCURRENT_HALT_RETURN (-2): concurrent halt requested.
 //   TIME_LIMIT_RETURN (-3): time limit exceeded.
 template <typename i_t, typename f_t>

--- a/cpp/src/grpc/codegen/generate_conversions.py
+++ b/cpp/src/grpc/codegen/generate_conversions.py
@@ -2215,6 +2215,8 @@ def _gen_proto_to_problem(registry, indent="  "):
                 f'{b["name"]} size mismatch");'
             )
             lines.append(f"{ind}    }}")
+        if name == "quadratic_constraints":
+            lines.append(f"{ind}    io::canonicalize_qc_entry(_entry);")
         lines.append(f"{ind}    _entries.push_back(std::move(_entry));")
         lines.append(f"{ind}  }}")
         lines.append(f"{ind}  cpu_problem.{setter}(std::move(_entries));")
@@ -2811,6 +2813,8 @@ def _gen_chunked_arrays_to_problem(registry, indent="  "):
                     f'{b["name"]} size mismatch");'
                 )
                 lines.append(f"{ind}    }}")
+            if name == "quadratic_constraints":
+                lines.append(f"{ind}    io::canonicalize_qc_entry(_entry);")
             lines.append(f"{ind}    _entries.push_back(std::move(_entry));")
             lines.append(f"{ind}  }}")
             lines.append(f"{ind}  cpu_problem.{setter}(std::move(_entries));")

--- a/cpp/src/grpc/codegen/generated/generated_chunked_arrays_to_problem.inc
+++ b/cpp/src/grpc/codegen/generated/generated_chunked_arrays_to_problem.inc
@@ -194,6 +194,7 @@
       if (_entry.cols.size() != _entry.vals.size()) {
         throw std::invalid_argument("set_quadratic_constraints: cols/vals size mismatch");
       }
+      io::canonicalize_qc_entry(_entry);
       _entries.push_back(std::move(_entry));
     }
     cpu_problem.set_quadratic_constraints(std::move(_entries));

--- a/cpp/src/grpc/codegen/generated/generated_proto_to_problem.inc
+++ b/cpp/src/grpc/codegen/generated/generated_proto_to_problem.inc
@@ -96,6 +96,7 @@
       if (_entry.cols.size() != _entry.vals.size()) {
         throw std::invalid_argument("set_quadratic_constraints: cols/vals size mismatch");
       }
+      io::canonicalize_qc_entry(_entry);
       _entries.push_back(std::move(_entry));
     }
     cpu_problem.set_quadratic_constraints(std::move(_entries));

--- a/cpp/src/grpc/grpc_problem_mapper.cpp
+++ b/cpp/src/grpc/grpc_problem_mapper.cpp
@@ -11,6 +11,7 @@
 #include <cuopt/linear_programming/cpu_optimization_problem.hpp>
 #include <cuopt/linear_programming/mip/solver_settings.hpp>
 #include <cuopt/linear_programming/pdlp/solver_settings.hpp>
+#include <quadratic_constraint_coo.hpp>
 #include "grpc_settings_mapper.hpp"
 
 #include <algorithm>

--- a/cpp/src/io/CMakeLists.txt
+++ b/cpp/src/io/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PARSERS_SRC_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_data_model.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_writer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/quadratic_constraint_coo.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/writer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/utilities/cython_parser.cpp

--- a/cpp/src/io/data_model_view.cpp
+++ b/cpp/src/io/data_model_view.cpp
@@ -6,6 +6,7 @@
 /* clang-format on */
 
 #include <cuopt/linear_programming/io/data_model_view.hpp>
+
 #include <utilities/error.hpp>
 
 #include <span>

--- a/cpp/src/io/lp_parser.cpp
+++ b/cpp/src/io/lp_parser.cpp
@@ -118,43 +118,6 @@ bool is_free_keyword(std::string_view lower) { return lower == "free"; }
 
 bool is_infinity_text(std::string_view lower) { return lower == "inf" || lower == "infinity"; }
 
-// Builds the symmetric Q in COO from LP-format raw upper-triangular triples.
-// Each input triple (i, j, c) with i <= j represents `c * x_i * x_j` in the
-// LP source. The output Q satisfies x^T Q x = sum of those terms.
-//   Diagonal (i == j): Q[i,i] = c (one entry).
-//   Off-diagonal (i != j): Q[i,j] = Q[j,i] = c/2 (two entries; symmetric split).
-template <typename i_t, typename f_t>
-void build_symmetric_q_coo(const coo_entries_t<i_t, f_t>& raw_triples,
-                           std::vector<i_t>& out_row_indices,
-                           std::vector<i_t>& out_col_indices,
-                           std::vector<f_t>& out_values)
-{
-  out_row_indices.clear();
-  out_col_indices.clear();
-  out_values.clear();
-  out_row_indices.reserve(raw_triples.size() * 2);
-  out_col_indices.reserve(raw_triples.size() * 2);
-  out_values.reserve(raw_triples.size() * 2);
-
-  for (size_t p = 0; p < raw_triples.size(); p++) {
-    const i_t i = raw_triples.rows[p];
-    const i_t j = raw_triples.cols[p];
-    const f_t c = raw_triples.vals[p];
-    if (i == j) {
-      out_row_indices.push_back(i);
-      out_col_indices.push_back(i);
-      out_values.push_back(c);
-    } else {
-      out_row_indices.push_back(i);
-      out_col_indices.push_back(j);
-      out_values.push_back(c / 2);
-      out_row_indices.push_back(j);
-      out_col_indices.push_back(i);
-      out_values.push_back(c / 2);
-    }
-  }
-}
-
 // ===========================================================================
 // Token stream
 // ===========================================================================
@@ -257,9 +220,8 @@ class LpParseEngine {
   //   Objective:  must be followed by '/ 2'; the inner-coefficient convention
   //               is QUADOBJ-style 0.5 x^T Q x, so off-diagonals are halved
   //               and linear-inside-bracket terms also get /2.
-  //   Constraint: must NOT be followed by '/ 2'; coefficients are taken at
-  //               face value (x^T Q x); bracket must contain at least one
-  //               quadratic term.
+  //   Constraint: must NOT be followed by '/ 2'; coefficients are face value
+  //               for x^T Q x (canonicalized in append_quadratic_constraint).
   enum class BracketRole { Objective, Constraint };
   void parse_quadratic_bracket(int outer_sign,
                                BracketRole role,
@@ -964,9 +926,8 @@ void LpParseEngine<i_t, f_t>::parse_quadratic_bracket(int outer_sign,
                        "constraint must contain at least one quadratic term",
                        peek().line);
 
-    // Coefficients are at face value — the post-pass that flushes the
-    // quadratic_constraint_block_t to the data model handles the symmetric
-    // expansion and the /2 split for off-diagonals.
+    // Coefficients are face value for x^T Q x; canonicalization runs in
+    // append_quadratic_constraint() when the block is flushed to the data model.
     out_quad_entries.rows.insert(
       out_quad_entries.rows.end(), raw_quad.rows.begin(), raw_quad.rows.end());
     out_quad_entries.cols.insert(
@@ -1514,19 +1475,15 @@ void flush_quadratic_constraints(mps_data_model_t<i_t, f_t>& problem,
   const i_t linear_row_count = static_cast<i_t>(parser.row_names.size());
   for (i_t k = 0; k < static_cast<i_t>(parser.quadratic_constraint_blocks.size()); k++) {
     const auto& block = parser.quadratic_constraint_blocks[k];
-    std::vector<i_t> q_row_indices;
-    std::vector<i_t> q_col_indices;
-    std::vector<f_t> q_values;
-    build_symmetric_q_coo(block.quad_triples, q_row_indices, q_col_indices, q_values);
     problem.append_quadratic_constraint(linear_row_count + k,
                                         block.row_name,
                                         static_cast<char>(block.row_type),
                                         block.linear_values,
                                         block.linear_indices,
                                         block.rhs_value,
-                                        q_values,
-                                        q_row_indices,
-                                        q_col_indices);
+                                        block.quad_triples.vals,
+                                        block.quad_triples.rows,
+                                        block.quad_triples.cols);
   }
 }
 

--- a/cpp/src/io/lp_parser.hpp
+++ b/cpp/src/io/lp_parser.hpp
@@ -55,9 +55,9 @@ class lp_parser_t {
   std::vector<f_t> variable_upper_bounds{};
   std::vector<f_t> variable_lower_bounds{};
   bool maximize{false};
-  // Quadratic objective entries (row, col, value) in upper-triangular
-  // QUADOBJ convention; finalize_problem() mirrors to the full symmetric
-  // matrix and applies the *0.5 factor required by cuOpt's x^T Q x form.
+  // Quadratic objective entries (row, col, value) in upper-triangular form;
+  // coefficients are /2-scaled in parse_quadratic_bracket for the LP "/ 2"
+  // convention. finalize_problem() emits them as CSR.
   coo_entries_t<i_t, f_t> quadobj_entries{};
 
   // Per-row data for constraints whose LHS contains a quadratic bracket.
@@ -73,9 +73,9 @@ class lp_parser_t {
     std::vector<i_t> linear_indices{};
     std::vector<f_t> linear_values{};
     f_t rhs_value{};
-    // Upper-triangular (i <= j) raw triples directly from the LP source
-    // (face value, no /2). The post-pass mirrors and halves off-diagonals
-    // to build the symmetric Q in CSR.
+    // Upper-triangular (i <= j) face-value triples from the LP source; each
+    // contributes c * x_i * x_j to x^T Q x. Canonicalized in
+    // append_quadratic_constraint().
     coo_entries_t<i_t, f_t> quad_triples{};
   };
   std::vector<quadratic_constraint_block_t> quadratic_constraint_blocks{};

--- a/cpp/src/io/mps_data_model.cpp
+++ b/cpp/src/io/mps_data_model.cpp
@@ -8,6 +8,8 @@
 #include <cuopt/linear_programming/io/mps_data_model.hpp>
 #include <utilities/error.hpp>
 
+#include <quadratic_constraint_coo.hpp>
+
 #include <algorithm>
 #include <numeric>
 #include <utility>
@@ -148,7 +150,8 @@ void mps_data_model_t<i_t, f_t>::append_quadratic_constraint(i_t constraint_row_
                                                              f_t rhs_value,
                                                              std::span<const f_t> vals,
                                                              std::span<const i_t> rows,
-                                                             std::span<const i_t> cols)
+                                                             std::span<const i_t> cols,
+                                                             bool require_symmetric_q_offdiagonal)
 {
   mps_parser_expects(constraint_row_index >= 0,
                      error_type_t::ValidationError,
@@ -194,26 +197,10 @@ void mps_data_model_t<i_t, f_t>::append_quadratic_constraint(i_t constraint_row_
     qc.cols.clear();
     qc.vals.clear();
   } else {
-    std::vector<i_t> wr(rows.begin(), rows.end());
-    std::vector<i_t> wc(cols.begin(), cols.end());
-    std::vector<f_t> wv(vals.begin(), vals.end());
-
-    std::vector<size_t> perm(q_nnz);
-    std::iota(perm.begin(), perm.end(), size_t{0});
-    std::sort(perm.begin(), perm.end(), [&](size_t a, size_t b) {
-      if (wr[a] != wr[b]) { return wr[a] < wr[b]; }
-      return wc[a] < wc[b];
-    });
-
-    qc.rows.resize(q_nnz);
-    qc.cols.resize(q_nnz);
-    qc.vals.resize(q_nnz);
-    for (size_t t = 0; t < q_nnz; ++t) {
-      const size_t ix = perm[t];
-      qc.rows[t]      = wr[ix];
-      qc.cols[t]      = wc[ix];
-      qc.vals[t]      = wv[ix];
-    }
+    qc.rows.assign(rows.begin(), rows.end());
+    qc.cols.assign(cols.begin(), cols.end());
+    qc.vals.assign(vals.begin(), vals.end());
+    canonicalize_qc_entry(qc, require_symmetric_q_offdiagonal);
   }
 
   quadratic_constraints_.push_back(std::move(qc));
@@ -473,10 +460,25 @@ bool mps_data_model_t<i_t, f_t>::has_quadratic_constraints() const noexcept
   return !quadratic_constraints_.empty();
 }
 
+template <typename i_t, typename f_t>
+void canonicalize_quadratic_constraints(
+  std::vector<typename mps_data_model_t<i_t, f_t>::quadratic_constraint_t>& constraints,
+  bool require_symmetric_q_offdiagonal)
+{
+  for (auto& qc : constraints) {
+    canonicalize_qc_entry(qc, require_symmetric_q_offdiagonal);
+  }
+}
+
 // NOTE: Explicitly instantiate all types here in order to avoid linker error
 template class mps_data_model_t<int, float>;
 
 template class mps_data_model_t<int, double>;
+
+template void canonicalize_quadratic_constraints<int, float>(
+  std::vector<mps_data_model_t<int, float>::quadratic_constraint_t>&, bool);
+template void canonicalize_quadratic_constraints<int, double>(
+  std::vector<mps_data_model_t<int, double>::quadratic_constraint_t>&, bool);
 //  TODO current raft to cusparse wrappers only support int64_t
 //  can be CUSPARSE_INDEX_16U, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_64I
 

--- a/cpp/src/io/mps_parser.cpp
+++ b/cpp/src/io/mps_parser.cpp
@@ -461,7 +461,8 @@ void mps_parser_t<i_t, f_t>::fill_problem(mps_data_model_t<i_t, f_t>& problem)
                                         b_values[row_id],
                                         block.entries.vals,
                                         block.entries.rows,
-                                        block.entries.cols);
+                                        block.entries.cols,
+                                        true);
   }
 
   if (!quadratic_row_ids.empty()) {

--- a/cpp/src/io/mps_writer.cpp
+++ b/cpp/src/io/mps_writer.cpp
@@ -9,6 +9,7 @@
 
 #include <cuopt/linear_programming/io/data_model_view.hpp>
 #include <cuopt/linear_programming/io/mps_data_model.hpp>
+#include <quadratic_constraint_coo.hpp>
 #include <utilities/error.hpp>
 #include <utilities/sparse_matrix_helpers.hpp>
 
@@ -498,11 +499,13 @@ void mps_writer_t<i_t, f_t>::write(const std::string& mps_file_path)
   if (problem_.has_quadratic_constraints()) {
     for (const auto& qc : problem_.get_quadratic_constraints()) {
       mps_file << "QCMATRIX   " << qc.constraint_row_name << "\n";
-      const i_t nnz = qc.vals.size();
+      typename mps_data_model_t<i_t, f_t>::quadratic_constraint_t qc_canon = qc;
+      canonicalize_qc_entry(qc_canon);
+      const i_t nnz = static_cast<i_t>(qc_canon.vals.size());
       for (i_t p = 0; p < nnz; ++p) {
-        const i_t i              = qc.rows[p];
-        const i_t j              = qc.cols[p];
-        f_t v                    = qc.vals[p];
+        const i_t i              = qc_canon.rows[p];
+        const i_t j              = qc_canon.cols[p];
+        f_t v                    = qc_canon.vals[p];
         std::string row_var_name = static_cast<size_t>(i) < problem_.get_variable_names().size()
                                      ? problem_.get_variable_names()[i]
                                      : "C" + std::to_string(i);
@@ -510,7 +513,14 @@ void mps_writer_t<i_t, f_t>::write(const std::string& mps_file_path)
                                      ? problem_.get_variable_names()[j]
                                      : "C" + std::to_string(j);
         if (v != 0) {
-          mps_file << "    " << row_var_name << " " << col_var_name << " " << v << "\n";
+          if (i != j) {
+            // MPS QCMATRIX uses symmetric halves for cross terms.
+            const f_t half = v / f_t(2);
+            mps_file << "    " << row_var_name << " " << col_var_name << " " << half << "\n";
+            mps_file << "    " << col_var_name << " " << row_var_name << " " << half << "\n";
+          } else {
+            mps_file << "    " << row_var_name << " " << col_var_name << " " << v << "\n";
+          }
         }
       }
     }

--- a/cpp/src/io/quadratic_constraint_coo.cpp
+++ b/cpp/src/io/quadratic_constraint_coo.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#include <quadratic_constraint_coo.hpp>
+
+namespace cuopt::linear_programming::io {
+
+namespace {
+
+template <typename i_t>
+struct pair_hash {
+  size_t operator()(const std::pair<i_t, i_t>& p) const noexcept
+  {
+    return std::hash<i_t>{}(p.first) ^ (std::hash<i_t>{}(p.second) << 1);
+  }
+};
+
+template <typename f_t>
+bool approx_eq(f_t a, f_t b, f_t tol)
+{
+  const f_t scale = std::max({f_t(1), std::abs(a), std::abs(b)});
+  return std::abs(a - b) <= tol * scale;
+}
+
+template <typename i_t, typename f_t>
+f_t lookup_coeff(const std::unordered_map<std::pair<i_t, i_t>, f_t, pair_hash<i_t>>& agg,
+                 i_t r,
+                 i_t c,
+                 f_t tol)
+{
+  const auto it = agg.find({r, c});
+  if (it == agg.end()) { return f_t(0); }
+  return std::abs(it->second) > tol ? it->second : f_t(0);
+}
+
+}  // namespace
+
+template <typename i_t, typename f_t>
+void canonicalize_qc_coo(std::vector<i_t>& rows,
+                         std::vector<i_t>& cols,
+                         std::vector<f_t>& vals,
+                         const qc_coo_canonicalize_options_t<f_t>& opts)
+{
+  const size_t n = vals.size();
+  cuopt_expects(rows.size() == n && cols.size() == n,
+                error_type_t::ValidationError,
+                "Q COO rows/cols/vals length mismatch");
+
+  if (n == 0) {
+    rows.clear();
+    cols.clear();
+    vals.clear();
+    return;
+  }
+
+  std::unordered_map<std::pair<i_t, i_t>, f_t, pair_hash<i_t>> agg;
+  agg.reserve(n);
+  for (size_t t = 0; t < n; ++t) {
+    const i_t r = rows[t];
+    const i_t c = cols[t];
+    const f_t v = vals[t];
+    if (std::abs(v) <= opts.tol) { continue; }
+    agg[{r, c}] += v;
+  }
+
+  std::vector<std::tuple<i_t, i_t, f_t>> out;
+  out.reserve(agg.size());
+
+  std::unordered_map<std::pair<i_t, i_t>, char, pair_hash<i_t>> visited;
+  for (const auto& [rc, v] : agg) {
+    if (rc.first == rc.second) { continue; }
+    const i_t lo = std::min(rc.first, rc.second);
+    const i_t hi = std::max(rc.first, rc.second);
+    if (visited[{lo, hi}]) { continue; }
+    visited[{lo, hi}] = 1;
+
+    const f_t v_lo_hi    = lookup_coeff(agg, lo, hi, opts.tol);
+    const f_t v_hi_lo    = lookup_coeff(agg, hi, lo, opts.tol);
+    const bool has_lo_hi = std::abs(v_lo_hi) > opts.tol;
+    const bool has_hi_lo = std::abs(v_hi_lo) > opts.tol;
+
+    if (opts.require_symmetric_offdiagonal_pairs) {
+      cuopt_expects(has_lo_hi && has_hi_lo,
+                    error_type_t::ValidationError,
+                    "Quadratic constraint '%s' QCMATRIX off-diagonal (%d,%d) requires a matching "
+                    "(%d,%d) entry",
+                    opts.constraint_name.c_str(),
+                    static_cast<int>(lo),
+                    static_cast<int>(hi),
+                    static_cast<int>(hi),
+                    static_cast<int>(lo));
+      cuopt_expects(
+        approx_eq(v_lo_hi, v_hi_lo, opts.tol),
+        error_type_t::ValidationError,
+        "Quadratic constraint '%s' QCMATRIX symmetric off-diagonals (%d,%d) and (%d,%d) must "
+        "match; got %.17g and %.17g",
+        opts.constraint_name.c_str(),
+        static_cast<int>(lo),
+        static_cast<int>(hi),
+        static_cast<int>(hi),
+        static_cast<int>(lo),
+        static_cast<double>(v_lo_hi),
+        static_cast<double>(v_hi_lo));
+    }
+
+    if (has_lo_hi && has_hi_lo && approx_eq(v_lo_hi, v_hi_lo, opts.tol)) {
+      out.emplace_back(lo, hi, v_lo_hi + v_hi_lo);
+    } else {
+      if (has_lo_hi) { out.emplace_back(lo, hi, v_lo_hi); }
+      if (has_hi_lo) { out.emplace_back(hi, lo, v_hi_lo); }
+    }
+  }
+
+  for (const auto& [rc, v] : agg) {
+    if (rc.first == rc.second) { out.emplace_back(rc.first, rc.second, v); }
+  }
+
+  std::sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
+    if (std::get<0>(a) != std::get<0>(b)) { return std::get<0>(a) < std::get<0>(b); }
+    return std::get<1>(a) < std::get<1>(b);
+  });
+
+  rows.resize(out.size());
+  cols.resize(out.size());
+  vals.resize(out.size());
+  for (size_t t = 0; t < out.size(); ++t) {
+    rows[t] = std::get<0>(out[t]);
+    cols[t] = std::get<1>(out[t]);
+    vals[t] = std::get<2>(out[t]);
+  }
+}
+
+template void canonicalize_qc_coo<int, float>(std::vector<int>&,
+                                              std::vector<int>&,
+                                              std::vector<float>&,
+                                              const qc_coo_canonicalize_options_t<float>&);
+template void canonicalize_qc_coo<int, double>(std::vector<int>&,
+                                               std::vector<int>&,
+                                               std::vector<double>&,
+                                               const qc_coo_canonicalize_options_t<double>&);
+
+}  // namespace cuopt::linear_programming::io

--- a/cpp/src/io/quadratic_constraint_coo.hpp
+++ b/cpp/src/io/quadratic_constraint_coo.hpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <cuopt/error.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace cuopt::linear_programming::io {
+
+/**
+ * @brief Options for quadratic-constraint Q COO canonicalization.
+ *
+ * Internal storage uses one triplet per variable pair: off-diagonal cross terms store the full
+ * coefficient on x_i*x_j (e.g. -2*d for rotated SOC), not symmetric halves.
+ *
+ * Canonicalization runs at ingestion boundaries only:
+ * - MPS/LP: append_quadratic_constraint()
+ * - C API: optimization_problem add_quadratic_constraint()
+ * - Python view -> solver: populate_from_data_model_view()
+ * - gRPC decode: before set_quadratic_constraints()
+ * - MPS export: mps_writer QCMATRIX emission
+ */
+template <typename f_t>
+struct qc_coo_canonicalize_options_t {
+  /** When true (MPS QCMATRIX), every off-diagonal pair must appear symmetrically in the input. */
+  bool require_symmetric_offdiagonal_pairs{false};
+  f_t tol{1e-12};
+  std::string constraint_name{};
+};
+
+/**
+ * @brief Canonicalize quadratic-constraint Q in COO form.
+ *
+ * - Merges duplicate (row, col) indices by summing coefficients.
+ * - Collapses symmetric off-diagonal pairs (a,b,v)+(b,a,v) into a single (min,max,2v) entry.
+ * - Leaves genuinely unsymmetric pairs as separate entries (general convex quadratics).
+ * - Sorts output by (row, col).
+ */
+template <typename i_t, typename f_t>
+void canonicalize_qc_coo(std::vector<i_t>& rows,
+                         std::vector<i_t>& cols,
+                         std::vector<f_t>& vals,
+                         const qc_coo_canonicalize_options_t<f_t>& opts = {});
+
+/** Canonicalize Q on a constraint entry with rows/cols/vals and constraint_row_name. */
+template <typename QC>
+void canonicalize_qc_entry(QC& qc, bool require_symmetric_offdiagonal_pairs = false)
+{
+  using f_t = typename std::decay_t<decltype(qc.vals)>::value_type;
+  qc_coo_canonicalize_options_t<f_t> opts;
+  opts.require_symmetric_offdiagonal_pairs = require_symmetric_offdiagonal_pairs;
+  opts.constraint_name                     = qc.constraint_row_name;
+  canonicalize_qc_coo(qc.rows, qc.cols, qc.vals, opts);
+}
+
+}  // namespace cuopt::linear_programming::io

--- a/cpp/src/pdlp/cpu_optimization_problem.cpp
+++ b/cpp/src/pdlp/cpu_optimization_problem.cpp
@@ -14,6 +14,7 @@
 
 #include <cuopt/linear_programming/io/writer.hpp>
 #include <mip_heuristics/mip_constants.hpp>
+#include <quadratic_constraint_coo.hpp>
 #include <utilities/logger.hpp>
 
 #include <algorithm>
@@ -171,6 +172,7 @@ void cpu_optimization_problem_t<i_t, f_t>::add_quadratic_constraint(
   qc.vals.assign(coeff.begin(), coeff.end());
   qc.linear_values.assign(linear_values.begin(), linear_values.end());
   qc.linear_indices.assign(linear_indices.begin(), linear_indices.end());
+  io::canonicalize_qc_entry(qc);
   quadratic_constraints_.push_back(std::move(qc));
 }
 

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -10,6 +10,8 @@
 #include <cuopt/linear_programming/optimization_problem_utils.hpp>
 #include <cuopt/linear_programming/solve_remote.hpp>
 
+#include <quadratic_constraint_coo.hpp>
+
 #include <cuopt/error.hpp>
 #include <cuopt/linear_programming/csr_matrix_utils.hpp>
 #include <cuopt/linear_programming/io/writer.hpp>
@@ -242,6 +244,7 @@ void optimization_problem_t<i_t, f_t>::add_quadratic_constraint(char constraint_
   qc.vals.assign(coeff.begin(), coeff.end());
   qc.linear_values.assign(linear_values.begin(), linear_values.end());
   qc.linear_indices.assign(linear_indices.begin(), linear_indices.end());
+  io::canonicalize_qc_entry(qc);
   quadratic_constraints_.push_back(std::move(qc));
 }
 

--- a/cpp/tests/dual_simplex/unit_tests/right_looking_ldlt.cpp
+++ b/cpp/tests/dual_simplex/unit_tests/right_looking_ldlt.cpp
@@ -512,6 +512,26 @@ TEST(right_looking_ldlt, indefinite_2x2)
   EXPECT_EQ(result, INDEFINITE_MATRIX_RETURN);
 }
 
+// Test 14b: Cross-only indefinite matrix (zero diagonals, no 1x1 pivot).
+// A = [0, 2; 2, 0] has eigenvalues +2 and -2 (indefinite).
+TEST(right_looking_ldlt, indefinite_cross_only_2x2)
+{
+  const int n               = 2;
+  std::vector<double> dense = {0.0, 2.0, 2.0, 0.0};
+  auto A                    = dense_to_lower_csc(n, dense);
+
+  simplex_solver_settings_t<int, double> settings;
+  std::vector<int> perm;
+  csc_matrix_t<int, double> L(n, n, 1);
+  std::vector<double> D;
+  double work_estimate = 0;
+  double start_time    = tic();
+
+  int result = right_looking_ldlt(A, settings, 1e-12, start_time, perm, L, D, work_estimate);
+
+  EXPECT_EQ(result, INDEFINITE_MATRIX_RETURN);
+}
+
 // Test 15: Larger indefinite matrix (4x4 with mixed eigenvalues).
 // A = [2, 1, 0, 1; 1, 0, 1, 0; 0, 1, 2, -1; 1, 0, -1, -1]
 TEST(right_looking_ldlt, indefinite_4x4)

--- a/cpp/tests/linear_programming/c_api_tests/c_api_test.c
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_test.c
@@ -1540,6 +1540,7 @@ cuopt_int_t test_quadratic_constraint_problem(cuopt_int_t* termination_status_pt
   cuopt_int_t qc_row_index[] = {0, 1, 2, 3};
   cuopt_int_t qc_col_index[] = {0, 1, 2, 3};
   cuopt_float_t qc_coeff[]   = {1.0, 1.0, 1.0, -1.0};
+  // Canonical COO: diagonal tail +s and head -s (one entry per variable pair).
 
   cuopt_int_t status;
 
@@ -1635,7 +1636,7 @@ cuopt_int_t test_general_quadratic_constraint_problem(cuopt_int_t* termination_s
   //            x0 - x1 = 0
   // Q is given with only upper triangle entry for the cross term:
   //   (0,0,2), (0,1,3), (1,1,2)
-  // After symmetrization: H = [4 3; 3 4], eigenvalues 1 and 7 (PD).
+  // Hessian H = (Q + Q^T)/2 is [4 3; 3 4], eigenvalues 1 and 7 (PD).
   // With x0 = x1: quadratic = 7*x0^2 <= 1, min 2*x0 at x0 = -1/sqrt(7)
   // Optimal objective = -2/sqrt(7) ≈ -0.755929
   cuopt_int_t num_variables          = 2;
@@ -1655,7 +1656,7 @@ cuopt_int_t test_general_quadratic_constraint_problem(cuopt_int_t* termination_s
   cuopt_float_t var_upper_bounds[] = {CUOPT_INFINITY, CUOPT_INFINITY};
   char variable_types[]            = {CUOPT_CONTINUOUS, CUOPT_CONTINUOUS};
 
-  // Unsymmetric Q: only upper triangle cross term (0,1,3)
+  // Canonical COO: (0,0,2), (0,1,3), (1,1,2) — one cross coefficient on (0,1).
   cuopt_int_t qc_row_index[] = {0, 0, 1};
   cuopt_int_t qc_col_index[] = {0, 1, 1};
   cuopt_float_t qc_coeff[]   = {2.0, 3.0, 2.0};
@@ -1692,6 +1693,236 @@ cuopt_int_t test_general_quadratic_constraint_problem(cuopt_int_t* termination_s
                                        NULL,
                                        CUOPT_LESS_THAN,
                                        1.0);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error adding quadratic constraint: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptCreateSolverSettings(&settings);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating solver settings: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSetIntegerParameter(settings, CUOPT_METHOD, CUOPT_METHOD_BARRIER);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error setting barrier method: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSolve(problem, settings, &solution);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error solving problem: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetTerminationStatus(solution, termination_status_ptr);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting termination status: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveValue(solution, objective_ptr);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting objective value: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetPrimalSolution(solution, solution_values);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting primal solution: %d\n", status);
+    goto DONE;
+  }
+
+DONE:
+  cuOptDestroyProblem(&problem);
+  cuOptDestroySolverSettings(&settings);
+  cuOptDestroySolution(&solution);
+
+  return status;
+}
+
+cuopt_int_t test_rotated_soc_constraint_problem(cuopt_int_t* termination_status_ptr,
+                                                cuopt_float_t* objective_ptr,
+                                                cuopt_float_t* solution_values)
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuOptSolverSettings settings     = NULL;
+  cuOptSolution solution           = NULL;
+
+  // Same as docs/cuopt-c/convex/examples/rotated_socp_example.c:
+  //   min  x3 + x4
+  //   s.t. x1 + x2 >= 2
+  //        x1^2 + x2^2 - x3*x4 <= 0   (||tail||^2 <= x3*x4)
+  //        x3 >= 0, x4 >= 0
+  cuopt_int_t num_variables          = 4;
+  cuopt_int_t num_linear_constraints = 1;
+  cuopt_int_t objective_sense        = CUOPT_MINIMIZE;
+  cuopt_float_t objective_offset     = 0.0;
+  cuopt_float_t objective_coefficients[] = {0.0, 0.0, 1.0, 1.0};
+
+  cuopt_int_t row_offsets[]    = {0, 2};
+  cuopt_int_t column_indices[] = {0, 1};
+  cuopt_float_t values[]       = {1.0, 1.0};
+
+  cuopt_float_t constraint_bounds[] = {2.0};
+  char constraint_sense[]           = {CUOPT_GREATER_THAN};
+
+  cuopt_float_t var_lower_bounds[] = {-CUOPT_INFINITY, -CUOPT_INFINITY, 0.0, 0.0};
+  cuopt_float_t var_upper_bounds[] = {
+    CUOPT_INFINITY, CUOPT_INFINITY, CUOPT_INFINITY, CUOPT_INFINITY};
+  char variable_types[] = {CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS};
+
+  // Canonical cross term Q[x3, x4] = -1 (not MPS symmetric halves).
+  cuopt_int_t qc_row_index[] = {0, 1, 2};
+  cuopt_int_t qc_col_index[] = {0, 1, 3};
+  cuopt_float_t qc_coeff[]   = {1.0, 1.0, -1.0};
+
+  cuopt_int_t status;
+
+  status = cuOptCreateProblem(num_linear_constraints,
+                              num_variables,
+                              objective_sense,
+                              objective_offset,
+                              objective_coefficients,
+                              row_offsets,
+                              column_indices,
+                              values,
+                              constraint_sense,
+                              constraint_bounds,
+                              var_lower_bounds,
+                              var_upper_bounds,
+                              variable_types,
+                              &problem);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating problem: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptAddQuadraticConstraint(problem,
+                                       3,
+                                       qc_row_index,
+                                       qc_col_index,
+                                       qc_coeff,
+                                       0,
+                                       NULL,
+                                       NULL,
+                                       CUOPT_LESS_THAN,
+                                       0.0);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error adding quadratic constraint: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptCreateSolverSettings(&settings);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating solver settings: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSetIntegerParameter(settings, CUOPT_METHOD, CUOPT_METHOD_BARRIER);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error setting barrier method: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSolve(problem, settings, &solution);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error solving problem: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetTerminationStatus(solution, termination_status_ptr);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting termination status: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveValue(solution, objective_ptr);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting objective value: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetPrimalSolution(solution, solution_values);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting primal solution: %d\n", status);
+    goto DONE;
+  }
+
+DONE:
+  cuOptDestroyProblem(&problem);
+  cuOptDestroySolverSettings(&settings);
+  cuOptDestroySolution(&solution);
+
+  return status;
+}
+
+cuopt_int_t test_rotated_soc_standard_cross_term_problem(cuopt_int_t* termination_status_ptr,
+                                                         cuopt_float_t* objective_ptr,
+                                                         cuopt_float_t* solution_values)
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuOptSolverSettings settings     = NULL;
+  cuOptSolution solution           = NULL;
+
+  // Standard Lorentz rotated cone ||tail||^2 <= 2*x3*x4 written as
+  // x1^2 + x2^2 - 2*x3*x4 <= 0 with canonical cross Q[x3, x4] = -2.
+  //   min  x3 + x4
+  //   s.t. x1 + x2 >= 2, x3 >= 0, x4 >= 0
+  cuopt_int_t num_variables          = 4;
+  cuopt_int_t num_linear_constraints = 1;
+  cuopt_int_t objective_sense        = CUOPT_MINIMIZE;
+  cuopt_float_t objective_offset     = 0.0;
+  cuopt_float_t objective_coefficients[] = {0.0, 0.0, 1.0, 1.0};
+
+  cuopt_int_t row_offsets[]    = {0, 2};
+  cuopt_int_t column_indices[] = {0, 1};
+  cuopt_float_t values[]       = {1.0, 1.0};
+
+  cuopt_float_t constraint_bounds[] = {2.0};
+  char constraint_sense[]           = {CUOPT_GREATER_THAN};
+
+  cuopt_float_t var_lower_bounds[] = {-CUOPT_INFINITY, -CUOPT_INFINITY, 0.0, 0.0};
+  cuopt_float_t var_upper_bounds[] = {
+    CUOPT_INFINITY, CUOPT_INFINITY, CUOPT_INFINITY, CUOPT_INFINITY};
+  char variable_types[] = {CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS};
+
+  cuopt_int_t qc_row_index[] = {0, 1, 2};
+  cuopt_int_t qc_col_index[] = {0, 1, 3};
+  cuopt_float_t qc_coeff[]   = {1.0, 1.0, -2.0};
+
+  cuopt_int_t status;
+
+  status = cuOptCreateProblem(num_linear_constraints,
+                              num_variables,
+                              objective_sense,
+                              objective_offset,
+                              objective_coefficients,
+                              row_offsets,
+                              column_indices,
+                              values,
+                              constraint_sense,
+                              constraint_bounds,
+                              var_lower_bounds,
+                              var_upper_bounds,
+                              variable_types,
+                              &problem);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating problem: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptAddQuadraticConstraint(problem,
+                                       3,
+                                       qc_row_index,
+                                       qc_col_index,
+                                       qc_coeff,
+                                       0,
+                                       NULL,
+                                       NULL,
+                                       CUOPT_LESS_THAN,
+                                       0.0);
   if (status != CUOPT_SUCCESS) {
     printf("Error adding quadratic constraint: %d\n", status);
     goto DONE;

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -256,6 +256,39 @@ TEST(c_api, test_general_quadratic_constraint_problem)
   EXPECT_NEAR(solution_values[1], -1.0 / sqrt(7.0), 1e-4);
 }
 
+TEST(c_api, test_rotated_soc_constraint_problem)
+{
+  cuopt_int_t termination_status;
+  cuopt_float_t objective;
+  cuopt_float_t solution_values[4];
+  EXPECT_EQ(test_rotated_soc_constraint_problem(&termination_status, &objective, solution_values),
+            CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERMINATION_STATUS_OPTIMAL);
+  // Optimal: x1 = x2 = 1, x3 = x4 = sqrt(2), obj = 2*sqrt(2)
+  EXPECT_NEAR(objective, 2.0 * sqrt(2.0), 1e-4);
+  EXPECT_NEAR(solution_values[0], 1.0, 1e-4);
+  EXPECT_NEAR(solution_values[1], 1.0, 1e-4);
+  EXPECT_NEAR(solution_values[2], sqrt(2.0), 1e-4);
+  EXPECT_NEAR(solution_values[3], sqrt(2.0), 1e-4);
+}
+
+TEST(c_api, test_rotated_soc_standard_cross_term_problem)
+{
+  cuopt_int_t termination_status;
+  cuopt_float_t objective;
+  cuopt_float_t solution_values[4];
+  EXPECT_EQ(
+    test_rotated_soc_standard_cross_term_problem(&termination_status, &objective, solution_values),
+    CUOPT_SUCCESS);
+  EXPECT_EQ(termination_status, CUOPT_TERMINATION_STATUS_OPTIMAL);
+  // ||tail||^2 <= 2*x3*x4 with canonical Q[x3,x4] = -2: x1 = x2 = x3 = x4 = 1, obj = 2
+  EXPECT_NEAR(objective, 2.0, 1e-4);
+  EXPECT_NEAR(solution_values[0], 1.0, 1e-4);
+  EXPECT_NEAR(solution_values[1], 1.0, 1e-4);
+  EXPECT_NEAR(solution_values[2], 1.0, 1e-4);
+  EXPECT_NEAR(solution_values[3], 1.0, 1e-4);
+}
+
 TEST(c_api, test_write_problem)
 {
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
@@ -45,6 +45,12 @@ cuopt_int_t test_quadratic_constraint_problem(cuopt_int_t* termination_status_pt
 cuopt_int_t test_general_quadratic_constraint_problem(cuopt_int_t* termination_status_ptr,
                                                       cuopt_float_t* objective_ptr,
                                                       cuopt_float_t* solution_values);
+cuopt_int_t test_rotated_soc_constraint_problem(cuopt_int_t* termination_status_ptr,
+                                                cuopt_float_t* objective_ptr,
+                                                cuopt_float_t* solution_values);
+cuopt_int_t test_rotated_soc_standard_cross_term_problem(cuopt_int_t* termination_status_ptr,
+                                                         cuopt_float_t* objective_ptr,
+                                                         cuopt_float_t* solution_values);
 cuopt_int_t test_write_problem(const char* input_filename, const char* output_filename);
 cuopt_int_t test_maximize_problem_dual_variables(cuopt_int_t method,
                                                  cuopt_int_t* termination_status_ptr,

--- a/cpp/tests/linear_programming/parser_test.cpp
+++ b/cpp/tests/linear_programming/parser_test.cpp
@@ -11,6 +11,7 @@
 #include <cuopt/linear_programming/io/mps_writer.hpp>
 #include <cuopt/linear_programming/io/parser.hpp>
 #include <mps_parser_internal.hpp>
+#include <quadratic_constraint_coo.hpp>
 
 #include <gtest/gtest.h>
 
@@ -2163,10 +2164,10 @@ End
   EXPECT_NEAR(qc.vals[1], 1.0, tolerance);
 }
 
-TEST(lp_parser, qc_cross_term_splits_symmetrically)
+TEST(lp_parser, qc_cross_term_stored_canonical)
 {
-  // `4 x*y` in the LP source means coefficient on x_i * x_j = 4 in the
-  // symmetric x^T Q x. Split into Q[x,y] = Q[y,x] = 2 in the CSR.
+  // `4 x*y` in the LP source means coefficient on x_i * x_j = 4 in x^T Q x.
+  // Canonical storage keeps one upper-triangular cross entry (0, 1, 4).
   auto m = read_lp_string(R"LP(
 Minimize
   x + y
@@ -2176,14 +2177,12 @@ End
 )LP");
   ASSERT_EQ(m.get_quadratic_constraints().size(), 1u);
   const auto& qc = nth_qc(m, 0);
-  // Q has 4 entries (all of [[1,2],[2,1]]) stored as COO triplets.
-  EXPECT_EQ(qc.rows, (std::vector<int>{0, 0, 1, 1}));
-  EXPECT_EQ(qc.cols, (std::vector<int>{0, 1, 0, 1}));
-  ASSERT_EQ(qc.vals.size(), 4u);
+  EXPECT_EQ(qc.rows, (std::vector<int>{0, 0, 1}));
+  EXPECT_EQ(qc.cols, (std::vector<int>{0, 1, 1}));
+  ASSERT_EQ(qc.vals.size(), 3u);
   EXPECT_NEAR(qc.vals[0], 1.0, tolerance);  // (0, 0)
-  EXPECT_NEAR(qc.vals[1], 2.0, tolerance);  // (0, 1)
-  EXPECT_NEAR(qc.vals[2], 2.0, tolerance);  // (1, 0)
-  EXPECT_NEAR(qc.vals[3], 1.0, tolerance);  // (1, 1)
+  EXPECT_NEAR(qc.vals[1], 4.0, tolerance);  // (0, 1)
+  EXPECT_NEAR(qc.vals[2], 1.0, tolerance);  // (1, 1)
 }
 
 TEST(lp_parser, qc_linear_and_quadratic_mixed)
@@ -2723,6 +2722,60 @@ TEST(mps_bounds, invalid_bound_type)
   ASSERT_THROW(read_from_mps("linear_programming/bad-mps-bound-1.mps", false), std::logic_error);
 }
 
+TEST(qc_coo_canonicalize, merges_duplicate_entries)
+{
+  std::vector<int> rows    = {0, 0};
+  std::vector<int> cols    = {1, 1};
+  std::vector<double> vals = {2.0, 3.0};
+  canonicalize_qc_coo(rows, cols, vals);
+  ASSERT_EQ(rows.size(), 1u);
+  EXPECT_EQ(rows[0], 0);
+  EXPECT_EQ(cols[0], 1);
+  EXPECT_NEAR(vals[0], 5.0, tolerance);
+}
+
+TEST(qc_coo_canonicalize, collapses_symmetric_mps_halves)
+{
+  std::vector<int> rows    = {0, 1};
+  std::vector<int> cols    = {1, 0};
+  std::vector<double> vals = {2.0, 2.0};
+  qc_coo_canonicalize_options_t<double> opts;
+  opts.require_symmetric_offdiagonal_pairs = true;
+  opts.constraint_name                     = "QC0";
+  canonicalize_qc_coo(rows, cols, vals, opts);
+  ASSERT_EQ(rows.size(), 1u);
+  EXPECT_EQ(rows[0], 0);
+  EXPECT_EQ(cols[0], 1);
+  EXPECT_NEAR(vals[0], 4.0, tolerance);
+}
+
+TEST(qc_coo_canonicalize, keeps_genuinely_unsymmetric_pairs)
+{
+  std::vector<int> rows    = {0, 1};
+  std::vector<int> cols    = {1, 0};
+  std::vector<double> vals = {2.0, 3.0};
+  // Default opts (API path): do not collapse mismatched off-diagonal halves.
+  canonicalize_qc_coo(rows, cols, vals);
+  ASSERT_EQ(rows.size(), 2u);
+  EXPECT_EQ(rows[0], 0);
+  EXPECT_EQ(cols[0], 1);
+  EXPECT_NEAR(vals[0], 2.0, tolerance);
+  EXPECT_EQ(rows[1], 1);
+  EXPECT_EQ(cols[1], 0);
+  EXPECT_NEAR(vals[1], 3.0, tolerance);
+}
+
+TEST(qc_coo_canonicalize, mps_requires_matching_symmetric_half)
+{
+  std::vector<int> rows    = {0};
+  std::vector<int> cols    = {1};
+  std::vector<double> vals = {2.0};
+  qc_coo_canonicalize_options_t<double> opts;
+  opts.require_symmetric_offdiagonal_pairs = true;
+  opts.constraint_name                     = "QC0";
+  EXPECT_THROW(canonicalize_qc_coo(rows, cols, vals, opts), std::logic_error);
+}
+
 TEST(qps_parser, qcmatrix_append_api)
 {
   using model_t = mps_data_model_t<int, double>;
@@ -2738,10 +2791,10 @@ TEST(qps_parser, qcmatrix_append_api)
   EXPECT_TRUE(default_qcm.linear_indices.empty());
   EXPECT_EQ(0.0, default_qcm.rhs_value);
 
-  // QC0: [[10, 2], [2, 2]]
-  const std::vector<double> qc0_values        = {10.0, 2.0, 2.0, 2.0};
-  const std::vector<int> qc0_row_indices      = {0, 0, 1, 1};
-  const std::vector<int> qc0_col_indices      = {0, 1, 0, 1};
+  // MPS-style symmetric halves [[10, 2], [2, 2]] -> canonical (0,0,10), (0,1,4), (1,1,2)
+  const std::vector<double> mps_qc0_values    = {10.0, 2.0, 2.0, 2.0};
+  const std::vector<int> mps_qc0_row_indices  = {0, 0, 1, 1};
+  const std::vector<int> mps_qc0_col_indices  = {0, 1, 0, 1};
   const std::vector<double> qc0_linear_values = {1.0, 1.0};
   const std::vector<int> qc0_linear_indices   = {0, 1};
   model.append_quadratic_constraint(0,
@@ -2750,14 +2803,15 @@ TEST(qps_parser, qcmatrix_append_api)
                                     qc0_linear_values,
                                     qc0_linear_indices,
                                     5.0,
-                                    qc0_values,
-                                    qc0_row_indices,
-                                    qc0_col_indices);
+                                    mps_qc0_values,
+                                    mps_qc0_row_indices,
+                                    mps_qc0_col_indices,
+                                    true);
 
-  // QC1: [[4, 1], [1, 6]]
-  const std::vector<double> qc1_values        = {4.0, 1.0, 1.0, 6.0};
-  const std::vector<int> qc1_row_indices      = {0, 0, 1, 1};
-  const std::vector<int> qc1_col_indices      = {0, 1, 0, 1};
+  // API-style canonical COO [[4, 2], [2, 6]] -> stored unchanged after merge/sort
+  const std::vector<double> api_qc1_values    = {4.0, 2.0, 6.0};
+  const std::vector<int> api_qc1_row_indices  = {0, 0, 1};
+  const std::vector<int> api_qc1_col_indices  = {0, 1, 1};
   const std::vector<double> qc1_linear_values = {3.0, 1.0};
   const std::vector<int> qc1_linear_indices   = {0, 1};
   model.append_quadratic_constraint(1,
@@ -2766,13 +2820,17 @@ TEST(qps_parser, qcmatrix_append_api)
                                     qc1_linear_values,
                                     qc1_linear_indices,
                                     10.0,
-                                    qc1_values,
-                                    qc1_row_indices,
-                                    qc1_col_indices);
+                                    api_qc1_values,
+                                    api_qc1_row_indices,
+                                    api_qc1_col_indices);
 
   ASSERT_TRUE(model.has_quadratic_constraints());
   const auto& qcs = model.get_quadratic_constraints();
   ASSERT_EQ(2u, qcs.size());
+
+  const std::vector<double> qc0_canon_vals     = {10.0, 4.0, 2.0};
+  const std::vector<int> qc0_canon_row_indices = {0, 0, 1};
+  const std::vector<int> qc0_canon_col_indices = {0, 1, 1};
 
   EXPECT_EQ(0, qcs[0].constraint_row_index);
   EXPECT_EQ("QC0", qcs[0].constraint_row_name);
@@ -2780,9 +2838,9 @@ TEST(qps_parser, qcmatrix_append_api)
   EXPECT_EQ(qc0_linear_values, qcs[0].linear_values);
   EXPECT_EQ(qc0_linear_indices, qcs[0].linear_indices);
   EXPECT_EQ(5.0, qcs[0].rhs_value);
-  EXPECT_EQ(qc0_values, qcs[0].vals);
-  EXPECT_EQ(qc0_row_indices, qcs[0].rows);
-  EXPECT_EQ(qc0_col_indices, qcs[0].cols);
+  EXPECT_EQ(qc0_canon_vals, qcs[0].vals);
+  EXPECT_EQ(qc0_canon_row_indices, qcs[0].rows);
+  EXPECT_EQ(qc0_canon_col_indices, qcs[0].cols);
 
   EXPECT_EQ(1, qcs[1].constraint_row_index);
   EXPECT_EQ("QC1", qcs[1].constraint_row_name);
@@ -2790,9 +2848,25 @@ TEST(qps_parser, qcmatrix_append_api)
   EXPECT_EQ(qc1_linear_values, qcs[1].linear_values);
   EXPECT_EQ(qc1_linear_indices, qcs[1].linear_indices);
   EXPECT_EQ(10.0, qcs[1].rhs_value);
-  EXPECT_EQ(qc1_values, qcs[1].vals);
-  EXPECT_EQ(qc1_row_indices, qcs[1].rows);
-  EXPECT_EQ(qc1_col_indices, qcs[1].cols);
+  EXPECT_EQ(api_qc1_values, qcs[1].vals);
+  EXPECT_EQ(api_qc1_row_indices, qcs[1].rows);
+  EXPECT_EQ(api_qc1_col_indices, qcs[1].cols);
+
+  // Missing symmetric half is rejected when require_symmetric_q_offdiagonal=true.
+  const std::vector<double> bad_values   = {2.0};
+  const std::vector<int> bad_row_indices = {0};
+  const std::vector<int> bad_col_indices = {1};
+  EXPECT_THROW(model.append_quadratic_constraint(2,
+                                                 "QC_bad",
+                                                 'L',
+                                                 std::vector<double>{},
+                                                 std::vector<int>{},
+                                                 0.0,
+                                                 bad_values,
+                                                 bad_row_indices,
+                                                 bad_col_indices,
+                                                 true),
+               std::logic_error);
 }
 
 // QCQP MPS: each quadratic constraint bundles row + linear + rhs + quadratic.

--- a/cpp/tests/socp/general_quadratic_test.cu
+++ b/cpp/tests/socp/general_quadratic_test.cu
@@ -742,16 +742,15 @@ TEST(general_quadratic, rotated_soc_heads_nonneg_accepted)
   user_problem.num_range_rows = 0;
   user_problem.var_types.assign(n, variable_type_t::CONTINUOUS);
 
-  // Q COO: x0^2 + x1^2 - 2*y*z <= 0
-  // Diagonal: (0,0,1), (1,1,1). Off-diagonal: (2,3,-1), (3,2,-1)
+  // Q COO: x0^2 + x1^2 - 2*y*z <= 0 (canonical single cross term)
   qc_t qc;
   qc.constraint_row_index = 0;
   qc.constraint_row_name  = "rsoc_valid";
   qc.constraint_row_type  = 'L';
   qc.rhs_value            = 0.0;
-  qc.rows                 = {0, 1, 2, 3};
-  qc.cols                 = {0, 1, 3, 2};
-  qc.vals                 = {1.0, 1.0, -1.0, -1.0};
+  qc.rows                 = {0, 1, 2};
+  qc.cols                 = {0, 1, 3};
+  qc.vals                 = {1.0, 1.0, -2.0};
 
   dual_simplex::csr_matrix_t<i_t, f_t> csr_A(m, n, nz);
   csr_A.m         = m;
@@ -806,9 +805,9 @@ TEST(general_quadratic, rotated_soc_heads_free_rejected)
   qc.constraint_row_name  = "rsoc_invalid";
   qc.constraint_row_type  = 'L';
   qc.rhs_value            = 0.0;
-  qc.rows                 = {0, 1, 2, 3};
-  qc.cols                 = {0, 1, 3, 2};
-  qc.vals                 = {1.0, 1.0, -1.0, -1.0};
+  qc.rows                 = {0, 1, 2};
+  qc.cols                 = {0, 1, 3};
+  qc.vals                 = {1.0, 1.0, -2.0};
 
   dual_simplex::csr_matrix_t<i_t, f_t> csr_A(m, n, nz);
   csr_A.m         = m;

--- a/cpp/tests/socp/general_quadratic_test.cu
+++ b/cpp/tests/socp/general_quadratic_test.cu
@@ -207,6 +207,59 @@ TEST(general_quadratic, rejects_non_convex)
     cuopt::logic_error);
 }
 
+// Test: cross-only indefinite Q (issue #1434). H = [[0, 2]; [2, 0]] has zero diagonals so LDLT
+// returns rank 0 without a negative pivot; must still be rejected as non-convex.
+TEST(general_quadratic, rejects_cross_only_indefinite)
+{
+  raft::handle_t handle{};
+  init_handler(&handle);
+
+  using namespace cuopt::linear_programming::dual_simplex;
+  user_problem_t<i_t, f_t> user_problem(&handle);
+
+  constexpr int m  = 0;
+  constexpr int n  = 2;
+  constexpr int nz = 0;
+
+  user_problem.num_rows  = m;
+  user_problem.num_cols  = n;
+  user_problem.objective = {1.0, 1.0};
+
+  user_problem.A.m      = m;
+  user_problem.A.n      = n;
+  user_problem.A.nz_max = nz;
+  user_problem.A.reallocate(nz);
+  user_problem.A.col_start = {0, 0, 0};
+
+  user_problem.rhs.clear();
+  user_problem.row_sense.clear();
+  user_problem.lower          = {-1.0, -1.0};
+  user_problem.upper          = {1.0, 1.0};
+  user_problem.num_range_rows = 0;
+  user_problem.var_types.assign(n, variable_type_t::CONTINUOUS);
+
+  // Q COO: (0,1,2) → 2*x0*x1 <= 0.5, H = [[0, 2]; [2, 0]]
+  qc_t qc;
+  qc.constraint_row_index = 0;
+  qc.constraint_row_name  = "cross_only_indefinite";
+  qc.constraint_row_type  = 'L';
+  qc.rhs_value            = 0.5;
+  qc.rows                 = {0};
+  qc.cols                 = {1};
+  qc.vals                 = {2.0};
+
+  dual_simplex::csr_matrix_t<i_t, f_t> csr_A(m, n, nz);
+  csr_A.m         = m;
+  csr_A.n         = n;
+  csr_A.row_start = {0};
+
+  std::vector<qc_t> qcs = {qc};
+
+  EXPECT_THROW(
+    (convert_quadratic_constraints_to_second_order_cones<i_t, f_t>(n, qcs, csr_A, user_problem)),
+    cuopt::logic_error);
+}
+
 // Test: rank-deficient PSD Q (e.g., Q = v*v^T with v = [1, 1])
 // minimize x0 + x1
 // subject to (x0 + x1)^2 <= 4   (i.e., |x0 + x1| <= 2)

--- a/docs/cuopt/source/convex-features.rst
+++ b/docs/cuopt/source/convex-features.rst
@@ -157,20 +157,31 @@ Second-order cone constraints must be specified as a quadratic constraint with a
 These constraints are of the form:
 
 
-   x_2^2 + x_2^2 + ... + x_n^2 <= x_0 * x_1,  x_0 >= 0,  x_1 >= 0.
+   x_2^2 + x_3^2 + ... + x_n^2 <= 2 * x_0 * x_1,  x_0 >= 0,  x_1 >= 0.
 
 Rotated second-order cone constraints must be specified as a quadratic constraint with a bounds on the x_0 and x_1 variables:
 
 .. code-block:: text
 
-   x_2^2 + x_2^2 + ... + x_n^2 - 0.5 * x_0 * x_1 - 0.5 * x_1 * x_0 <= 0,  x_0 >= 0,  x_1 >= 0.
+   x_2^2 + x_3^2 + ... + x_n^2 - 2 * x_0 * x_1 <= 0,  x_0 >= 0,  x_1 >= 0.
 
-Note that for rotated second-order cone constraints, cuOpt expects the quadratic matrix to be symmetric.
-For any cross term, provide both ``Q_i,j`` and ``Q_j,i``. cuOpt expects only symmetric ``Q``:
+In the Python and C APIs, write the cross term naturally as ``-2 * x_0 * x_1``. MPS QCMATRIX
+files must supply symmetric halves (see the MPS examples); cuOpt canonicalizes them internally to
+one cross coefficient per variable pair.
 
 .. code-block:: text
 
-   Q[x_0, x_1] = Q[x_1, x_0] = -0.5.
+   Q[x_0, x_1] = -2 * d    (API / canonical internal form)
+
+MPS interchange format uses symmetric halves:
+
+.. code-block:: text
+
+   Q[x_0, x_1] = Q[x_1, x_0] = -d   (MPS; canonicalizes to stored ``-2*d``)
+
+For example, MPS halves ``-0.5`` give stored ``-1`` and the cone
+``||tail||^2 <= x_0 * x_1``. A single API term ``-2*x_0*x_1`` gives stored ``-2``
+and the cone ``||tail||^2 <= 2*x_0*x_1``.
 
 When any quadratic constraint is present, cuOpt automatically selects the barrier method and disables presolve optimizations that apply only to linear problems.
 
@@ -188,7 +199,7 @@ When any quadratic constraint is present, cuOpt automatically selects the barrie
 
     problem.addConstraint(x1*x1 + x2*x2 - x0*x0 <= 0, name="soc")
 
-**Python example — rotated cone** ``x_2^2 + x_3^2 <= x_0 * x_1``:
+**Python example — rotated cone** ``x_2^2 + x_3^2 <= 2 * x_0 * x_1``:
 
 .. code-block:: python
 
@@ -199,16 +210,16 @@ When any quadratic constraint is present, cuOpt automatically selects the barrie
     x3 = problem.addVariable(name="x2")
 
     problem.addConstraint(x1 + x2 >= 2)
-    # x2^2 + x3^2 <= x0 * x1. cuOpt expects a symmetric Q, so the cross term is
-    # supplied as the two equal halves -0.5*x0*x1 and -0.5*x1*x0
-    # (i.e. Q[x0,x1] = Q[x1,x0] = -0.5).
+    # x2^2 + x3^2 <= 2*x0*x1
     problem.addConstraint(
-        x2*x2 + x3*x3 - 0.5*x0*x1 - 0.5*x1*x0 <= 0, name="rotated_soc"
+        x2*x2 + x3*x3 - 2*x0*x1 <= 0, name="rotated_soc"
     )
 
 .. note::
-   cuOpt expects the quadratic matrix ``Q`` to be symmetric. Supply each cross
-   term as two equal halves, as in ``-0.5*x0*x1 - 0.5*x1*x0`` above.
+   MPS QCMATRIX files require symmetric cross-term halves; the Python and C APIs accept a single
+   cross coefficient per variable pair. Use ``-2*x0*x1`` for the standard form
+   ``||tail||^2 <= 2*x0*x1``; use ``-x0*x1`` (or MPS halves ``-0.5`` each) for
+   ``||tail||^2 <= x0*x1``.
 
 **C API:** Use :c:func:`cuOptAddQuadraticConstraint` to add convex quadratic constraints or second-order and rotated second-order cone constraints expressed as quadratic inequalities.
 

--- a/docs/cuopt/source/cuopt-c/convex/convex-c-api.rst
+++ b/docs/cuopt/source/cuopt-c/convex/convex-c-api.rst
@@ -68,9 +68,10 @@ For problems with quadratic constraints, first create a problem, and then use
    supports three types of quadratic constraints:
    - **Convex quadratic constraints** of the form ``x^T Q x + d^T x <= alpha`` where ``H=(Q+Q^T)/2`` is a symmetric positive semidefinite matrix. `Q` need not be symmetric.
    - **Second-order cone constraints** of the form ``sum_{i=1}^n x_i^2 <= x_0``, ``x_0 >= 0``
-   - **Rotated second-order cone constraints** of the form ``sum_{i=2}^n x_i^2  - 0. 5 * x_0 * x_1 - 0. 5 * x_1 * x_0 <= 0``, ``x_0 >= 0``, ``x_1 >= 0``
+   - **Rotated second-order cone constraints** of the form ``sum_{i=2}^n x_i^2 - 2 * x_0 * x_1 <= 0``, ``x_0 >= 0``, ``x_1 >= 0``
+     (supply ``Q[x_0, x_1] = -2`` in COO, or ``-x_0*x_1`` for the ``<= x_0*x_1`` cone form; see :doc:`/convex-features`)
 
-   For the rotated second-order cone constraints, cuOpt expects the quadratic matrix to be symmetric.
+   MPS QCMATRIX requires symmetric off-diagonal halves; the C API accepts a single cross coefficient per variable pair (canonicalized on ingest).
    Only ``CUOPT_LESS_THAN`` and ``CUOPT_GREATER_THAN`` sense is supported; equality constraints are not supported.
 
 A optimization problem must be destroyed with the following function

--- a/docs/cuopt/source/cuopt-c/convex/convex-examples.rst
+++ b/docs/cuopt/source/cuopt-c/convex/convex-examples.rst
@@ -269,9 +269,9 @@ Rotated Second-Order Cone Example
 ---------------------------------
 
 This example adds a **rotated** cone with :c:func:`cuOptAddQuadraticConstraint`. The
-quadratic matrix ``Q`` must be supplied **symmetrically**, so the cross term of
-``x1^2 + x2^2 <= x3*x4`` is given as the two equal off-diagonal entries
-``Q[x3, x4] = Q[x4, x3] = -0.5`` (triplets ``(2, 3, -0.5)`` and ``(3, 2, -0.5)``).
+cone ``x1^2 + x2^2 <= x3*x4`` uses the canonical cross term ``Q[x3, x4] = -1``
+(i.e. ``-x3*x4`` in ``x^T Q x``). MPS QCMATRIX uses symmetric halves instead; see
+:doc:`/convex-features` for other RSOC forms.
 It minimizes ``x3 + x4`` subject to ``x1 + x2 >= 2`` and the rotated cone.
 
 The example code is available at ``examples/cuopt-c/lp/rotated_socp_example.c`` (:download:`download <examples/rotated_socp_example.c>`):
@@ -319,7 +319,7 @@ General Convex Quadratic Constraint Example
 This example adds a general convex quadratic constraint with
 :c:func:`cuOptAddQuadraticConstraint`. Here we add the convex quadratic constraint
 ``2*x^2 + 2*x*y + 2*y^2 <= 6``. Note that the quadratic matrix Q that encodes this
-constraint need no be symmetric. Here the term ``2*x*y`` is supplied as a single entry ``Q[0,1] = 2``.
+   constraint need not be symmetric. Here the term ``2*x*y`` is supplied as a single entry ``Q[0,1] = 2``.
 
 The example code is available at ``examples/cuopt-c/lp/general_quadratic_example.c`` (:download:`download <examples/general_quadratic_example.c>`):
 
@@ -427,8 +427,8 @@ minimizes ``s + p + q`` subject to ``a + b >= 2`` and two cones:
    :language: text
    :linenos:
 
-The rotated cone's cross term is given symmetrically as the two half-entries
-``P Q -0.5`` and ``Q P -0.5`` (so that ``x^T Q x`` contributes ``-p*q``). Run it
+The rotated cone uses symmetric cross-term halves ``P Q -0.5`` and ``Q P -0.5`` in the
+QCMATRIX section. Run it
 with the same binary:
 
 .. code-block:: bash

--- a/docs/cuopt/source/cuopt-c/convex/examples/general_quadratic_example.c
+++ b/docs/cuopt/source/cuopt-c/convex/examples/general_quadratic_example.c
@@ -10,9 +10,9 @@
  * then the quadratic constraint is added with cuOptAddQuadraticConstraint.
  *
  * Q may be any matrix whose symmetric part (Q + Q^T)/2 is positive semidefinite.
- * Note that Q need not be supplied symmetrically: here the cross term 2*x*y is
- * given as the single off-diagonal entry Q[0,1] = 2; cuOpt symmetrizes Q
- * internally automatically.
+ * Q need not be supplied symmetrically: here the cross term 2*x*y is given as
+ * one canonical COO entry Q[0,1] = 2 (full coefficient on x*y, canonicalized
+ * on ingest).
  *
  * Problem:
  *   minimize    x + y
@@ -77,10 +77,8 @@ cuopt_int_t test_general_quadratic()
   cuopt_float_t var_upper_bounds[] = {CUOPT_INFINITY, CUOPT_INFINITY};
   char variable_types[]            = {CUOPT_CONTINUOUS, CUOPT_CONTINUOUS};
 
-  // General convex quadratic constraint 2*x^2 + 2*x*y + 2*y^2 <= 6, given as the
-  // quadratic matrix Q in coordinate (triplet) form. The cross term 2*x*y is
-  // supplied as the single entry Q[0,1] = 2 (Q need not be symmetric; cuOpt
-  // symmetrizes it internally).
+  // General convex quadratic constraint 2*x^2 + 2*x*y + 2*y^2 <= 6 in canonical
+  // COO form. The cross term 2*x*y is one entry Q[0,1] = 2 (not MPS halves).
   cuopt_int_t q_row_index[]  = {0, 1, 0};
   cuopt_int_t q_col_index[]  = {0, 1, 1};
   cuopt_float_t q_coeff[]    = {2.0, 2.0, 2.0};

--- a/docs/cuopt/source/cuopt-c/convex/examples/rotated_socp_example.c
+++ b/docs/cuopt/source/cuopt-c/convex/examples/rotated_socp_example.c
@@ -5,19 +5,16 @@
 /*
  * Rotated SOCP C API Example
  *
- * Demonstrates a rotated second-order cone with the cuOpt C API. A linear
- * problem is created with cuOptCreateProblem, then a rotated cone is added with
- * cuOptAddQuadraticConstraint.
- *
- * The quadratic matrix Q must be supplied symmetrically: the cross term of a
- * rotated cone is given as the two equal off-diagonal entries
- * Q[x3, x4] = Q[x4, x3] = -0.5, so that x^T Q x contributes -x3*x4.
+ * Demonstrates a rotated second-order cone with the cuOpt C API.
  *
  * Problem:
  *   minimize    x3 + x4
  *   subject to  x1 + x2 >= 2
- *               x1^2 + x2^2 - x3*x4 <= 0
+ *               x1^2 + x2^2 <= x3*x4
  *               x3 >= 0, x4 >= 0,  x1, x2 free
+ *
+ * The cone cross term is supplied as one canonical COO entry
+ * Q[x3, x4] = -1 (i.e. -x3*x4 in x^T Q x for ||tail||^2 <= x3*x4).
  *
  * Optimal: x1 = x2 = 1, x3 = x4 = sqrt(2) ~= 1.414214, objective = 2*sqrt(2) ~= 2.828427.
  *
@@ -79,12 +76,10 @@ cuopt_int_t test_rotated_socp()
   char variable_types[] = {
     CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS, CUOPT_CONTINUOUS};
 
-  // Rotated cone x1^2 + x2^2 - x3*x4 <= 0, supplied as a symmetric quadratic
-  // matrix Q in coordinate (triplet) form. The cross term is split into the two
-  // equal off-diagonal entries Q[x3, x4] = Q[x4, x3] = -0.5. rhs must be 0.
-  cuopt_int_t q_row_index[]  = {0, 1, 2, 3};
-  cuopt_int_t q_col_index[]  = {0, 1, 3, 2};
-  cuopt_float_t q_coeff[]    = {1.0, 1.0, -0.5, -0.5};
+  // Rotated cone x1^2 + x2^2 <= x3*x4 (canonical cross term Q[x3,x4] = -1).
+  cuopt_int_t q_row_index[]  = {0, 1, 2};
+  cuopt_int_t q_col_index[]  = {0, 1, 3};
+  cuopt_float_t q_coeff[]    = {1.0, 1.0, -1.0};
 
   cuopt_int_t status;
   cuopt_float_t time;
@@ -116,7 +111,7 @@ cuopt_int_t test_rotated_socp()
 
   // Add the rotated second-order cone constraint (no linear term, rhs = 0)
   status = cuOptAddQuadraticConstraint(problem,
-                                       4,  // number of quadratic entries
+                                       3,  // number of quadratic entries
                                        q_row_index,
                                        q_col_index,
                                        q_coeff,

--- a/docs/cuopt/source/cuopt-python/convex/convex-examples.rst
+++ b/docs/cuopt/source/cuopt-python/convex/convex-examples.rst
@@ -83,10 +83,9 @@ Second-Order Cone Programming with Rotated Second-Order Cones Example
 
 :download:`rotated_socp_example.py <examples/rotated_socp_example.py>`
 
-This example solves a **rotated** second-order cone ``x1^2 + x2^2 <= x3 * x4, x3 >= 0, x4 >= 0``. For rotated cones, cuOpt expects a
-symmetric quadratic matrix ``Q``, so the cross term is supplied as the two equal
-halves ``-0.5*x3*x4`` and ``-0.5*x4*x3``. It minimizes ``x3 + x4`` subject to
-``x1 + x2 >= 2``.
+This example solves a **rotated** second-order cone ``x1^2 + x2^2 <= x3 * x4, x3 >= 0, x4 >= 0``.
+The cross term is written as ``-x3*x4``. See :doc:`/convex-features` for other RSOC forms.
+It minimizes ``x3 + x4`` subject to ``x1 + x2 >= 2``.
 
 .. literalinclude:: examples/rotated_socp_example.py
    :language: python

--- a/docs/cuopt/source/cuopt-python/convex/examples/rotated_socp_example.py
+++ b/docs/cuopt/source/cuopt-python/convex/examples/rotated_socp_example.py
@@ -14,11 +14,7 @@ Problem:
                 x1^2 + x2^2 <= x3 * x4     (rotated second-order cone)
                 x3 >= 0, x4 >= 0
 
-The rotated cone is supplied as the quadratic inequality
-``x1^2 + x2^2 - 0.5 * x3*x4 - 0.5 * x4*x3 <= 0``. cuOpt expects a symmetric quadratic matrix ``Q``,
-so the cross term is split into the two equal halves ``-0.5*x3*x4`` and
-``-0.5*x4*x3`` (i.e. ``Q[x3, x4] = Q[x4, x3] = -0.5``). cuOpt detects the
-second-order cone structure and solves with the barrier method.
+The rotated cone is written as ``x1^2 + x2^2 - x3*x4 <= 0``.
 
 Optimal solution: x1 = x2 = 1, x3 = x4 = sqrt(2) ~= 1.4142, objective ~= 2.8284.
 """
@@ -41,10 +37,9 @@ def main():
     # Linear constraint
     prob.addConstraint(x1 + x2 >= 2)
 
-    # Rotated cone x1^2 + x2^2 <= x3 * x4. The quadratic matrix must be
-    # symmetric, so the cross term is supplied as two equal halves.
+    # x1^2 + x2^2 <= x3*x4
     prob.addConstraint(
-        x1 * x1 + x2 * x2 - 0.5 * x3 * x4 - 0.5 * x4 * x3 <= 0,
+        x1 * x1 + x2 * x2 - x3 * x4 <= 0,
         name="rotated_soc",
     )
 

--- a/python/cuopt/cuopt/tests/socp/test_socp.py
+++ b/python/cuopt/cuopt/tests/socp/test_socp.py
@@ -173,9 +173,9 @@ def test_general_quadratic_unsymmetric():
     s.t. 2*x0^2 + 3*x0*x1 + 2*x1^2 <= 1  (unsymmetric Q: cross term only as x0*x1)
          x0 - x1 = 0
 
-    Q is given unsymmetrically: the 3*x0*x1 term is stored as a single
-    entry (row=0, col=1, val=3) rather than symmetric (0,1,1.5)+(1,0,1.5).
-    After symmetrization H = [4 3; 3 4], eigenvalues 1 and 7 (PD).
+    Q is given unsymmetrically: the 3*x0*x1 term is one canonical cross entry
+    (not duplicate COO halves). Hessian H = (Q + Q^T)/2 is [4 3; 3 4],
+    eigenvalues 1 and 7 (PD).
 
     With x0 = x1 = t: 2t^2 + 3t^2 + 2t^2 = 7t^2 <= 1
     min 2t at t = -1/sqrt(7), obj = -2/sqrt(7) ≈ -0.755929


### PR DESCRIPTION
## Description

This PR fixes two related QCQP input / conversion bugs:

**#1435 — Canonical quadratic-constraint Q COO and RSOC detection**

Quadratic-constraint `Q` is now stored in **canonical COO** internally: one coefficient per variable pair (e.g. a single `-2` for `2·x₀·x₁`), with symmetric MPS halves merged at ingest. Canonicalization runs at ingest boundaries (MPS/LP parser, C API, Python→solver, gRPC, PDLP CPU/GPU problem setup). MPS `QCMATRIX` still accepts symmetric halves; the MPS writer expands canonical cross terms back to symmetric form on export.

The RSOC fast path now accepts a single eligible cross term (e.g. `-2·t·u` for `||tail||² ≤ 2·t·u`) instead of requiring two symmetric off-diagonal entries. Previously, natural Python/API forms were misrouted to the general path or failed pattern matching, producing wrong optima (e.g. ~0 instead of √2).

**#1434 — Reject nonconvex quadratics on the general path**

Cross-only indefinite constraints (e.g. `2·x₀·x₁ ≤ 0.5` with `H = [[0,2],[2,0]]`) previously passed convexity checks: diagonal LDLT returned `rank = 0` without `INDEFINITE_MATRIX_RETURN`, and a degenerate `r = 0` SOC lift silently dropped the quadratic term (wrong optimum reported as Optimal).

Fixes:
- `right_looking_ldlt`: return `INDEFINITE_MATRIX_RETURN` when factorization stalls at `rank = 0` on a nonzero matrix.
- `translate_soc.hpp` (general path): `cuopt_expects(rank >= 1, …)` before building the SOC lift.

Adds LDLT and SOC-conversion unit tests for the cross-only indefinite case.

## Issue

closes #1435
closes #1434

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [x] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [x] Added new documentation
   - [ ] NA

## Test plan

- [ ] `./build.sh libcuopt` with conda env active, then verify `cuopt_cli` uses installed `libcuopt` from `$CONDA_PREFIX`
- [ ] C++: `ctest --test-dir cpp/build -R 'DUAL_SIMPLEX_TEST|SOCP_TEST|MPS_PARSER_TEST|C_API_TEST'`
- [ ] C++ GTest filters:
  - `right_looking_ldlt.indefinite_cross_only_2x2`
  - `general_quadratic.rejects_cross_only_indefinite`
  - `general_quadratic.rejects_non_convex`
  - parser / C API canonical QC COO tests (`qc_cross_term_stored_canonical`, rotated SOC C API tests)
- [ ] Python: `pytest -v cuopt/cuopt/tests/socp/test_socp.py -k rotated_soc`
- [ ] Manual #1435 repro: rotated SOC with single `-2*t*u` cross term → objective ≈ √2
- [ ] Manual #1434 repro: `datasets/qcqp/issue_1434_nonconvex.lp` → `ValidationError` (not Optimal obj=2)