### PR TITLE
fix(ci): correct transport_cuopt skip pattern typo in nbtest.sh

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -111,3 +111,26 @@ jobs:
         run: |
           docker tag "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-py${PYTHON_SHORT}-${ARCH}" "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-py${PYTHON_SHORT}-${ARCH}"
           docker push "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-py${PYTHON_SHORT}-${ARCH}"
+
+      - name: Build UBI10 image and push to DockerHub and NGC
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: ./ci/docker/context
+          file: ./ci/docker/Dockerfile.ubi
+          push: true
+          pull: true
+          provenance: false
+          sbom: false
+          build-args: |
+            CUDA_VER=${{ inputs.CUDA_VER }}
+            CUOPT_VER=${{ inputs.CUOPT_VER }}
+          tags: nvidia/cuopt:${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ steps.trim.outputs.CUDA_SHORT }}-ubi10-${{ matrix.ARCH }}
+
+      - name: Push UBI10 image to NGC
+        env:
+          IMAGE_TAG_PREFIX: ${{ inputs.IMAGE_TAG_PREFIX }}
+          ARCH: ${{ matrix.ARCH }}
+          CUDA_SHORT: ${{ steps.trim.outputs.CUDA_SHORT }}
+        run: |
+          docker tag "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-${ARCH}" "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-${ARCH}"
+          docker push "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-${ARCH}"

--- a/.github/workflows/test_images.yaml
+++ b/.github/workflows/test_images.yaml
@@ -69,3 +69,20 @@ jobs:
       - name: Test cuopt
         run: |
           bash ./ci/docker/test_image.sh
+
+  test-ubi10:
+    name: test-images-ubi10 (${{ inputs.ARCH }}, ${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ needs.prepare.outputs.CUDA_SHORT }}-ubi10)
+    runs-on: "linux-${{ inputs.ARCH }}-gpu-a100-latest-1"
+    needs: prepare
+    container:
+      image: "nvidia/cuopt:${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ needs.prepare.outputs.CUDA_SHORT }}-ubi10"
+    steps:
+      - name: Checkout code repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.sha }}
+          persist-credentials: false
+      - name: Test cuopt
+        run: |
+          bash ./ci/docker/test_image.sh

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ of our latest development branch. Just replace `-c rapidsai` with `-c rapidsai-n
 
 ### Container
 
-Users can pull the cuOpt container from the NVIDIA container registry.
+cuOpt ships two container variants on Docker Hub — an Ubuntu-based image for general use and a Red Hat Universal Base Image 10 (UBI10) image for FIPS 140-3 compliant environments.
+
+#### Ubuntu image
 
 ```bash
 # For CUDA 12.x
@@ -146,9 +148,25 @@ docker pull nvidia/cuopt:latest-cu12
 docker pull nvidia/cuopt:latest-cu13
 ```
 
-Note: The ``latest`` tag is the latest stable release of cuOpt. If you want to use a specific version, you can use the ``<version>-cu12`` or ``<version>-cu13`` tag. For example, to use cuOpt 26.6.0, you can use the ``26.6.0-cu12`` or ``26.6.0-cu13`` tag. Fully-qualified tags that also pin the CUDA minor and Python version (for example ``26.6.0-cuda12.9-py3.14``) are published alongside the short tags. Please refer to [cuOpt dockerhub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the list of available tags.
+The `latest` tag is the latest stable release. To pin a specific version use `<version>-cu12` / `<version>-cu13` (e.g. `26.6.0-cu13`). Fully-qualified tags that also pin the CUDA minor and Python version (e.g. `26.6.0-cuda13.3-py3.14`) are published alongside the short tags. See the [cuOpt Docker Hub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the full list.
 
-Nightly container images are built from the HEAD of the development branch. They are tagged as ``<version>a-cu12`` or ``<version>a-cu13`` (note the ``a`` alpha suffix). See the [cuOpt dockerhub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the full list.
+#### UBI10 image (FIPS 140-3)
+
+Based on Red Hat Universal Base Image 10 (RHEL 10), which ships OpenSSL 3.5 validated under FIPS 140-3. Use this image in environments with strict FIPS or RHEL compliance requirements.
+
+```bash
+# For CUDA 12.x
+docker pull nvidia/cuopt:latest-cu12-ubi10
+
+# For CUDA 13.x
+docker pull nvidia/cuopt:latest-cu13-ubi10
+```
+
+Fully-qualified tags follow the pattern `<version>-cuda<X.Y>-ubi10` (e.g. `26.6.0-cuda13.3-ubi10`). Nightly builds use the `<version>a-cu<N>-ubi10` tag scheme. See the [cuOpt Docker Hub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the full list.
+
+Both images include the same cuOpt packages (`libcuopt`, `cuopt`, `cuopt-server`, `cuopt-sh-client`) and expose the same server entrypoint. They are built and tested for x86-64 and ARM64.
+
+Nightly container images for both variants are built from the HEAD of the development branch. They are tagged as `<version>a-cu12` / `<version>a-cu13` (Ubuntu) and `<version>a-cu12-ubi10` / `<version>a-cu13-ubi10` (UBI10).
 
 More information about the cuOpt container can be found [here](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-server/quick-start.html#container-from-docker-hub).
 

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1.2
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG CUDA_VER=unset
+ARG CUOPT_VER=unset
+
+# Stage 1: source for libnvrtc / libnvJitLink (not in base image)
+FROM nvcr.io/nvidia/cuda:${CUDA_VER}-runtime-ubi10 AS cuda-libs
+
+# Stage 2: source for CUDA headers needed for CuPy/NVRTC runtime compilation
+FROM nvcr.io/nvidia/cuda:${CUDA_VER}-devel-ubi10 AS cuda-headers
+
+# Stage 3: small base — install Python + cuOpt via pip
+FROM nvcr.io/nvidia/cuda:${CUDA_VER}-base-ubi10 AS python-env
+
+ARG CUDA_VER
+ARG CUOPT_VER
+
+# gcc is required for building psutils
+RUN dnf install -y \
+        gcc \
+        python3-devel \
+        python3-pip \
+    && dnf clean all \
+    && python3 -m pip install --upgrade pip
+
+RUN alternatives --install /usr/bin/python  python  /usr/bin/python3 100
+
+FROM python-env AS install-env
+
+ARG CUDA_VER
+ARG CUOPT_VER
+
+RUN \
+    cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
+    cuda_major_minor=$(echo ${CUDA_VER} | cut -d'.' -f1-2) && \
+    python -m pip install \
+      --extra-index-url https://pypi.nvidia.com \
+      --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
+      --no-cache-dir \
+      "pyyaml" \
+      "cuopt-server-${cuda_suffix}==${CUOPT_VER}" \
+      "cuopt-${cuda_suffix}==${CUOPT_VER}" \
+      "libcuopt-${cuda_suffix}==${CUOPT_VER}" \
+      "cuopt-sh-client==${CUOPT_VER}" && \
+    python -m pip list
+
+# Remove build-only deps to reduce CVE surface area
+RUN dnf remove -y gcc && dnf clean all
+
+FROM install-env AS cuopt-final
+
+# On UBI10: libcuopt, cuopt, rapids_logger install to lib64; cuopt_server to lib.
+ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.12/site-packages/libcuopt/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/wsl/lib:/usr/local/lib64/python3.12/site-packages/libcuopt/lib64/:/usr/local/lib64/python3.12/site-packages/rapids_logger/lib64:/usr/local/lib/python3.12/site-packages/nvidia/cu13/lib:${LD_LIBRARY_PATH}"
+
+# Directory creation, permissions
+RUN mkdir -p /opt/cuopt && \
+    chmod 777 /opt/cuopt && \
+    chmod -R 755 /usr/local/lib64/python3.12/site-packages/cuopt* && \
+    chmod -R 755 /usr/local/lib64/python3.12/site-packages/libcuopt* && \
+    chmod -R 755 /usr/local/lib/python3.12/site-packages/cuopt_* && \
+    chmod -R 755 /usr/local/bin/*
+
+WORKDIR /opt/cuopt
+
+COPY ./LICENSE ./VERSION ./THIRD_PARTY_LICENSES ./COMMIT_SHA ./COMMIT_TIME /opt/cuopt/
+
+# Copy CUDA libraries from the runtime stage
+COPY --from=cuda-libs /usr/local/cuda/lib64/libnvrtc* /usr/local/cuda/lib64/
+COPY --from=cuda-libs /usr/local/cuda/lib64/libnvJitLink* /usr/local/cuda/lib64/
+
+# Copy CUDA headers needed for runtime compilation (e.g., CuPy NVRTC)
+COPY --from=cuda-headers /usr/local/cuda/include/ /usr/local/cuda/include/
+
+COPY ./entrypoint.sh /opt/cuopt/entrypoint.sh
+ENTRYPOINT ["/opt/cuopt/entrypoint.sh"]
+CMD ["python", "-m", "cuopt_server.cuopt_service"]

--- a/ci/docker/README.md
+++ b/ci/docker/README.md
@@ -4,10 +4,25 @@
 
 Add all the files and data for the buildx context to ``context`` folder like entrypoint script, and others.
 
+## Dockerfiles
+
+| File | Base | Use case |
+|------|------|----------|
+| `Dockerfile` | Ubuntu | General use |
+| `Dockerfile.ubi` | Red Hat UBI 10 (RHEL 10) | FIPS 140-3 compliant environments |
+
+Both images install the same cuOpt packages via pip and expose the same server entrypoint.
+
 ## test
 
-To test the container image, run the [test_image.sh](test_image.sh) script as shown below from the latest github repo:
+The [test_image.sh](test_image.sh) script is shared between both images. It detects the OS at runtime (`/etc/redhat-release` present → UBI10/RHEL, absent → Ubuntu) and adjusts package manager and library paths accordingly.
+
+To test either image locally (requires a GPU):
 
 ```bash
+# Ubuntu image
 docker run -it --rm --gpus all -u root --volume $PWD:/repo -w /repo --entrypoint "/bin/bash" nvidia/cuopt:[TAG] ./ci/docker/test_image.sh
+
+# UBI10 image
+docker run -it --rm --gpus all -u root --volume $PWD:/repo -w /repo --entrypoint "/bin/bash" nvidia/cuopt:[TAG]-ubi10 ./ci/docker/test_image.sh
 ```

--- a/ci/docker/create_multiarch_manifest.sh
+++ b/ci/docker/create_multiarch_manifest.sh
@@ -109,4 +109,43 @@ else
     echo "Skipping latest manifest creation (IMAGE_TAG_PREFIX='${IMAGE_TAG_PREFIX}' is not a release version)"
 fi
 
+echo "=== Creating UBI10 manifests ==="
+create_manifest \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+create_manifest \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+create_manifest \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+create_manifest \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+if [[ "${IMAGE_TAG_PREFIX}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${IMAGE_TAG_PREFIX}" != *"a"* ]]; then
+    create_manifest \
+        "nvidia/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+    create_manifest \
+        "nvidia/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+    create_manifest \
+        "nvcr.io/nvstaging/nvaie/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+    create_manifest \
+        "nvcr.io/nvstaging/nvaie/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+fi
+
 echo "=== Multi-architecture manifest creation completed ==="

--- a/ci/docker/test_image.sh
+++ b/ci/docker/test_image.sh
@@ -5,9 +5,18 @@
 
 set -euo pipefail
 
-# Install dependencies
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends file bzip2 gcc
+# Detect distro and install test dependencies
+if [ -f /etc/redhat-release ]; then
+    dnf install -y file bzip2 gcc wget unzip
+    dnf clean all
+    # pip-installed CUDA wheels land in a non-standard prefix on UBI/RHEL.
+    # su - resets the environment, so carry the path forward explicitly.
+    EXTRA_LD_PATH="/usr/local/lib/python3.12/site-packages/nvidia/cu13/lib"
+else
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends file bzip2 gcc
+    EXTRA_LD_PATH=""
+fi
 
 # Download test data
 bash datasets/linear_programming/download_pdlp_test_dataset.sh
@@ -26,6 +35,11 @@ chmod -R a+w "$(pwd)"
 cat > /opt/cuopt/test.sh <<EOF
 set -euo pipefail
 
+# Restore library path stripped by su - login shell
+if [ -n "${EXTRA_LD_PATH}" ]; then
+    export LD_LIBRARY_PATH="${EXTRA_LD_PATH}:\${LD_LIBRARY_PATH:-}"
+fi
+
 cd /opt/cuopt/cuopt
 python -m pip install pytest pexpect
 export RAPIDS_DATASET_ROOT_DIR=\$(realpath datasets)
@@ -41,8 +55,8 @@ python -m pytest python/cuopt_server/cuopt_server/tests/
 echo '----------------- CUOPT SERVER TEST END ---------------'
 EOF
 
-# Create a temporary user with UID 888
-useradd -m -u 888 -s /bin/bash tempuser888
+# Create a temporary user with UID 1001 (within standard range for both Ubuntu and RHEL)
+useradd -m -u 1001 -s /bin/bash tempuser1001 2>/dev/null || true
 
 # Switch to it
-su - tempuser888 -c "bash /opt/cuopt/test.sh"
+su - tempuser1001 -c "bash /opt/cuopt/test.sh"

--- a/ci/utils/nbtest.sh
+++ b/ci/utils/nbtest.sh
@@ -34,7 +34,7 @@ for nb in "$@"; do
 
     # Skip notebooks that are not yet supported
     SKIP_NOTEBOOKS=(
-        "trnsport_cuopt"
+        "transport_cuopt"
         "Production_Planning_Example_Pulp"
         "Simple_LP_pulp"
         "Simple_MIP_pulp"

--- a/docs/cuopt/source/_static/install-selector.js
+++ b/docs/cuopt/source/_static/install-selector.js
@@ -47,6 +47,14 @@
         default: "docker pull nvidia/cuopt:latest-cu13",
         run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu13 /bin/bash",
       },
+      "cu12-ubi10": {
+        default: "docker pull nvidia/cuopt:latest-cu12-ubi10",
+        run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu12-ubi10 /bin/bash",
+      },
+      "cu13-ubi10": {
+        default: "docker pull nvidia/cuopt:latest-cu13-ubi10",
+        run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu13-ubi10 /bin/bash",
+      },
     },
     nightly: {
       cu12: {
@@ -56,6 +64,14 @@
       cu13: {
         default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13",
         run: "docker run --gpus all -it --rm nvidia/cuopt:" + V_NEXT + ".0a-cu13 /bin/bash",
+      },
+      "cu12-ubi10": {
+        default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
+        run: "docker run --gpus all -it --rm nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10 /bin/bash",
+      },
+      "cu13-ubi10": {
+        default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10",
+        run: "docker run --gpus all -it --rm nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10 /bin/bash",
       },
     },
   };
@@ -214,6 +230,14 @@
             default: "docker pull nvidia/cuopt:latest-cu13",
             run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu13",
           },
+          "cu12-ubi10": {
+            default: "docker pull nvidia/cuopt:latest-cu12-ubi10",
+            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu12-ubi10",
+          },
+          "cu13-ubi10": {
+            default: "docker pull nvidia/cuopt:latest-cu13-ubi10",
+            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu13-ubi10",
+          },
         },
         nightly: {
           cu12: {
@@ -223,6 +247,14 @@
           cu13: {
             default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13",
             run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:" + V_NEXT + ".0a-cu13",
+          },
+          "cu12-ubi10": {
+            default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
+            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
+          },
+          "cu13-ubi10": {
+            default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10",
+            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10",
           },
         },
       },
@@ -265,8 +297,11 @@
 
     var cmd = "";
     if (method === "container") {
-      var cudaKey = cuda || "cu12";
-      var c = data[release][cudaKey] || data[release].cu12;
+      var variant = getSelectedValue("cuopt-variant") || "ubuntu";
+      var baseCuda = cuda || "cu12";
+      var cudaKey = baseCuda + (variant === "ubi10" ? "-ubi10" : "");
+      var fallbackKey = "cu12" + (variant === "ubi10" ? "-ubi10" : "");
+      var c = data[release][cudaKey] || data[release][fallbackKey];
       var hubPull = c.default;
       var tag = "latest-cu12";
       var tm = hubPull.match(/docker pull nvidia\/cuopt:(\S+)/);
@@ -346,6 +381,10 @@
       hasCudaVariants(ifaceForVariants, method);
     cudaRow.style.display = showCuda ? "table-row" : "none";
     releaseRow.style.display = releaseVisible ? "table-row" : "none";
+    var variantRow = document.getElementById("cuopt-variant-row");
+    if (variantRow) {
+      variantRow.style.display = method === "container" ? "table-row" : "none";
+    }
     var registryRow = document.getElementById("cuopt-registry-row");
     if (registryRow) {
       registryRow.style.display = method === "container" ? "table-row" : "none";
@@ -395,6 +434,10 @@
       '<label class="cuopt-opt"><input type="radio" name="cuopt-cuda" value="cu12" checked> 12.x</label>' +
       '<label class="cuopt-opt"><input type="radio" name="cuopt-cuda" value="cu13"> 13.x</label>' +
       '</td></tr>' +
+      '<tr id="cuopt-variant-row" style="display:none;"><td class="cuopt-opt-label">Variant</td><td class="cuopt-opt-group" role="group" aria-label="Container variant">' +
+      '<label class="cuopt-opt"><input type="radio" name="cuopt-variant" value="ubuntu" checked> Ubuntu</label>' +
+      '<label class="cuopt-opt"><input type="radio" name="cuopt-variant" value="ubi10"> UBI10 (FIPS 140-3)</label>' +
+      '</td></tr>' +
       '<tr id="cuopt-registry-row" style="display:none;"><td class="cuopt-opt-label">Registry</td><td class="cuopt-opt-group" role="group" aria-label="Container registry">' +
       '<label class="cuopt-opt"><input type="radio" name="cuopt-registry" value="hub" checked> Docker Hub</label>' +
       '<label class="cuopt-opt"><input type="radio" name="cuopt-registry" value="ngc"> NVIDIA NGC</label>' +
@@ -405,7 +448,7 @@
       '<div class="cuopt-install-copy-wrap"><button type="button" id="cuopt-copy-btn" class="cuopt-install-copy-btn" style="display:none;">Copy command</button></div>' +
       "</div></div>";
 
-    ["cuopt-iface", "cuopt-method", "cuopt-release", "cuopt-cuda", "cuopt-registry"].forEach(
+    ["cuopt-iface", "cuopt-method", "cuopt-release", "cuopt-cuda", "cuopt-variant", "cuopt-registry"].forEach(
       function (name) {
         var inputs = document.querySelectorAll('input[name="' + name + '"]');
         inputs.forEach(function (input) {


### PR DESCRIPTION
The GAMSPy notebook (`transport_cuopt.ipynb`) was never being skipped because the skip pattern was `trnsport_cuopt` (missing 'a'), which never matched the notebook filename.

Found while running the full notebook test suite locally in the cuopt container.