### PR TITLE
fix(ci): correct transport_cuopt skip pattern typo in nbtest.sh

### DIFF
--- a/ci/utils/nbtest.sh
+++ b/ci/utils/nbtest.sh
@@ -34,7 +34,7 @@ for nb in "$@"; do
 
     # Skip notebooks that are not yet supported
     SKIP_NOTEBOOKS=(
-        "trnsport_cuopt"
+        "transport_cuopt"
         "Production_Planning_Example_Pulp"
         "Simple_LP_pulp"
         "Simple_MIP_pulp"


### PR DESCRIPTION
The GAMSPy notebook (`transport_cuopt.ipynb`) was never being skipped because the skip pattern was `trnsport_cuopt` (missing 'a'), which never matched the filename.

Found while running the full notebook test suite locally in the cuopt container.