### PR TITLE
fix(ci): restrict UBI10 build, test, and manifest to CUDA 13.x only

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -113,6 +113,7 @@ jobs:
           docker push "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-py${PYTHON_SHORT}-${ARCH}"
 
       - name: Build UBI10 image and push to DockerHub and NGC
+        if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./ci/docker/context
@@ -127,6 +128,7 @@ jobs:
           tags: nvidia/cuopt:${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ steps.trim.outputs.CUDA_SHORT }}-ubi10-${{ matrix.ARCH }}
 
       - name: Push UBI10 image to NGC
+        if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
         env:
           IMAGE_TAG_PREFIX: ${{ inputs.IMAGE_TAG_PREFIX }}
           ARCH: ${{ matrix.ARCH }}

--- a/.github/workflows/test_images.yaml
+++ b/.github/workflows/test_images.yaml
@@ -72,6 +72,7 @@ jobs:
 
   test-ubi10:
     name: test-images-ubi10 (${{ inputs.ARCH }}, ${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ needs.prepare.outputs.CUDA_SHORT }}-ubi10)
+    if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
     runs-on: "linux-${{ inputs.ARCH }}-gpu-a100-latest-1"
     needs: prepare
     container:

--- a/ci/docker/create_multiarch_manifest.sh
+++ b/ci/docker/create_multiarch_manifest.sh
@@ -109,43 +109,48 @@ else
     echo "Skipping latest manifest creation (IMAGE_TAG_PREFIX='${IMAGE_TAG_PREFIX}' is not a release version)"
 fi
 
-echo "=== Creating UBI10 manifests ==="
-create_manifest \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-create_manifest \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-
-create_manifest \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-create_manifest \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-
-if [[ "${IMAGE_TAG_PREFIX}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${IMAGE_TAG_PREFIX}" != *"a"* ]]; then
+# UBI10 base images are only published for CUDA 13.x and later
+if [[ "${CUDA_MAJOR}" == "13" ]]; then
+    echo "=== Creating UBI10 manifests ==="
     create_manifest \
-        "nvidia/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
     create_manifest \
-        "nvidia/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
 
     create_manifest \
-        "nvcr.io/nvstaging/nvaie/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
     create_manifest \
-        "nvcr.io/nvstaging/nvaie/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+    if [[ "${IMAGE_TAG_PREFIX}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${IMAGE_TAG_PREFIX}" != *"a"* ]]; then
+        create_manifest \
+            "nvidia/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+        create_manifest \
+            "nvidia/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+        create_manifest \
+            "nvcr.io/nvstaging/nvaie/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+        create_manifest \
+            "nvcr.io/nvstaging/nvaie/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+    fi
+else
+    echo "Skipping UBI10 manifests (CUDA_MAJOR='${CUDA_MAJOR}' — UBI10 base images require CUDA 13+)"
 fi
 
 echo "=== Multi-architecture manifest creation completed ==="


### PR DESCRIPTION
## Summary

- UBI10 CUDA base images (`nvidia/cuda:*-ubi10`) are not published for any CUDA 12.x version on Docker Hub or NGC
- CI was failing when attempting to build the UBI10 image for CUDA 12.9.0 with `not found`
- Skip UBI10 build/push steps in `build_images.yaml` when `CUDA_VER` starts with `12.`
- Skip UBI10 test job in `test_images.yaml` for CUDA 12.x
- Skip UBI10 manifest creation in `create_multiarch_manifest.sh` when `CUDA_MAJOR != 13`
