### PR TITLE
fix(ci): restrict UBI10 build, test, and manifest to CUDA 13.x only

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -113,6 +113,7 @@ jobs:
           docker push "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-py${PYTHON_SHORT}-${ARCH}"
 
       - name: Build UBI10 image and push to DockerHub and NGC
+        if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./ci/docker/context
@@ -127,6 +128,7 @@ jobs:
           tags: nvidia/cuopt:${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ steps.trim.outputs.CUDA_SHORT }}-ubi10-${{ matrix.ARCH }}
 
       - name: Push UBI10 image to NGC
+        if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
         env:
           IMAGE_TAG_PREFIX: ${{ inputs.IMAGE_TAG_PREFIX }}
           ARCH: ${{ matrix.ARCH }}

--- a/.github/workflows/test_images.yaml
+++ b/.github/workflows/test_images.yaml
@@ -72,6 +72,7 @@ jobs:
 
   test-ubi10:
     name: test-images-ubi10 (${{ inputs.ARCH }}, ${{ inputs.IMAGE_TAG_PREFIX }}-cuda${{ needs.prepare.outputs.CUDA_SHORT }}-ubi10)
+    if: ${{ startsWith(inputs.CUDA_VER, '13.') }}
     runs-on: "linux-${{ inputs.ARCH }}-gpu-a100-latest-1"
     needs: prepare
     container:

--- a/README.md
+++ b/README.md
@@ -152,21 +152,17 @@ The `latest` tag is the latest stable release. To pin a specific version use `<v
 
 #### UBI10 image (FIPS 140-3)
 
-Based on Red Hat Universal Base Image 10 (RHEL 10), which ships OpenSSL 3.5 validated under FIPS 140-3. Use this image in environments with strict FIPS or RHEL compliance requirements.
+Based on Red Hat Universal Base Image 10 (RHEL 10), which ships OpenSSL 3.5 validated under FIPS 140-3. Use this image in environments with strict FIPS or RHEL compliance requirements. UBI10 images are available for CUDA 13.x only.
 
 ```bash
-# For CUDA 12.x
-docker pull nvidia/cuopt:latest-cu12-ubi10
-
-# For CUDA 13.x
 docker pull nvidia/cuopt:latest-cu13-ubi10
 ```
 
-Fully-qualified tags follow the pattern `<version>-cuda<X.Y>-ubi10` (e.g. `26.6.0-cuda13.3-ubi10`). Nightly builds use the `<version>a-cu<N>-ubi10` tag scheme. See the [cuOpt Docker Hub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the full list.
+Fully-qualified tags follow the pattern `<version>-cuda<X.Y>-ubi10` (e.g. `26.6.0-cuda13.3-ubi10`). Nightly builds use the `<version>a-cu13-ubi10` tag scheme. See the [cuOpt Docker Hub page](https://hub.docker.com/r/nvidia/cuopt/tags) for the full list.
 
 Both images include the same cuOpt packages (`libcuopt`, `cuopt`, `cuopt-server`, `cuopt-sh-client`) and expose the same server entrypoint. They are built and tested for x86-64 and ARM64.
 
-Nightly container images for both variants are built from the HEAD of the development branch. They are tagged as `<version>a-cu12` / `<version>a-cu13` (Ubuntu) and `<version>a-cu12-ubi10` / `<version>a-cu13-ubi10` (UBI10).
+Nightly container images for both variants are built from the HEAD of the development branch. They are tagged as `<version>a-cu12` / `<version>a-cu13` (Ubuntu) and `<version>a-cu13-ubi10` (UBI10).
 
 More information about the cuOpt container can be found [here](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-server/quick-start.html#container-from-docker-hub).
 

--- a/ci/docker/create_multiarch_manifest.sh
+++ b/ci/docker/create_multiarch_manifest.sh
@@ -109,43 +109,48 @@ else
     echo "Skipping latest manifest creation (IMAGE_TAG_PREFIX='${IMAGE_TAG_PREFIX}' is not a release version)"
 fi
 
-echo "=== Creating UBI10 manifests ==="
-create_manifest \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-create_manifest \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-
-create_manifest \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-create_manifest \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
-    "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
-
-if [[ "${IMAGE_TAG_PREFIX}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${IMAGE_TAG_PREFIX}" != *"a"* ]]; then
+# UBI10 CUDA base images are only published for CUDA 13.x and later
+if [[ "${CUDA_MAJOR}" == "13" ]]; then
+    echo "=== Creating UBI10 manifests ==="
     create_manifest \
-        "nvidia/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
     create_manifest \
-        "nvidia/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
 
     create_manifest \
-        "nvcr.io/nvstaging/nvaie/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
     create_manifest \
-        "nvcr.io/nvstaging/nvaie/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+        "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cu${CUDA_MAJOR}-ubi10" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
         "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+    if [[ "${IMAGE_TAG_PREFIX}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${IMAGE_TAG_PREFIX}" != *"a"* ]]; then
+        create_manifest \
+            "nvidia/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+        create_manifest \
+            "nvidia/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvidia/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+
+        create_manifest \
+            "nvcr.io/nvstaging/nvaie/cuopt:latest-cuda${CUDA_SHORT}-ubi10" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+        create_manifest \
+            "nvcr.io/nvstaging/nvaie/cuopt:latest-cu${CUDA_MAJOR}-ubi10" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-amd64" \
+            "nvcr.io/nvstaging/nvaie/cuopt:${IMAGE_TAG_PREFIX}-cuda${CUDA_SHORT}-ubi10-arm64"
+    fi
+else
+    echo "Skipping UBI10 manifests (CUDA_MAJOR='${CUDA_MAJOR}' — UBI10 base images require CUDA 13+)"
 fi
 
 echo "=== Multi-architecture manifest creation completed ==="

--- a/docs/cuopt/source/_static/install-selector.js
+++ b/docs/cuopt/source/_static/install-selector.js
@@ -47,10 +47,6 @@
         default: "docker pull nvidia/cuopt:latest-cu13",
         run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu13 /bin/bash",
       },
-      "cu12-ubi10": {
-        default: "docker pull nvidia/cuopt:latest-cu12-ubi10",
-        run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu12-ubi10 /bin/bash",
-      },
       "cu13-ubi10": {
         default: "docker pull nvidia/cuopt:latest-cu13-ubi10",
         run: "docker run --gpus all -it --rm nvidia/cuopt:latest-cu13-ubi10 /bin/bash",
@@ -64,10 +60,6 @@
       cu13: {
         default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13",
         run: "docker run --gpus all -it --rm nvidia/cuopt:" + V_NEXT + ".0a-cu13 /bin/bash",
-      },
-      "cu12-ubi10": {
-        default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
-        run: "docker run --gpus all -it --rm nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10 /bin/bash",
       },
       "cu13-ubi10": {
         default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10",
@@ -230,10 +222,6 @@
             default: "docker pull nvidia/cuopt:latest-cu13",
             run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu13",
           },
-          "cu12-ubi10": {
-            default: "docker pull nvidia/cuopt:latest-cu12-ubi10",
-            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu12-ubi10",
-          },
           "cu13-ubi10": {
             default: "docker pull nvidia/cuopt:latest-cu13-ubi10",
             run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:latest-cu13-ubi10",
@@ -247,10 +235,6 @@
           cu13: {
             default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13",
             run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:" + V_NEXT + ".0a-cu13",
-          },
-          "cu12-ubi10": {
-            default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
-            run: "docker run --gpus all -it --rm -p 8000:8000 -e CUOPT_SERVER_PORT=8000 nvidia/cuopt:" + V_NEXT + ".0a-cu12-ubi10",
           },
           "cu13-ubi10": {
             default: "docker pull nvidia/cuopt:" + V_NEXT + ".0a-cu13-ubi10",
@@ -300,7 +284,7 @@
       var variant = getSelectedValue("cuopt-variant") || "ubuntu";
       var baseCuda = cuda || "cu12";
       var cudaKey = baseCuda + (variant === "ubi10" ? "-ubi10" : "");
-      var fallbackKey = "cu12" + (variant === "ubi10" ? "-ubi10" : "");
+      var fallbackKey = (variant === "ubi10") ? "cu13-ubi10" : "cu12";
       var c = data[release][cudaKey] || data[release][fallbackKey];
       var hubPull = c.default;
       var tag = "latest-cu12";


### PR DESCRIPTION
## Summary

`nvidia/cuda` UBI10 base images are only published for CUDA 13.x — neither Docker Hub nor NGC provide them for any 12.x release. The CI was failing with `not found` when attempting to build the UBI10 image for CUDA 12.9.0.

