### PR TITLE
style(cpp): drop gratuitous static_cast<size_t> on container subscripts

### DIFF
--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -1202,15 +1202,15 @@ i_t presolve(const lp_problem_t<i_t, f_t>& original,
     if (problem.Q.n > 0 && !presolve_info.negated_variables.empty()) {
       std::vector<bool> is_negated(static_cast<size_t>(problem.num_cols), false);
       for (i_t const j : presolve_info.negated_variables) {
-        is_negated[static_cast<size_t>(j)] = true;
+        is_negated[j] = true;
       }
       for (i_t row = 0; row < problem.Q.m; ++row) {
         const i_t q_start         = problem.Q.row_start[row];
         const i_t q_end           = problem.Q.row_start[row + 1];
-        const bool is_negated_row = is_negated[static_cast<size_t>(row)];
+        const bool is_negated_row = is_negated[row];
         for (i_t p = q_start; p < q_end; ++p) {
           const i_t col = problem.Q.j[p];
-          if (is_negated_row != is_negated[static_cast<size_t>(col)]) { problem.Q.x[p] *= -1.0; }
+          if (is_negated_row != is_negated[col]) { problem.Q.x[p] *= -1.0; }
         }
       }
     }

--- a/cpp/src/grpc/server/grpc_service_impl.cpp
+++ b/cpp/src/grpc/server/grpc_service_impl.cpp
@@ -882,7 +882,7 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
     if (max_count > 0 && count > max_count) { count = max_count; }
 
     for (int64_t i = 0; i < count; ++i) {
-      const auto& inc = incumbents[static_cast<size_t>(from_index + i)];
+      const auto& inc = incumbents[from_index + i];
       auto* out       = response->add_incumbents();
       out->set_index(from_index + i);
       out->set_objective(inc.objective);

--- a/cpp/src/io/mps_parser.cpp
+++ b/cpp/src/io/mps_parser.cpp
@@ -272,17 +272,17 @@ void canonicalize_coo_matrix(std::vector<i_t>& rows, std::vector<i_t>& cols, std
   // Bucket entry indices by canonical row via a stable counting sort.
   std::vector<i_t> offsets(static_cast<size_t>(max_row - min_idx) + 2, 0);
   for (size_t k = 0; k < n; ++k) {
-    offsets[static_cast<size_t>(std::min(rows[k], cols[k]) - min_idx) + 1]++;
+    offsets[std::min(rows[k], cols[k]) - min_idx + 1]++;
   }
   for (i_t r = 0; r <= max_row - min_idx; ++r) {
-    offsets[static_cast<size_t>(r) + 1] += offsets[static_cast<size_t>(r)];
+    offsets[r + 1] += offsets[r];
   }
   std::vector<i_t> perm(n);
   std::vector<i_t> cursor(offsets.begin(), offsets.end() - 1);
   for (size_t k = 0; k < n; ++k) {
-    const i_t r                          = std::min(rows[k], cols[k]) - min_idx;
-    perm[static_cast<size_t>(cursor[r])] = static_cast<i_t>(k);
-    cursor[static_cast<size_t>(r)]++;
+    const i_t r     = std::min(rows[k], cols[k]) - min_idx;
+    perm[cursor[r]] = static_cast<i_t>(k);
+    cursor[r]++;
   }
 
   // Merge duplicate (row, col) entries within each canonical row using a marker array
@@ -298,17 +298,16 @@ void canonicalize_coo_matrix(std::vector<i_t>& rows, std::vector<i_t>& cols, std
   std::vector<i_t> marker(static_cast<size_t>(max_col - min_idx) + 1, 0);
   for (i_t r = 0; r <= max_row - min_idx; ++r) {
     const i_t row_start = static_cast<i_t>(entries.size());
-    for (i_t p = offsets[static_cast<size_t>(r)]; p < offsets[static_cast<size_t>(r) + 1]; ++p) {
-      const i_t k   = perm[static_cast<size_t>(p)];
-      const i_t row = std::min(rows[static_cast<size_t>(k)], cols[static_cast<size_t>(k)]);
-      const i_t col = std::max(rows[static_cast<size_t>(k)], cols[static_cast<size_t>(k)]);
+    for (i_t p = offsets[r]; p < offsets[r + 1]; ++p) {
+      const i_t k   = perm[p];
+      const i_t row = std::min(rows[k], cols[k]);
+      const i_t col = std::max(rows[k], cols[k]);
       const i_t c   = col - min_idx;
-      if (marker[static_cast<size_t>(c)] <= row_start) {
-        entries.push_back(entry_t{row, col, vals[static_cast<size_t>(k)]});
-        marker[static_cast<size_t>(c)] = static_cast<i_t>(entries.size());
+      if (marker[c] <= row_start) {
+        entries.push_back(entry_t{row, col, vals[k]});
+        marker[c] = static_cast<i_t>(entries.size());
       } else {
-        entries[static_cast<size_t>(marker[static_cast<size_t>(c)] - 1)].val +=
-          vals[static_cast<size_t>(k)];
+        entries[marker[c] - 1].val += vals[k];
       }
     }
     std::sort(entries.begin() + row_start,

--- a/cpp/src/pdlp/cuopt_c.cpp
+++ b/cpp/src/pdlp/cuopt_c.cpp
@@ -124,8 +124,8 @@ void coo_to_csr(cuopt_int_t num_entries,
   std::vector<cuopt_int_t> perm(static_cast<size_t>(num_entries));
   std::vector<cuopt_int_t> row_cursor(offsets.begin(), offsets.begin() + num_rows);
   for (cuopt_int_t k = 0; k < num_entries; ++k) {
-    const cuopt_int_t row                        = row_index[k];
-    perm[static_cast<size_t>(row_cursor[row]++)] = k;
+    const cuopt_int_t row   = row_index[k];
+    perm[row_cursor[row]++] = k;
   }
 
   // Per row: merge duplicate columns in one pass. col_mark[col] stores the index into
@@ -143,7 +143,7 @@ void coo_to_csr(cuopt_int_t num_entries,
     if (start >= end) { continue; }
 
     for (cuopt_int_t p = start; p < end; ++p) {
-      const cuopt_int_t k   = perm[static_cast<size_t>(p)];
+      const cuopt_int_t k   = perm[p];
       const cuopt_int_t col = col_index[k];
       const size_t col_u    = static_cast<size_t>(col);
       if (col_mark[col_u] < row_out_start) {
@@ -152,7 +152,7 @@ void coo_to_csr(cuopt_int_t num_entries,
         values.push_back(coeff[k]);
         ++out_nnz;
       } else {
-        values[static_cast<size_t>(col_mark[col_u])] += coeff[k];
+        values[col_mark[col_u]] += coeff[k];
       }
     }
   }


### PR DESCRIPTION
Remove 20 `x[static_cast<size_t>(...)]` casts where the index is already a signed type (`i_t` / `cuopt_int_t` / `int64_t`). The build uses `-Werror` but not `-Wsign-conversion`/`-Wconversion` and has no clang-tidy, so these casts suppressed no warning and only added noise inconsistent with the surrounding bare-signed-indexing style.

Legitimate casts are kept: container sizing from signed subtraction, the `size_t`->`i_t` narrowing of `.size()`, and the hoisted `col_u` variable.

Verified with clang-format 20.1.8 and a full `./build.sh libcuopt` (-Werror) pass.

See #1505 for the style guidance change.