### PR TITLE
ci(test): increase xdist workers from 2 to 8

### DIFF
--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -36,7 +36,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 2 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 8 "$@" tests || rc=$?
 fi
 
 # If not a crash, exit normally

--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -36,7 +36,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 4 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
 fi
 
 # If not a crash, exit normally

--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -36,7 +36,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 4 "$@" tests || rc=$?
 fi
 
 # If not a crash, exit normally

--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -36,7 +36,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 8 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
 fi
 
 # If not a crash, exit normally

--- a/ci/run_cuopt_server_pytests.sh
+++ b/ci/run_cuopt_server_pytests.sh
@@ -35,7 +35,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 2 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 8 "$@" tests || rc=$?
 fi
 
 if [ "${rc}" -le 128 ]; then

--- a/ci/run_cuopt_server_pytests.sh
+++ b/ci/run_cuopt_server_pytests.sh
@@ -35,7 +35,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 8 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
 fi
 
 if [ "${rc}" -le 128 ]; then

--- a/ci/run_cuopt_server_pytests.sh
+++ b/ci/run_cuopt_server_pytests.sh
@@ -35,7 +35,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 4 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
 fi
 
 if [ "${rc}" -le 128 ]; then

--- a/ci/run_cuopt_server_pytests.sh
+++ b/ci/run_cuopt_server_pytests.sh
@@ -35,7 +35,7 @@ rc=0
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
     pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
 else
-    pytest -s --cache-clear -n 6 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 4 "$@" tests || rc=$?
 fi
 
 if [ "${rc}" -le 128 ]; then

--- a/cpp/src/grpc/client/grpc_client.cpp
+++ b/cpp/src/grpc/client/grpc_client.cpp
@@ -319,6 +319,7 @@ void grpc_client_t::drain_log_streaming()
   // common non-streaming solve path.
   if (!log_thread_) return;
 
+
   // On the success path the server drains all pending log lines and then sends
   // a job_complete sentinel; the streaming thread exits naturally when that
   // sentinel arrives.  Poll for natural completion (up to kDrainTimeout) so

--- a/cpp/src/grpc/client/grpc_client.cpp
+++ b/cpp/src/grpc/client/grpc_client.cpp
@@ -319,7 +319,6 @@ void grpc_client_t::drain_log_streaming()
   // common non-streaming solve path.
   if (!log_thread_) return;
 
-
   // On the success path the server drains all pending log lines and then sends
   // a job_complete sentinel; the streaming thread exits naturally when that
   // sentinel arrives.  Poll for natural completion (up to kDrainTimeout) so


### PR DESCRIPTION
## Summary

Bumps `-n 2` → `-n 8` in both `run_cuopt_pytests.sh` and `run_cuopt_server_pytests.sh`, following bdice's suggestion on #1486:

> Generally we use `-n 6` or `-n 8` in most of RAPIDS. The safe maximum depends on the GPU memory usage of your tests, not the number of CPU cores! Try to design it to run safely on a 16GB GPU.

Base infrastructure (pytest-xdist dependency, worker-aware gRPC/server ports) landed in #1486.

## What to watch in CI

- GPU stability on V100 (16GB) — the tightest runner; `cudaErrorInvalidDevice` or OOM would indicate too much GPU pressure
- Timing improvement vs `-n 2` baseline (~3m 48s cuopt, ~5m 34s server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)