### PR TITLE
remove 'cuda-python' dependency, test against oldest numba and numpy

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -20,7 +20,7 @@ rapids-dependency-file-generator \
   --file-key test_python \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - cpp-argparse
 - cuda-nvcc
 - cuda-nvtx-dev
-- cuda-python>=12.9.2,<13.0
 - cuda-sanitizer-api
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - cpp-argparse
 - cuda-nvcc
 - cuda-nvtx-dev
-- cuda-python>=12.9.2,<13.0
 - cuda-sanitizer-api
 - cuda-version=12.9
 - cudf==26.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - cpp-argparse
 - cuda-nvcc
 - cuda-nvtx-dev
-- cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -16,7 +16,6 @@ dependencies:
 - cpp-argparse
 - cuda-nvcc
 - cuda-nvtx-dev
-- cuda-python>=13.0.1,<14.0
 - cuda-sanitizer-api
 - cuda-version=13.3
 - cudf==26.8.*,>=0.0.0a0

--- a/conda/recipes/cuopt/recipe.yaml
+++ b/conda/recipes/cuopt/recipe.yaml
@@ -79,9 +79,6 @@ requirements:
     - rapids-build-backend >=0.4.0,<0.5.0
     - rmm =${{ minor_version }}
     - scikit-build-core>=0.11.0
-    - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
   run:
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
@@ -100,9 +97,6 @@ requirements:
     - cuda-nvcc-impl
     # TODO: Add nvjitlink here
     # xref: https://github.com/rapidsai/cudf/issues/12822
-    - if: cuda_major == "12"
-      then: cuda-python >=12.9.2,<13.0
-      else: cuda-python >=13.0.1,<14.0
   ignore_run_exports:
     by_name:
       - cuda-version

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -310,6 +310,16 @@ dependencies:
           - pytest-cov
           - pytest-rerunfailures
           - pytest-xdist
+    specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              dependencies: "oldest"
+            packages:
+              - numba-cuda==0.22.*
+              - numpy==2.0.*
+          - matrix:
+            packages:
   test_python_cuopt:
     common:
       - output_types: [conda]
@@ -327,17 +337,6 @@ dependencies:
           - &pandas pandas>=2.0
           - *pyyaml
           - scipy>=1.14.1
-    specific:
-      - output_types: [conda, requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - cuda-python>=12.9.2,<13.0
-          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
-          - matrix:
-            packages:
-              - cuda-python>=13.0.1,<14.0
 
   test_python_cuopt_server:
     common:

--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -19,7 +19,6 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "cuda-python>=13.0.1,<14.0",
     "cudf==26.8.*,>=0.0.0a0",
     "cupy-cuda13x[ctk]>=14.0.1,!=14.1.0",
     "libcuopt==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/285

Removes this project's `cuda-python` dependency, which appears to be unnecessary:

```console
$ git grep -E 'from cuda.*import|import cuda'
ci/utils/notebook_list.py:from numba import cuda
python/cuopt/cuopt/distance_engine/waypoint_matrix_wrapper.pyx:from numba import cuda
python/cuopt/cuopt/linear_programming/solver/solver_wrapper.pyx:from numba import cuda
python/cuopt/cuopt/routing/utils_wrapper.pyx:from numba import cuda
python/cuopt/cuopt/routing/vehicle_routing_wrapper.pyx:from numba import cuda
```

While doing that, also adds some use of the "test against oldest versions of dependencies" stuff originally set up in https://github.com/rapidsai/build-planning/issues/81. That's used in a few RAPIDS repos and has been valuable in detecting when a floor needs to be bumped or compatibility workarounds need to be put in place. Proposing adding `numpy` and `numba-cuda` there for now.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [x] Added tests
- Documentation
   - [x] The documentation is up to date with these changes