### PR TITLE
ci: reduce wheel-tests-cuopt-server matrix to 1 job per CUDA major

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,6 +96,7 @@ jobs:
       wheel_lean_filter: ${{ steps.set-filters.outputs.wheel_lean_filter }}
       libcuopt_filter: ${{ steps.set-filters.outputs.libcuopt_filter }}
       cuopt_server_filter: ${{ steps.set-filters.outputs.cuopt_server_filter }}
+      cuopt_server_test_filter: ${{ steps.set-filters.outputs.cuopt_server_test_filter }}
       cuopt_sh_client_filter: ${{ steps.set-filters.outputs.cuopt_sh_client_filter }}
     steps:
       - name: Set matrix filters
@@ -109,6 +110,7 @@ jobs:
             echo "wheel_lean_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "libcuopt_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "cuopt_server_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
+            echo "cuopt_server_test_filter=[map(select(.ARCH == \"amd64\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
             echo "cuopt_sh_client_filter=[map(select(.ARCH == \"amd64\" and .PY_VER == \"3.12\")) | max_by(.CUDA_VER | split(\".\") | map(tonumber))]" >> $GITHUB_OUTPUT
           else
             echo "conda_lean_filter=." >> $GITHUB_OUTPUT
@@ -116,6 +118,7 @@ jobs:
             echo "wheel_lean_filter=." >> $GITHUB_OUTPUT
             echo "libcuopt_filter=group_by([.ARCH, (.CUDA_VER|split(\".\")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(\".\")|map(tonumber)))" >> $GITHUB_OUTPUT
             echo "cuopt_server_filter=map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER|split(\".\")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(\".\")|map(tonumber)), (.CUDA_VER|split(\".\")|map(tonumber))]))" >> $GITHUB_OUTPUT
+            echo "cuopt_server_test_filter=map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER | split(\".\") | map(tonumber) | .[0]) | map(max_by([(.PY_VER | split(\".\") | map(tonumber)), (.CUDA_VER | split(\".\") | map(tonumber))]))" >> $GITHUB_OUTPUT
             echo "cuopt_sh_client_filter=[map(select(.ARCH == \"amd64\")) | min_by((.PY_VER | split(\".\") | map(tonumber)), (.CUDA_VER | split(\".\") | map(-tonumber)))]" >> $GITHUB_OUTPUT
           fi
 
@@ -598,7 +601,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cuopt_server.sh
-      matrix_filter: ${{ needs.compute-matrix-filters.outputs.wheel_lean_filter }}
+      matrix_filter: ${{ needs.compute-matrix-filters.outputs.cuopt_server_test_filter }}
     secrets:
       script-env-secret-1-key: CUOPT_S3_URI
       script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}


### PR DESCRIPTION
`wheel-tests-cuopt-server` ran the same 8-job matrix as `wheel-tests-cuopt` (arm64, Python 3.11–3.14, all GPU types). Since `cuopt-server` is pure Python, this coverage adds no value — server correctness is already fully validated by `conda-python-tests` which runs `run_cuopt_server_pytests.sh` across all 8 environments.

Introduces a dedicated `cuopt_server_test_filter`: amd64 only, 1 job per CUDA major (latest Python × latest CUDA minor), matching the `cuopt-server-cu12` / `cuopt-server-cu13` published package split.

**8 jobs → 2 jobs per PR run.**