### PR TITLE
Assign gRPC workers to distinct GPUs via cudaSetDevice

### DIFF
--- a/cpp/src/grpc/server/grpc_server_main.cpp
+++ b/cpp/src/grpc/server/grpc_server_main.cpp
@@ -260,6 +260,7 @@ int main(int argc, char** argv)
     }
 
     signal(SIGPIPE, SIG_IGN);
+    log_worker_gpu_layout();
     spawn_workers();
 
     cuopt_expects(!worker_pids.empty(), error_type_t::RuntimeError, "No workers started");

--- a/cpp/src/grpc/server/grpc_server_types.hpp
+++ b/cpp/src/grpc/server/grpc_server_types.hpp
@@ -347,7 +347,7 @@ void create_job_log_file(const std::string& job_id);
 void delete_log_file(const std::string& job_id);
 void cleanup_shared_memory();
 void log_worker_gpu_layout();
-void init_worker_cuda_environment(int worker_id);
+bool init_worker_cuda_environment(int worker_id);
 void spawn_workers();
 void wait_for_workers();
 void worker_monitor_thread();

--- a/cpp/src/grpc/server/grpc_server_types.hpp
+++ b/cpp/src/grpc/server/grpc_server_types.hpp
@@ -249,6 +249,9 @@ inline std::vector<pid_t> worker_pids;
 
 inline ServerConfig config;
 
+// Physical GPU count used for startup logging only (no CUDA calls in the parent).
+inline int visible_gpu_count = 0;
+
 inline std::vector<WorkerPipes> worker_pipes;
 inline std::mutex worker_pipes_mutex;
 
@@ -343,6 +346,8 @@ void ensure_log_dir_exists();
 void create_job_log_file(const std::string& job_id);
 void delete_log_file(const std::string& job_id);
 void cleanup_shared_memory();
+void log_worker_gpu_layout();
+void init_worker_cuda_environment(int worker_id);
 void spawn_workers();
 void wait_for_workers();
 void worker_monitor_thread();

--- a/cpp/src/grpc/server/grpc_worker.cpp
+++ b/cpp/src/grpc/server/grpc_worker.cpp
@@ -9,6 +9,60 @@
 #include "grpc_pipe_serialization.hpp"
 #include "grpc_server_types.hpp"
 
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+
+#include <memory>
+
+namespace {
+
+void init_worker_rmm_pool()
+{
+  int pool_gigs = 1;
+  if (const char* env = std::getenv("CUOPT_GIGABYTES_PER_PROC")) {
+    const int parsed = std::atoi(env);
+    if (parsed > 0) { pool_gigs = parsed; }
+  }
+
+  // Keep the pool alive for the lifetime of this worker process.
+  static std::unique_ptr<rmm::mr::pool_memory_resource> pool_mr;
+  static bool initialized = false;
+  if (initialized) { return; }
+
+  pool_mr = std::make_unique<rmm::mr::pool_memory_resource>(
+    rmm::mr::cuda_memory_resource(), static_cast<std::size_t>(pool_gigs) * (1ULL << 30));
+  rmm::mr::set_current_device_resource(*pool_mr);
+  initialized = true;
+
+  SERVER_LOG_INFO("[Worker] RMM pool size: %d GiB", pool_gigs);
+}
+
+}  // namespace
+
+void init_worker_cuda_environment(int worker_id)
+{
+  int device_count            = 0;
+  const cudaError_t count_err = cudaGetDeviceCount(&device_count);
+  if (count_err != cudaSuccess || device_count <= 0) {
+    SERVER_LOG_WARN("[Worker %d] cudaGetDeviceCount failed (%s); using default device",
+                    worker_id,
+                    cudaGetErrorString(count_err));
+    return;
+  }
+
+  const int device          = worker_id % device_count;
+  const cudaError_t set_err = cudaSetDevice(device);
+  if (set_err != cudaSuccess) {
+    SERVER_LOG_ERROR(
+      "[Worker %d] cudaSetDevice(%d) failed: %s", worker_id, device, cudaGetErrorString(set_err));
+    return;
+  }
+
+  init_worker_rmm_pool();
+
+  SERVER_LOG_INFO("[Worker %d] Using CUDA device %d of %d", worker_id, device, device_count);
+}
+
 // ---------------------------------------------------------------------------
 // Data-transfer structs used to pass results between decomposed functions.
 // ---------------------------------------------------------------------------
@@ -524,6 +578,8 @@ static void publish_result(const SolveResult& sr, const std::string& job_id, int
 void worker_process(int worker_id)
 {
   SERVER_LOG_INFO("[Worker %d] Started (PID: %d)", worker_id, getpid());
+
+  init_worker_cuda_environment(worker_id);
 
   shm_ctrl->active_workers++;
 

--- a/cpp/src/grpc/server/grpc_worker.cpp
+++ b/cpp/src/grpc/server/grpc_worker.cpp
@@ -12,17 +12,33 @@
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
+#include <cerrno>
+#include <climits>
+#include <limits>
 #include <memory>
 
 namespace {
 
-void init_worker_rmm_pool()
+int parse_pool_gigs_env()
 {
   int pool_gigs = 1;
   if (const char* env = std::getenv("CUOPT_GIGABYTES_PER_PROC")) {
-    const int parsed = std::atoi(env);
-    if (parsed > 0) { pool_gigs = parsed; }
+    char* end              = nullptr;
+    errno                  = 0;
+    const long long parsed = std::strtoll(env, &end, 10);
+    if (errno == 0 && end != env && *end == '\0' && parsed > 0 &&
+        parsed <= std::numeric_limits<int>::max()) {
+      pool_gigs = static_cast<int>(parsed);
+    } else {
+      SERVER_LOG_WARN("[Worker] Ignoring invalid CUOPT_GIGABYTES_PER_PROC='%s'", env);
+    }
   }
+  return pool_gigs;
+}
+
+void init_worker_rmm_pool()
+{
+  const int pool_gigs = parse_pool_gigs_env();
 
   // Keep the pool alive for the lifetime of this worker process.
   static std::unique_ptr<rmm::mr::pool_memory_resource> pool_mr;
@@ -39,15 +55,14 @@ void init_worker_rmm_pool()
 
 }  // namespace
 
-void init_worker_cuda_environment(int worker_id)
+bool init_worker_cuda_environment(int worker_id)
 {
   int device_count            = 0;
   const cudaError_t count_err = cudaGetDeviceCount(&device_count);
   if (count_err != cudaSuccess || device_count <= 0) {
-    SERVER_LOG_WARN("[Worker %d] cudaGetDeviceCount failed (%s); using default device",
-                    worker_id,
-                    cudaGetErrorString(count_err));
-    return;
+    SERVER_LOG_ERROR(
+      "[Worker %d] cudaGetDeviceCount failed (%s)", worker_id, cudaGetErrorString(count_err));
+    return false;
   }
 
   const int device          = worker_id % device_count;
@@ -55,12 +70,13 @@ void init_worker_cuda_environment(int worker_id)
   if (set_err != cudaSuccess) {
     SERVER_LOG_ERROR(
       "[Worker %d] cudaSetDevice(%d) failed: %s", worker_id, device, cudaGetErrorString(set_err));
-    return;
+    return false;
   }
 
   init_worker_rmm_pool();
 
   SERVER_LOG_INFO("[Worker %d] Using CUDA device %d of %d", worker_id, device, device_count);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -579,7 +595,10 @@ void worker_process(int worker_id)
 {
   SERVER_LOG_INFO("[Worker %d] Started (PID: %d)", worker_id, getpid());
 
-  init_worker_cuda_environment(worker_id);
+  if (!init_worker_cuda_environment(worker_id)) {
+    SERVER_LOG_ERROR("[Worker %d] CUDA environment initialization failed; exiting", worker_id);
+    _exit(1);
+  }
 
   shm_ctrl->active_workers++;
 

--- a/cpp/src/grpc/server/grpc_worker_infra.cpp
+++ b/cpp/src/grpc/server/grpc_worker_infra.cpp
@@ -13,6 +13,7 @@
 
 namespace {
 
+// GPU discovery for startup logging only. Avoids CUDA calls in the parent before fork().
 int count_cuda_visible_devices()
 {
   const char* visible = std::getenv("CUDA_VISIBLE_DEVICES");

--- a/cpp/src/grpc/server/grpc_worker_infra.cpp
+++ b/cpp/src/grpc/server/grpc_worker_infra.cpp
@@ -8,6 +8,67 @@
 #include "grpc_pipe_serialization.hpp"
 #include "grpc_server_types.hpp"
 
+#include <cctype>
+#include <cstdio>
+
+namespace {
+
+int count_cuda_visible_devices()
+{
+  const char* visible = std::getenv("CUDA_VISIBLE_DEVICES");
+  if (visible == nullptr || visible[0] == '\0') { return 0; }
+
+  int count     = 0;
+  bool in_token = false;
+  for (const char* p = visible; *p != '\0'; ++p) {
+    if (*p == ',') {
+      in_token = false;
+    } else if (!std::isspace(static_cast<unsigned char>(*p))) {
+      if (!in_token) {
+        ++count;
+        in_token = true;
+      }
+    }
+  }
+  return count;
+}
+
+int discover_gpu_count_via_nvidia_smi()
+{
+  FILE* fp = popen("nvidia-smi -L 2>/dev/null", "r");
+  if (fp == nullptr) { return 0; }
+
+  int count = 0;
+  char line[512];
+  while (fgets(line, sizeof(line), fp) != nullptr) {
+    int gpu_id = -1;
+    if (std::sscanf(line, "GPU %d:", &gpu_id) == 1) { ++count; }
+  }
+  pclose(fp);
+  return count;
+}
+
+}  // namespace
+
+void log_worker_gpu_layout()
+{
+  visible_gpu_count = count_cuda_visible_devices();
+  if (visible_gpu_count <= 0) { visible_gpu_count = discover_gpu_count_via_nvidia_smi(); }
+
+  if (visible_gpu_count <= 0) {
+    SERVER_LOG_WARN(
+      "[Server] Could not determine GPU count; workers will select devices at startup");
+    return;
+  }
+
+  SERVER_LOG_INFO("[Server] %d GPU(s) available for worker assignment", visible_gpu_count);
+  if (config.num_workers > visible_gpu_count) {
+    SERVER_LOG_WARN("[Server] %d workers on %d GPU(s); multiple workers will share a GPU",
+                    config.num_workers,
+                    visible_gpu_count);
+  }
+}
+
 void cleanup_shared_memory()
 {
   if (job_queue) {


### PR DESCRIPTION
Round-robin workers across visible CUDA devices at worker startup and initialize a per-process RMM pool (CUOPT_GIGABYTES_PER_PROC) so multiple workers can share a GPU without exhausting memory.

The logic to actually map a worker process to a specific GPU was missing previously (oversight).