### PR TITLE
Disable coverage in cuOpt.jl tests

### DIFF
--- a/ci/thirdparty-testing/run_jump_tests.sh
+++ b/ci/thirdparty-testing/run_jump_tests.sh
@@ -67,5 +67,5 @@ try
 catch
 end
 println("Running Pkg.test() for cuOpt.jl");
-Pkg.test(; coverage=true)
+Pkg.test(; coverage=false)
 '

--- a/ci/thirdparty-testing/run_jump_tests.sh
+++ b/ci/thirdparty-testing/run_jump_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail


### PR DESCRIPTION
Code coverage isn't needed to check the Julia/JuMP interface is working.

The code coverage seems to be a factor triggering the crash detailed in https://github.com/NVIDIA/cuopt/issues/1485. 