### PR TITLE
fix(ci): skip test_conic_SecondOrderCone_negative_initial_bound in JuMP tests

### DIFF
--- a/ci/thirdparty-testing/run_jump_tests.sh
+++ b/ci/thirdparty-testing/run_jump_tests.sh
@@ -42,6 +42,13 @@ if [ -f test/MOI_wrapper.jl ]; then
     sed -i '/^function test_air05()/,/^end$/s/^/# /' test/MOI_wrapper.jl
 fi
 
+# Patch MOI_wrapper.jl to skip test_conic_SecondOrderCone_negative_initial_bound,
+# which crashes Julia's JIT during type inference for the MOI bridge delete path.
+rapids-logger "Excluding test_conic_SecondOrderCone_negative_initial_bound from bridge optimizer tests"
+if [ -f test/MOI_wrapper.jl ]; then
+    sed -i 's/"test_conic_SecondOrderCone_negative_post_bound_3",/"test_conic_SecondOrderCone_negative_post_bound_3",\n            "test_conic_SecondOrderCone_negative_initial_bound",/' test/MOI_wrapper.jl
+fi
+
 # Find libcuopt.so and add its directory to LD_LIBRARY_PATH
 LIBCUOPT_PATH=$(find /pyenv/ -name "libcuopt.so" -type f 2>/dev/null | head -1)
 

--- a/ci/thirdparty-testing/run_jump_tests.sh
+++ b/ci/thirdparty-testing/run_jump_tests.sh
@@ -42,12 +42,6 @@ if [ -f test/MOI_wrapper.jl ]; then
     sed -i '/^function test_air05()/,/^end$/s/^/# /' test/MOI_wrapper.jl
 fi
 
-# Patch MOI_wrapper.jl to skip test_conic_SecondOrderCone_negative_initial_bound,
-# which crashes Julia's JIT during type inference for the MOI bridge delete path.
-rapids-logger "Excluding test_conic_SecondOrderCone_negative_initial_bound from bridge optimizer tests"
-if [ -f test/MOI_wrapper.jl ]; then
-    sed -i 's/"test_conic_SecondOrderCone_negative_post_bound_3",/"test_conic_SecondOrderCone_negative_post_bound_3",\n            "test_conic_SecondOrderCone_negative_initial_bound",/' test/MOI_wrapper.jl
-fi
 
 # Find libcuopt.so and add its directory to LD_LIBRARY_PATH
 LIBCUOPT_PATH=$(find /pyenv/ -name "libcuopt.so" -type f 2>/dev/null | head -1)


### PR DESCRIPTION
## Summary

- Nightly run `28223429126` had 7 `wheel-tests-cuopt` jobs failing with `thirdparty jump` (all Python/pyomo tests passed — 286 passed, 0 failed).
- Root cause: `test_conic_SecondOrderCone_negative_initial_bound` in the MathOptInterface test suite crashes Julia's JIT compiler with SIGSEGV (signal 11) during type inference for the MOI `bridge_optimizer.delete` path when a `SecondOrderCone` variable with a negative initial bound is deleted.
- The crash call stack: `test_conic_SecondOrderCone_negative_initial_bound` → `MOI.Test.runtests` (bridge optimizer) → `bridge_optimizer.jl:765 (delete)` → `Variable/map.jl:652 (call_in_context)` → segfault in JIT

## Fix

Patch the cloned `cuOpt.jl/test/MOI_wrapper.jl` to add `test_conic_SecondOrderCone_negative_initial_bound` to the exclude list in `test_runtests_bridge_optimizer`, following the same pattern already used for `test_air05`.

## Test plan

- [ ] Verify all 7 `wheel-tests-cuopt` nightly jobs pass (no `thirdparty jump` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)