### PR TITLE
Update CuPy and NumPy dependency specs

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuda-sanitizer-api
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
@@ -47,7 +47,7 @@ dependencies:
 - notebook
 - numba-cuda>=0.22.1
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23.5,<3.0
+- numpy>=2.0,<3.0
 - numpydoc
 - openssl
 - pandas>=2.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuda-sanitizer-api
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
@@ -47,7 +47,7 @@ dependencies:
 - notebook
 - numba-cuda>=0.22.1
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23.5,<3.0
+- numpy>=2.0,<3.0
 - numpydoc
 - openssl
 - pandas>=2.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuda-sanitizer-api
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
@@ -47,7 +47,7 @@ dependencies:
 - notebook
 - numba-cuda>=0.22.1
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23.5,<3.0
+- numpy>=2.0,<3.0
 - numpydoc
 - openssl
 - pandas>=2.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cuda-sanitizer-api
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0
-- cupy>=13.6.0,!=14.0.0,!=14.1.0
+- cupy>=14.0.1,!=14.1.0
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
@@ -47,7 +47,7 @@ dependencies:
 - notebook
 - numba-cuda>=0.22.1
 - numba>=0.60.0,<0.65.0
-- numpy>=1.23.5,<3.0
+- numpy>=2.0,<3.0
 - numpydoc
 - openssl
 - pandas>=2.0

--- a/conda/recipes/cuopt-server/recipe.yaml
+++ b/conda/recipes/cuopt-server/recipe.yaml
@@ -37,7 +37,7 @@ requirements:
     - jsonref =1.1.0
     - msgpack-python =1.1.2
     - msgpack-numpy =0.4.8
-    - numpy >=1.23,<3.0
+    - numpy >=2.0,<3.0
     - pandas>=2
     - psutil>=6.0.0
     - python

--- a/conda/recipes/cuopt/recipe.yaml
+++ b/conda/recipes/cuopt/recipe.yaml
@@ -85,12 +85,12 @@ requirements:
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
-    - cupy >=13.6.0,!=14.0.0,!=14.1.0
+    - cupy >=14.0.1,!=14.1.0
     - h5py
     - libcuopt =${{ version }}
     - numba>=0.60.0,<0.65.0
     - numba-cuda>=0.22.1
-    - numpy >=1.23,<3.0
+    - numpy >=2.0,<3.0
     - pandas >=2.0
     - pylibraft =${{ minor_version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -296,7 +296,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &numpy numpy>=1.23.5,<3.0
+          - &numpy numpy>=2.0,<3.0
   build_python_common:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -510,7 +510,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0,!=14.0.0,!=14.1.0
+          - cupy>=14.0.1,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -520,11 +520,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
+              - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
   depends_on_rapids_logger:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -21,11 +21,11 @@ requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cudf==26.8.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
+    "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "libcuopt==26.8.*,>=0.0.0a0",
     "numba-cuda>=0.22.1",
     "numba>=0.60.0,<0.65.0",
-    "numpy>=1.23.5,<3.0",
+    "numpy>=2.0,<3.0",
     "pandas>=2.0",
     "pylibraft==26.8.*,>=0.0.0a0",
     "pyyaml>=6.0.0",
@@ -44,7 +44,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "numpy>=1.23.5,<3.0",
+    "numpy>=2.0,<3.0",
     "pytest-cov",
     "pytest-rerunfailures",
     "pytest<9.0",
@@ -101,7 +101,7 @@ dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
+    "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "cython>=3.0.3",
     "libcuopt==26.8.*,>=0.0.0a0",
     "ninja",

--- a/python/cuopt_server/pyproject.toml
+++ b/python/cuopt_server/pyproject.toml
@@ -22,12 +22,12 @@ license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "cuopt==26.8.*,>=0.0.0a0",
-    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
+    "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "fastapi",
     "jsonref==1.1.0",
     "msgpack-numpy==0.4.8",
     "msgpack==1.1.2",
-    "numpy>=1.23.5,<3.0",
+    "numpy>=2.0,<3.0",
     "pandas>=2.0",
     "psutil>=6.0.0",
     "uvicorn==0.34.*",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/279

RAPIDS is taking on requirements `cupy>=14.0.1,!=14.1.0` and `numpy>=2.0`. Wheel dependencies on `cupy-cuda12x` and `cupy-cuda13x` now use the `[ctk]` extra.

See the linked issue for details.