### PR TITLE
docs: fix NGC container catalog URL

### DIFF
--- a/docs/cuopt/source/cuopt-server/quick-start.rst
+++ b/docs/cuopt/source/cuopt-server/quick-start.rst
@@ -17,7 +17,7 @@ Container from NVIDIA NGC
 
 Step 1: Get a subscription for `NVIDIA AI Enterprise (NVAIE) <https://www.nvidia.com/en-us/data-center/products/ai-enterprise/>`_ to get the cuOpt container to host in your cloud.
 
-Step 2: Once given access, users can find `cuOpt container <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/cuopt/containers/cuopt>`_ in the NGC catalog.
+Step 2: Once given access, users can find `cuOpt container <https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt>`_ in the NGC catalog.
 
 Step 3: Access NGC registry:
 

--- a/docs/cuopt/source/faq.rst
+++ b/docs/cuopt/source/faq.rst
@@ -9,7 +9,7 @@ General FAQ
 
     There are two options:
     - NVIDIA Docker Hub (https://hub.docker.com/r/nvidia/cuopt)
-    - NVIDIA NGC registry (https://catalog.ngc.nvidia.com/orgs/nvidia/teams/cuopt/containers/cuopt/tags) with NVAIE license.
+    - NVIDIA NGC registry (https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags) with NVAIE license.
 
 .. dropdown:: How to get a NVAIE license?
 
@@ -17,7 +17,7 @@ General FAQ
 
 .. dropdown:: How to access NGC registry?
 
-    Once you have a NVAIE license, you can access the `NGC registry <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/cuopt/containers/cuopt/tags>`_ for cuOpt container images.
+    Once you have a NVAIE license, you can access the `NGC registry <https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags>`_ for cuOpt container images.
 
 .. dropdown:: How to pull cuOpt container images from NGC registry?
 

--- a/docs/cuopt/source/faq.rst
+++ b/docs/cuopt/source/faq.rst
@@ -9,7 +9,7 @@ General FAQ
 
     There are two options:
     - NVIDIA Docker Hub (https://hub.docker.com/r/nvidia/cuopt)
-    - NVIDIA NGC registry (https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags) with NVAIE license.
+    - NVIDIA NGC registry (https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags) with an NVAIE license or NVIDIA Developer Program membership.
 
 .. dropdown:: How to get a NVAIE license?
 
@@ -17,7 +17,7 @@ General FAQ
 
 .. dropdown:: How to access NGC registry?
 
-    Once you have a NVAIE license, you can access the `NGC registry <https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags>`_ for cuOpt container images.
+    With an NVAIE license or NVIDIA Developer Program membership, you can access the `NGC registry <https://catalog.ngc.nvidia.com/orgs/nvidia/cuopt/containers/cuopt/tags>`_ for cuOpt container images.
 
 .. dropdown:: How to pull cuOpt container images from NGC registry?
 


### PR DESCRIPTION
Fixes the NGC catalog links in the docs — the old path used `/orgs/nvidia/teams/cuopt/` but the current URL is `/orgs/nvidia/cuopt/` (no `/teams/` segment).

Updated in `cuopt-server/quick-start.rst` and `faq.rst`.