### PR TITLE
Use 'dual values' terminology instead of 'shadow prices' in skills

### DIFF
--- a/skills/cuopt-numerical-optimization-api-c/assets/lp_duals/README.md
+++ b/skills/cuopt-numerical-optimization-api-c/assets/lp_duals/README.md
@@ -1,6 +1,6 @@
 # LP duals and reduced costs (C API)
 
-Retrieve dual values (shadow prices) and reduced costs after solving an LP.
+Retrieve dual values and reduced costs after solving an LP.
 
 **Problem:** Minimize 3x + 2y + 5z subject to x + y + z = 4, 2x + y + z = 5, x, y, z ≥ 0.
 

--- a/skills/cuopt-numerical-optimization-api-python/assets/lp_duals/README.md
+++ b/skills/cuopt-numerical-optimization-api-python/assets/lp_duals/README.md
@@ -1,6 +1,6 @@
 # LP Duals and Reduced Costs
 
-Retrieve dual values (shadow prices) and reduced costs after solving an LP.
+Retrieve dual values and reduced costs after solving an LP.
 
 **Problem:** Minimize 3x + 2y + 5z subject to x + y + z = 4, 2x + y + z = 5, x, y, z ≥ 0.
 

--- a/skills/cuopt-numerical-optimization-formulation/SKILL.md
+++ b/skills/cuopt-numerical-optimization-formulation/SKILL.md
@@ -32,11 +32,11 @@ Concepts and workflow for going from a problem description to a clear formulatio
 | Constraints | Linear | Linear | Linear (no quadratic constraints) |
 | Variables | Continuous | Mixed: continuous + integer/binary | Continuous |
 | Sense | min or max | min or max | **minimize only** (negate to max) |
-| Duals / sensitivity | Shadow prices + reduced costs | **None** (integer optima) | Shadow prices + reduced costs |
+| Duals / sensitivity | Dual values + reduced costs | **None** (integer optima) | Dual values + reduced costs |
 
 If the objective is purely linear, prefer LP/MILP — do not artificially introduce quadratic terms. If any variable is integer or binary, the problem is MILP regardless of the rest.
 
-**Post-solve sensitivity (LP / QP only).** Continuous LP and QP solutions expose **dual values** (shadow prices — the marginal objective change per unit a binding constraint is relaxed: *where to invest to improve the outcome*) and **reduced costs** (for a variable the optimizer left at zero, how far it must improve to enter the solution: a *near-miss*). **MILP solutions have no duals** — integer optima are not continuous, so there are none to return. See the language-specific API skills for how to retrieve them after a solve.
+**Post-solve sensitivity (LP / QP only).** Continuous LP and QP solutions expose **dual values** (the marginal objective change per unit a binding constraint is relaxed: *where to invest to improve the outcome*) and **reduced costs** (for a variable the optimizer left at zero, how far it must improve to enter the solution: a *near-miss*). **MILP solutions have no duals** — integer optima are not continuous, so there are none to return. See the language-specific API skills for how to retrieve them after a solve.
 
 ## Required formulation questions
 


### PR DESCRIPTION
## Description

Terminology consistency: replace "shadow price(s)" with "dual value(s)" across the numerical-optimization skills, matching the term used elsewhere and the convention requested in review — the dual is the *sensitivity* d(objective)/d(rhs); "shadow price" is avoided. Touches:

- `cuopt-numerical-optimization-formulation/SKILL.md` — the per-type sensitivity table row and the post-solve sensitivity paragraph.
- `cuopt-numerical-optimization-api-python/assets/lp_duals/README.md` and `…-api-c/assets/lp_duals/README.md` — the one-line summary.

Wording only; no behavior, API, or eval changes. The signature / `BENCHMARK.md` / skill-card regenerate via NVSkills-Eval.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
