### PR TITLE
ci: disable pulp test_infeasible_2 pending fix in #1115

### DIFF
--- a/ci/thirdparty-testing/run_pulp_tests.sh
+++ b/ci/thirdparty-testing/run_pulp_tests.sh
@@ -36,12 +36,15 @@ pytest_rc=0
 # test_numpy_float calls model.solve() with no explicit solver; PuLP's
 # default-solver auto-detection list doesn't include CUOPT, so it raises
 # "No solver available" in our cuopt-only test environment. Skip it here.
+# test_infeasible_2: solver incorrectly returns Optimal for a genuinely
+# infeasible LP. Tracked in https://github.com/NVIDIA/cuopt/issues/1115.
 timeout 5m python -m pytest \
     --verbose \
     --capture=no \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-thirdparty-pulp.xml" \
     -k "cuopt or CUOPT" \
     --deselect pulp/tests/test_pulp.py::CUOPTTest::test_numpy_float \
+    --deselect pulp/tests/test_cuopt.py::CUOPTTest::test_infeasible_2 \
     pulp/tests/ || pytest_rc=$?
 
 if [ "$pytest_rc" -eq 5 ]; then


### PR DESCRIPTION
Deselects `CUOPTTest::test_infeasible_2` from the PuLP wheel test suite. The solver incorrectly returns Optimal for a genuinely infeasible LP; tracked in #1115.