### PR TITLE
Improve cuopt-numerical-optimization-api-cli

### DIFF
--- a/skills/cuopt-numerical-optimization-api-cli/SKILL.md
+++ b/skills/cuopt-numerical-optimization-api-cli/SKILL.md
@@ -23,24 +23,13 @@ Confirm problem type and formulation (variables, objective, constraints, variabl
 
 This skill is **CLI only** (MPS or LP file input).
 
-## Input formats
-
-`cuopt_cli` dispatches the parser automatically by file extension (case-insensitive):
-
-| Extension | Parser |
-|-----------|--------|
-| `.lp`, `.lp.gz`, `.lp.bz2` | LP format |
-| `.mps`, `.qps` and their `.gz` / `.bz2` variants | MPS format (QPS = quadratic MPS) |
-
-Any other extension is rejected. The `.gz` and `.bz2` compressed variants are read transparently.
-
 ## Basic usage
 
 ```bash
 cuopt_cli <problem-file> [options]
 ```
 
-The first positional argument is the input file; format is chosen by its extension (see above), and `.gz` / `.bz2` files are read transparently.
+The first positional argument is the input file. The format is chosen automatically from the extension — MPS, QPS, and LP files are all accepted (including `.gz` / `.bz2` compressed variants); run `cuopt_cli --help` for the exact list of supported extensions.
 
 ## Options
 

--- a/skills/cuopt-numerical-optimization-api-cli/SKILL.md
+++ b/skills/cuopt-numerical-optimization-api-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cuopt-numerical-optimization-api-cli
 version: "26.08.00"
-description: LP, MILP, and QP (beta) with cuOpt — CLI only (MPS files, cuopt_cli). Use when the user is solving LP, MILP, or QP from MPS via command line.
+description: LP, MILP, and QP (beta) with cuOpt — CLI only (MPS/LP/QPS files, cuopt_cli). Use when the user is solving LP, MILP, or QP from an MPS or LP file via command line.
 license: Apache-2.0
 metadata:
   author: NVIDIA cuOpt Team
@@ -17,17 +17,34 @@ metadata:
 
 # cuOpt Numerical Optimization — CLI
 
-Solve LP, MILP, and QP problems from MPS files via `cuopt_cli`. The same command, options, and MPS workflow apply across all three; QP uses the standard MPS quadratic-objective extension.
+Solve LP, MILP, and QP problems from MPS or LP files via `cuopt_cli`. The same command and options apply across all three; QP is supported in both MPS (QPS) and LP files.
 
 Confirm problem type and formulation (variables, objective, constraints, variable types) before coding.
 
-This skill is **CLI only** (MPS input).
+This skill is **CLI only** (MPS or LP file input).
+
+## Input formats
+
+`cuopt_cli` dispatches the parser automatically by file extension (case-insensitive):
+
+| Extension | Parser |
+|-----------|--------|
+| `.lp`, `.lp.gz`, `.lp.bz2` | LP format |
+| `.mps`, `.qps` and their `.gz` / `.bz2` variants | MPS format (QPS = quadratic MPS) |
+
+Any other extension is rejected. The `.gz` and `.bz2` compressed variants are read transparently.
 
 ## Basic usage
 
 ```bash
-# Solve LP or MILP from MPS file
+# Solve LP or MILP from an MPS file
 cuopt_cli problem.mps
+
+# Solve from an LP-format file (dispatched by the .lp extension)
+cuopt_cli problem.lp
+
+# Compressed input is read transparently
+cuopt_cli problem.mps.gz
 
 # With options
 cuopt_cli problem.mps --time-limit 120 --mip-relative-tolerance 0.01
@@ -51,29 +68,27 @@ cuopt_cli problem.mps --mip-absolute-tolerance 0.0001
 cuopt_cli problem.mps --presolve --iteration-limit 10000 --method 1
 ```
 
-## MPS format (required sections, in order)
+## Authoring input files
 
-1. **NAME** — problem name
-2. **ROWS** — N (objective), L/G/E (constraints)
-3. **COLUMNS** — variable names, row names, coefficients
-4. **RHS** — right-hand side values
-5. **BOUNDS** (optional) — LO, UP, FX, BV, LI, UI
-6. **ENDATA**
+MPS, QPS, and LP are precise, externally-specified file formats. Don't hand-author them from memory or from a partial recollection of the layout — column-position rules, marker conventions, the quadratic-objective encoding, and sign/scaling conventions are easy to get subtly wrong, and a malformed file either fails to parse or **silently encodes a different model than intended**.
 
-Integer variables: use `'MARKER' 'INTORG'` before and `'MARKER' 'INTEND'` after the integer columns.
+If you're building a model from data (rather than solving a file you already have), **define the problem through the cuOpt Python API or your preferred modeling interface — don't generate an MPS or LP file by hand to feed the CLI.** These interfaces take coefficients, bounds, and variable types as native data structures, so there's no text format to get wrong. The cuOpt Python API solves and returns the solution in the same program (see the `cuopt-numerical-optimization-api-python` skill); a separate modeling library (e.g. PuLP, Pyomo, JuMP) can export a valid file for the CLI or call its own solver. Reach for `cuopt_cli` when you *already* have a model file — e.g. a benchmark instance or a file exported by one of these tools.
 
-## QP via CLI (beta)
+When a file is genuinely the right artifact, still generate it programmatically rather than by hand:
 
-Quadratic objectives extend the standard MPS workflow — same `cuopt_cli` command, same options. Check `cuopt_cli --help` for QP-specific flags and the repo docs at `docs/cuopt/source/cuopt-cli/` for the quadratic-objective MPS format.
+- **From cuOpt's Python API** — build the model, then export it with `model.writeMPS("problem.mps")` (emits a valid MPS file, including the quadratic objective for QP) and solve with `cuopt_cli problem.mps`.
+- **From another modeling tool** — most LP/MILP modeling libraries and solvers can export standard MPS or LP files; pass the exported file straight to `cuopt_cli`.
 
-**QP rules:**
-- **MINIMIZE only.** For maximization, negate the objective coefficients (and Q entries) in the MPS file.
-- **Continuous variables only** — do not mix integer markers with quadratic objectives.
+If you must read or write these formats by hand anyway, work from the format's full specification (and the cuOpt repo docs at `docs/cuopt/source/cuopt-cli/` for cuOpt-specific conventions such as the quadratic-objective encoding) — not from an example alone.
+
+Either way, **validate before trusting the result**: `cuopt_cli` logs `Read file ...` on a successful parse, and reports the variable/constraint counts and objective — sanity-check those against your intended model.
+
+**QP notes (beta):** quadratic objectives are **MINIMIZE only** (for maximization, negate the objective, including the quadratic terms) and require **continuous variables only** (no integer variables mixed with a quadratic objective). Check `cuopt_cli --help` for QP-specific flags.
 
 ## Troubleshooting
 
-- **Failed to parse MPS** — Check ENDATA, section order (NAME, ROWS, COLUMNS, RHS, [BOUNDS], ENDATA), integer markers.
-- **Infeasible** — Check constraint directions (L/G/E) and RHS values.
+- **Parsing input file failed** — Confirm the extension matches the format (`.lp` vs `.mps`/`.qps`); an unrecognized extension is rejected before parsing. The parser error names the offending line — fix it against the format spec, or (more reliably) regenerate the file from a modeling tool rather than patching it by hand.
+- **Infeasible** — Re-check the model against your intended formulation: constraint directions, right-hand sides, and variable bounds.
 
 ## Examples
 

--- a/skills/cuopt-numerical-optimization-api-cli/SKILL.md
+++ b/skills/cuopt-numerical-optimization-api-cli/SKILL.md
@@ -37,36 +37,22 @@ Any other extension is rejected. The `.gz` and `.bz2` compressed variants are re
 ## Basic usage
 
 ```bash
-# Solve LP or MILP from an MPS file
-cuopt_cli problem.mps
-
-# Solve from an LP-format file (dispatched by the .lp extension)
-cuopt_cli problem.lp
-
-# Compressed input is read transparently
-cuopt_cli problem.mps.gz
-
-# With options
-cuopt_cli problem.mps --time-limit 120 --mip-relative-tolerance 0.01
+cuopt_cli <problem-file> [options]
 ```
 
-## Common options
+The first positional argument is the input file; format is chosen by its extension (see above), and `.gz` / `.bz2` files are read transparently.
 
-```bash
-cuopt_cli --help
+## Options
 
-# Time limit (seconds)
-cuopt_cli problem.mps --time-limit 120
+**`cuopt_cli --help` is the authoritative list — don't work from a hard-coded subset.** The CLI exposes every solver setting as a flag, generated from the parameter list at runtime: take any parameter documented in the cuOpt settings reference and replace underscores with hyphens (`time_limit` → `--time-limit`, `mip_relative_gap` → `--mip-relative-gap`). So if a parameter is documented, the flag exists; `--help` and the [solver-settings docs](https://docs.nvidia.com/cuopt/user-guide/latest/) are the sources of truth for names, meanings, and defaults.
 
-# MIP gap tolerance (stop when within X% of optimal)
-cuopt_cli problem.mps --mip-relative-tolerance 0.001
+A few options are CLI-specific (not solver parameters) and worth knowing because you wouldn't derive them from a parameter name:
 
-# MIP absolute tolerance
-cuopt_cli problem.mps --mip-absolute-tolerance 0.0001
+- `--params-file <file>` — supply many parameters from a `key = value` config file instead of repeating flags.
+- `--relaxation` — solve the continuous relaxation of a MILP (drop integrality).
+- `--initial-solution <file>` — warm-start from a solution file.
 
-# Presolve, iteration limit, method
-cuopt_cli problem.mps --presolve --iteration-limit 10000 --method 1
-```
+Run `cuopt_cli --help` for the complete, current set.
 
 ## Authoring input files
 

--- a/skills/cuopt-numerical-optimization-api-cli/skill-card.md
+++ b/skills/cuopt-numerical-optimization-api-cli/skill-card.md
@@ -1,5 +1,5 @@
 ## Description: <br>
-LP, MILP, and QP (beta) with cuOpt — CLI only (MPS files, cuopt_cli). Use when the user is solving LP, MILP, or QP from MPS via command line. <br>
+LP, MILP, and QP (beta) with cuOpt — CLI only (MPS/LP/QPS files, cuopt_cli). Use when the user is solving LP, MILP, or QP from an MPS or LP file via command line. <br>
 
 This skill is ready for commercial/non-commercial use. <br>
 
@@ -9,7 +9,7 @@ NVIDIA <br>
 ### License/Terms of Use: <br>
 Apache 2.0 <br>
 ## Use Case: <br>
-Developers and engineers solving LP, MILP, and QP optimization problems from MPS files via the cuopt_cli command-line interface. <br>
+Developers and engineers solving LP, MILP, and QP optimization problems from MPS or LP format files via the cuopt_cli command-line interface. <br>
 
 ### Deployment Geography for Use: <br>
 Global <br>


### PR DESCRIPTION
cuopt_cli accepts LP and QPS files in addition to MPS (dispatched by extension), and the LP/MPS parsers both support quadratic objectives. Update the CLI skill to reflect this, and replace the partial MPS/LP format specs with guidance to define models through the cuOpt Python API or a preferred modeling interface rather than hand-authoring files. This is industry standard practice.