### PR TITLE
Use pytest importlib mode to avoid shadowing installed cuopt.

### DIFF
--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -80,6 +80,9 @@ max_allowed_size_compressed = '55Mi'
 
 [tool.pytest.ini_options]
 testpaths = ["cuopt/tests"]
+# Avoid prepending the project root onto sys.path, which would shadow the
+# installed cuopt wheel (Cython extensions live in site-packages, not source).
+addopts = "--import-mode=importlib"
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"


### PR DESCRIPTION
When pytest is run from the repo root, prepending the source tree to sys.path can hide Cython extensions built into the installed wheel.

Pretty minor, but it bit me when testing Python gRPC bindings in the development environment when I ran tests from the repo root.