### PR TITLE
make selection of CPU or GPU memory for problem automatic in C api

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -216,14 +216,6 @@ for gt in "${GTEST_DIR}"/*_TEST; do
     run_gtest_with_retry "${gt}" "$@" || true
 done
 
-# Run C_API_TEST with CPU memory for local solves (excluding time limit tests)
-if [ -x "${GTEST_DIR}/C_API_TEST" ]; then
-  echo "Running gtest C_API_TEST with CUOPT_USE_CPU_MEM_FOR_LOCAL"
-  CUOPT_USE_CPU_MEM_FOR_LOCAL=1 run_gtest_with_retry "${GTEST_DIR}/C_API_TEST" --gtest_filter=-c_api/TimeLimitTestFixture.* "$@" || true
-else
-  echo "Skipping C_API_TEST with CUOPT_USE_CPU_MEM_FOR_LOCAL (binary not found)"
-fi
-
 # Final summary so failures are easy to spot in the raw run log.
 # nightly_report.py also produces a structured report from the XML files,
 # but this prints early (before any post-test-script steps) and surfaces

--- a/cpp/include/cuopt/mathematical_optimization/backend_selection.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/backend_selection.hpp
@@ -40,29 +40,10 @@ bool is_remote_execution_enabled();
 execution_mode_t get_execution_mode();
 
 /**
- * @brief Check if CPU memory should be used for local execution (test mode)
- *
- * Undocumented. Intended for testing CPU problem/solution structures without remote execution.
- * When enabled, local solve will convert CPU problems to GPU, solve, and convert back.
- *
- * @return true if CUOPT_USE_CPU_MEM_FOR_LOCAL is set to "true" or "1" (case-insensitive)
- */
-bool use_cpu_memory_for_local();
-
-/**
- * @brief Whether a CPU-memory-backed problem has a configured solve path without re-probing CUDA.
- *
- * True when remote execution is enabled or undocumented test mode CUOPT_USE_CPU_MEM_FOR_LOCAL is
- * set (local CPU-to-GPU bridge on a GPU host).
- */
-bool cpu_memory_backend_solve_allowed();
-
-/**
  * @brief Determine which memory backend to use based on execution mode and hardware
  *
  * Logic:
  *   - REMOTE execution -> always CPU memory
- *   - LOCAL + CUOPT_USE_CPU_MEM_FOR_LOCAL -> CPU memory (undocumented test mode)
  *   - LOCAL + no visible CUDA devices -> CPU memory (auto-detect CPU-only host)
  *   - LOCAL otherwise -> GPU memory
  *

--- a/cpp/include/cuopt/mathematical_optimization/backend_selection.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/backend_selection.hpp
@@ -42,7 +42,7 @@ execution_mode_t get_execution_mode();
 /**
  * @brief Check if CPU memory should be used for local execution (test mode)
  *
- * This is intended for testing CPU problem/solution structures without remote execution.
+ * Undocumented. Intended for testing CPU problem/solution structures without remote execution.
  * When enabled, local solve will convert CPU problems to GPU, solve, and convert back.
  *
  * @return true if CUOPT_USE_CPU_MEM_FOR_LOCAL is set to "true" or "1" (case-insensitive)
@@ -50,12 +50,21 @@ execution_mode_t get_execution_mode();
 bool use_cpu_memory_for_local();
 
 /**
- * @brief Determine which memory backend to use based on execution mode
+ * @brief Whether a CPU-memory-backed problem has a configured solve path without re-probing CUDA.
+ *
+ * True when remote execution is enabled or undocumented test mode CUOPT_USE_CPU_MEM_FOR_LOCAL is
+ * set (local CPU-to-GPU bridge on a GPU host).
+ */
+bool cpu_memory_backend_solve_allowed();
+
+/**
+ * @brief Determine which memory backend to use based on execution mode and hardware
  *
  * Logic:
  *   - REMOTE execution -> always CPU memory
- *   - LOCAL execution  -> GPU memory by default, CPU if CUOPT_USE_CPU_MEM_FOR_LOCAL=true (test
- * mode)
+ *   - LOCAL + CUOPT_USE_CPU_MEM_FOR_LOCAL -> CPU memory (undocumented test mode)
+ *   - LOCAL + no visible CUDA devices -> CPU memory (auto-detect CPU-only host)
+ *   - LOCAL otherwise -> GPU memory
  *
  * @return memory_backend_t::GPU or memory_backend_t::CPU
  */

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -895,7 +895,13 @@ std::unique_ptr<mip_solution_interface_t<i_t, f_t>> solve_mip(
 
     // Local execution - dispatch to appropriate overload based on problem type
     auto* cpu_prob = dynamic_cast<cpu_optimization_problem_t<i_t, f_t>*>(problem_interface);
-    if (cpu_prob != nullptr) { return solve_mip(*cpu_prob, settings); }
+    if (cpu_prob != nullptr) {
+      cuopt_expects(cpu_memory_backend_solve_allowed(),
+                    error_type_t::ValidationError,
+                    "A CPU-memory problem requires remote execution. Set CUOPT_REMOTE_HOST and "
+                    "CUOPT_REMOTE_PORT to solve on a remote GPU server.");
+      return solve_mip(*cpu_prob, settings);
+    }
 
     // GPU problem: call GPU solver directly
     auto* gpu_prob = dynamic_cast<optimization_problem_t<i_t, f_t>*>(problem_interface);

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -896,7 +896,7 @@ std::unique_ptr<mip_solution_interface_t<i_t, f_t>> solve_mip(
     // Local execution - dispatch to appropriate overload based on problem type
     auto* cpu_prob = dynamic_cast<cpu_optimization_problem_t<i_t, f_t>*>(problem_interface);
     if (cpu_prob != nullptr) {
-      cuopt_expects(cpu_memory_backend_solve_allowed(),
+      cuopt_expects(is_remote_execution_enabled(),
                     error_type_t::ValidationError,
                     "A CPU-memory problem requires remote execution. Set CUOPT_REMOTE_HOST and "
                     "CUOPT_REMOTE_PORT to solve on a remote GPU server.");

--- a/cpp/src/pdlp/backend_selection.cpp
+++ b/cpp/src/pdlp/backend_selection.cpp
@@ -8,9 +8,11 @@
 #include <cuopt/mathematical_optimization/backend_selection.hpp>
 #include <utilities/logger.hpp>
 
+#include <cuda_runtime.h>
+
 #include <algorithm>
+#include <atomic>
 #include <cctype>
-#include <cstdio>
 #include <cstdlib>
 #include <string>
 
@@ -40,11 +42,39 @@ bool use_cpu_memory_for_local()
   return false;
 }
 
+bool cpu_memory_backend_solve_allowed()
+{
+  return is_remote_execution_enabled() || use_cpu_memory_for_local();
+}
+
 memory_backend_t get_memory_backend_type()
 {
-  if (get_execution_mode() == execution_mode_t::REMOTE) { return memory_backend_t::CPU; }
-  // Local execution: GPU memory by default, CPU if CUOPT_USE_CPU_MEM_FOR_LOCAL is set
-  return use_cpu_memory_for_local() ? memory_backend_t::CPU : memory_backend_t::GPU;
+  // Remote execution and the undocumented local test mode force CPU memory
+  // regardless of hardware, so decide without probing CUDA.
+  if (is_remote_execution_enabled() || use_cpu_memory_for_local()) { return memory_backend_t::CPU; }
+
+  int cuda_count        = 0;
+  const cudaError_t err = cudaGetDeviceCount(&cuda_count);
+  if (err == cudaSuccess && cuda_count > 0) { return memory_backend_t::GPU; }
+
+  // Local run with no usable device: fall back to CPU memory, which requires remote
+  // execution at solve time. Log at INFO (the shipped level) so this surprising
+  // fallback is visible without a recompile -- the CUDA error code distinguishes
+  // "no device" from a driver/OS fault, and CUDA_VISIBLE_DEVICES reveals an
+  // intentionally hidden GPU. This query is invoked at both problem creation and
+  // solve time; the decision is fixed for the life of the process, so log only once
+  // to avoid duplicate lines.
+  static std::atomic<bool> already_logged{false};
+  if (!already_logged.exchange(true)) {
+    CUOPT_LOG_INFO(
+      "cuOpt selected CPU memory backend: no usable CUDA device "
+      "(cudaGetDeviceCount err=%d (%s) count=%d, CUDA_VISIBLE_DEVICES=%s)",
+      static_cast<int>(err),
+      cudaGetErrorString(err),
+      cuda_count,
+      std::getenv("CUDA_VISIBLE_DEVICES") ? std::getenv("CUDA_VISIBLE_DEVICES") : "(unset)");
+  }
+  return memory_backend_t::CPU;
 }
 
 }  // namespace cuopt::mathematical_optimization

--- a/cpp/src/pdlp/backend_selection.cpp
+++ b/cpp/src/pdlp/backend_selection.cpp
@@ -10,11 +10,8 @@
 
 #include <cuda_runtime.h>
 
-#include <algorithm>
 #include <atomic>
-#include <cctype>
 #include <cstdlib>
-#include <string>
 
 namespace cuopt::mathematical_optimization {
 
@@ -30,28 +27,10 @@ execution_mode_t get_execution_mode()
   return is_remote_execution_enabled() ? execution_mode_t::REMOTE : execution_mode_t::LOCAL;
 }
 
-bool use_cpu_memory_for_local()
-{
-  const char* use_cpu_mem = std::getenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
-  if (use_cpu_mem != nullptr) {
-    std::string value(use_cpu_mem);
-    // Convert to lowercase for case-insensitive comparison
-    std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-    return (value == "true" || value == "1");
-  }
-  return false;
-}
-
-bool cpu_memory_backend_solve_allowed()
-{
-  return is_remote_execution_enabled() || use_cpu_memory_for_local();
-}
-
 memory_backend_t get_memory_backend_type()
 {
-  // Remote execution and the undocumented local test mode force CPU memory
-  // regardless of hardware, so decide without probing CUDA.
-  if (is_remote_execution_enabled() || use_cpu_memory_for_local()) { return memory_backend_t::CPU; }
+  // Remote execution forces CPU memory regardless of hardware.
+  if (is_remote_execution_enabled()) { return memory_backend_t::CPU; }
 
   int cuda_count        = 0;
   const cudaError_t err = cudaGetDeviceCount(&cuda_count);

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -2288,7 +2288,7 @@ std::unique_ptr<lp_solution_interface_t<i_t, f_t>> solve_lp(
   // Local execution - dispatch to appropriate overload based on problem type
   auto* cpu_prob = dynamic_cast<cpu_optimization_problem_t<i_t, f_t>*>(problem_interface);
   if (cpu_prob != nullptr) {
-    cuopt_expects(cpu_memory_backend_solve_allowed(),
+    cuopt_expects(is_remote_execution_enabled(),
                   error_type_t::ValidationError,
                   "A CPU-memory problem requires remote execution. Set CUOPT_REMOTE_HOST and "
                   "CUOPT_REMOTE_PORT to solve on a remote GPU server.");

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -2288,6 +2288,10 @@ std::unique_ptr<lp_solution_interface_t<i_t, f_t>> solve_lp(
   // Local execution - dispatch to appropriate overload based on problem type
   auto* cpu_prob = dynamic_cast<cpu_optimization_problem_t<i_t, f_t>*>(problem_interface);
   if (cpu_prob != nullptr) {
+    cuopt_expects(cpu_memory_backend_solve_allowed(),
+                  error_type_t::ValidationError,
+                  "A CPU-memory problem requires remote execution. Set CUOPT_REMOTE_HOST and "
+                  "CUOPT_REMOTE_PORT to solve on a remote GPU server.");
     return solve_lp(*cpu_prob, settings, problem_checking, use_pdlp_solver_mode, is_batch_mode);
   }
 

--- a/cpp/tests/linear_programming/c_api_tests/c_api_test.c
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_test.c
@@ -2619,8 +2619,238 @@ DONE:
 }
 
 /**
- * Read a problem as a GPU-backed handle (remote env and CUOPT_USE_CPU_MEM_FOR_LOCAL
- * must be unset), then enable remote execution and verify cuOptSolve rejects the GPU problem.
+ * Exercise read-only C API on a CPU-backed problem (CUDA_VISIBLE_DEVICES="" and no remote).
+ * Caller must set CUDA_VISIBLE_DEVICES="" before invoking.
+ */
+cuopt_int_t test_cpu_host_read_problem_api(const char* filename)
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuopt_int_t status;
+  cuopt_int_t num_variables    = 0;
+  cuopt_int_t num_constraints  = 0;
+  cuopt_int_t nnz              = 0;
+  cuopt_int_t objective_sense  = 0;
+  cuopt_float_t objective_offset = 0;
+  cuopt_float_t* objective_coefficients = NULL;
+  cuopt_float_t* var_lower_bounds       = NULL;
+  cuopt_float_t* var_upper_bounds       = NULL;
+  cuopt_int_t* row_offsets              = NULL;
+  cuopt_int_t* column_indices           = NULL;
+  cuopt_float_t* values                 = NULL;
+  char* constraint_sense                = NULL;
+  cuopt_float_t* rhs                    = NULL;
+  cuopt_int_t is_mip                    = 0;
+
+  status = cuOptReadProblem(filename, &problem);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error reading problem on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetNumVariables(problem, &num_variables);
+  if (status != CUOPT_SUCCESS || num_variables != 32) {
+    printf("Unexpected num variables on CPU host (status=%d, n=%d)\n", status, num_variables);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  status = cuOptGetNumConstraints(problem, &num_constraints);
+  if (status != CUOPT_SUCCESS || num_constraints != 27) {
+    printf("Unexpected num constraints on CPU host (status=%d, n=%d)\n", status, num_constraints);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  status = cuOptGetNumNonZeros(problem, &nnz);
+  if (status != CUOPT_SUCCESS || nnz <= 0) {
+    printf("Unexpected nnz on CPU host (status=%d, nnz=%d)\n", status, nnz);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveSense(problem, &objective_sense);
+  if (status != CUOPT_SUCCESS || objective_sense != CUOPT_MINIMIZE) {
+    printf("Unexpected objective sense on CPU host (status=%d, sense=%d)\n",
+           status,
+           objective_sense);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveOffset(problem, &objective_offset);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting objective offset on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  objective_coefficients = (cuopt_float_t*)malloc(num_variables * sizeof(cuopt_float_t));
+  var_lower_bounds       = (cuopt_float_t*)malloc(num_variables * sizeof(cuopt_float_t));
+  var_upper_bounds       = (cuopt_float_t*)malloc(num_variables * sizeof(cuopt_float_t));
+  row_offsets            = (cuopt_int_t*)malloc((num_constraints + 1) * sizeof(cuopt_int_t));
+  column_indices         = (cuopt_int_t*)malloc(nnz * sizeof(cuopt_int_t));
+  values                 = (cuopt_float_t*)malloc(nnz * sizeof(cuopt_float_t));
+  constraint_sense       = (char*)malloc(num_constraints * sizeof(char));
+  rhs                    = (cuopt_float_t*)malloc(num_constraints * sizeof(cuopt_float_t));
+  if (objective_coefficients == NULL || var_lower_bounds == NULL || var_upper_bounds == NULL ||
+      row_offsets == NULL || column_indices == NULL || values == NULL || constraint_sense == NULL ||
+      rhs == NULL) {
+    printf("Out of memory allocating CPU host API buffers\n");
+    status = CUOPT_OUT_OF_MEMORY;
+    goto DONE;
+  }
+
+  status = cuOptGetObjectiveCoefficients(problem, objective_coefficients);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting objective coefficients on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetVariableLowerBounds(problem, var_lower_bounds);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting variable lower bounds on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetVariableUpperBounds(problem, var_upper_bounds);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting variable upper bounds on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetConstraintMatrix(problem, row_offsets, column_indices, values);
+  if (status != CUOPT_SUCCESS || row_offsets[0] != 0 || row_offsets[num_constraints] != nnz) {
+    printf("Unexpected constraint matrix on CPU host (status=%d)\n", status);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  status = cuOptGetConstraintSense(problem, constraint_sense);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting constraint sense on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptGetConstraintRightHandSide(problem, rhs);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error getting constraint rhs on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptIsMIP(problem, &is_mip);
+  if (status != CUOPT_SUCCESS || is_mip != 0) {
+    printf("Expected LP problem on CPU host (status=%d, is_mip=%d)\n", status, is_mip);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  printf("CPU host read-only C API test passed (%d vars, %d cons, nnz=%d)\n",
+         num_variables,
+         num_constraints,
+         nnz);
+
+DONE:
+  free(objective_coefficients);
+  free(var_lower_bounds);
+  free(var_upper_bounds);
+  free(row_offsets);
+  free(column_indices);
+  free(values);
+  free(constraint_sense);
+  free(rhs);
+  cuOptDestroyProblem(&problem);
+  return status;
+}
+
+/**
+ * Build a small MIP via cuOptCreateProblem on a CPU-backed host and verify getters (no solve).
+ * Caller must set CUDA_VISIBLE_DEVICES="" before invoking.
+ */
+cuopt_int_t test_cpu_host_create_problem_api()
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuopt_int_t status;
+
+  enum { k_num_items = 8, k_num_constraints = 1 };
+  const cuopt_int_t num_variables   = k_num_items;
+  const cuopt_int_t num_constraints = k_num_constraints;
+  const cuopt_int_t nnz             = k_num_items;
+  const cuopt_float_t max_weight    = 102;
+  cuopt_float_t value[]             = {15, 100, 90, 60, 40, 15, 10, 1};
+  cuopt_float_t weight[]            = {2, 20, 20, 30, 40, 30, 60, 10};
+  cuopt_int_t row_offsets[]         = {0, k_num_items};
+  cuopt_int_t column_indices[k_num_items];
+  cuopt_float_t rhs[]               = {max_weight};
+  char constraint_sense[]           = {CUOPT_LESS_THAN};
+  cuopt_float_t lower_bounds[k_num_items];
+  cuopt_float_t upper_bounds[k_num_items];
+  char variable_types[k_num_items];
+  cuopt_int_t objective_sense         = CUOPT_MAXIMIZE;
+  cuopt_float_t objective_offset      = 0;
+  cuopt_int_t is_mip                  = 0;
+
+  for (cuopt_int_t j = 0; j < k_num_items; j++) {
+    column_indices[j] = j;
+    variable_types[j] = CUOPT_INTEGER;
+    lower_bounds[j]   = 0;
+    upper_bounds[j]   = 1;
+  }
+
+  status = cuOptCreateProblem(num_constraints,
+                              num_variables,
+                              objective_sense,
+                              objective_offset,
+                              value,
+                              row_offsets,
+                              column_indices,
+                              weight,
+                              constraint_sense,
+                              rhs,
+                              lower_bounds,
+                              upper_bounds,
+                              variable_types,
+                              &problem);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating optimization problem on CPU host: %d\n", status);
+    goto DONE;
+  }
+
+  status = check_problem(problem,
+                         num_constraints,
+                         num_variables,
+                         nnz,
+                         objective_sense,
+                         objective_offset,
+                         value,
+                         row_offsets,
+                         column_indices,
+                         weight,
+                         constraint_sense,
+                         rhs,
+                         lower_bounds,
+                         upper_bounds,
+                         variable_types);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error checking CPU host created problem\n");
+    goto DONE;
+  }
+
+  status = cuOptIsMIP(problem, &is_mip);
+  if (status != CUOPT_SUCCESS || is_mip != 1) {
+    printf("Expected MIP on CPU host (status=%d, is_mip=%d)\n", status, is_mip);
+    status = CUOPT_VALIDATION_ERROR;
+    goto DONE;
+  }
+
+  printf("CPU host create-problem C API test passed\n");
+
+DONE:
+  cuOptDestroyProblem(&problem);
+  return status;
+}
+
+/**
+ * Read a problem as a GPU-backed handle (remote env must be unset), then enable
+ * remote execution and verify cuOptSolve rejects the GPU problem.
  */
 cuopt_int_t test_gpu_problem_remote_after_create(const char* filename)
 {
@@ -2631,13 +2861,10 @@ cuopt_int_t test_gpu_problem_remote_after_create(const char* filename)
 
   const char* orig_remote_host = getenv("CUOPT_REMOTE_HOST");
   const char* orig_remote_port = getenv("CUOPT_REMOTE_PORT");
-  const char* orig_use_cpu_mem   = getenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
-  const int host_was_set         = (orig_remote_host != NULL);
-  const int port_was_set         = (orig_remote_port != NULL);
-  const int use_cpu_mem_was_set  = (orig_use_cpu_mem != NULL);
-  char saved_remote_host[256]      = "";
-  char saved_remote_port[64]     = "";
-  char saved_use_cpu_mem[64]       = "";
+  const int host_was_set       = (orig_remote_host != NULL);
+  const int port_was_set       = (orig_remote_port != NULL);
+  char saved_remote_host[256]  = "";
+  char saved_remote_port[64]   = "";
 
   if (host_was_set) {
     strncpy(saved_remote_host, orig_remote_host, sizeof(saved_remote_host) - 1);
@@ -2647,14 +2874,9 @@ cuopt_int_t test_gpu_problem_remote_after_create(const char* filename)
     strncpy(saved_remote_port, orig_remote_port, sizeof(saved_remote_port) - 1);
     saved_remote_port[sizeof(saved_remote_port) - 1] = '\0';
   }
-  if (use_cpu_mem_was_set) {
-    strncpy(saved_use_cpu_mem, orig_use_cpu_mem, sizeof(saved_use_cpu_mem) - 1);
-    saved_use_cpu_mem[sizeof(saved_use_cpu_mem) - 1] = '\0';
-  }
 
   unsetenv("CUOPT_REMOTE_HOST");
   unsetenv("CUOPT_REMOTE_PORT");
-  unsetenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
 
   printf("Testing GPU problem rejects remote solve after create...\n");
   printf("  (read with remote unset, then set CUOPT_REMOTE_* before solve)\n");
@@ -2710,11 +2932,6 @@ DONE:
     setenv("CUOPT_REMOTE_PORT", saved_remote_port, 1);
   } else {
     unsetenv("CUOPT_REMOTE_PORT");
-  }
-  if (use_cpu_mem_was_set) {
-    setenv("CUOPT_USE_CPU_MEM_FOR_LOCAL", saved_use_cpu_mem, 1);
-  } else {
-    unsetenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
   }
 
   return status;

--- a/cpp/tests/linear_programming/c_api_tests/c_api_test.c
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_test.c
@@ -2617,3 +2617,105 @@ DONE:
   cuOptDestroySolution(&solution);
   return status;
 }
+
+/**
+ * Read a problem as a GPU-backed handle (remote env and CUOPT_USE_CPU_MEM_FOR_LOCAL
+ * must be unset), then enable remote execution and verify cuOptSolve rejects the GPU problem.
+ */
+cuopt_int_t test_gpu_problem_remote_after_create(const char* filename)
+{
+  cuOptOptimizationProblem problem = NULL;
+  cuOptSolverSettings settings     = NULL;
+  cuOptSolution solution           = NULL;
+  cuopt_int_t status;
+
+  const char* orig_remote_host = getenv("CUOPT_REMOTE_HOST");
+  const char* orig_remote_port = getenv("CUOPT_REMOTE_PORT");
+  const char* orig_use_cpu_mem   = getenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
+  const int host_was_set         = (orig_remote_host != NULL);
+  const int port_was_set         = (orig_remote_port != NULL);
+  const int use_cpu_mem_was_set  = (orig_use_cpu_mem != NULL);
+  char saved_remote_host[256]      = "";
+  char saved_remote_port[64]     = "";
+  char saved_use_cpu_mem[64]       = "";
+
+  if (host_was_set) {
+    strncpy(saved_remote_host, orig_remote_host, sizeof(saved_remote_host) - 1);
+    saved_remote_host[sizeof(saved_remote_host) - 1] = '\0';
+  }
+  if (port_was_set) {
+    strncpy(saved_remote_port, orig_remote_port, sizeof(saved_remote_port) - 1);
+    saved_remote_port[sizeof(saved_remote_port) - 1] = '\0';
+  }
+  if (use_cpu_mem_was_set) {
+    strncpy(saved_use_cpu_mem, orig_use_cpu_mem, sizeof(saved_use_cpu_mem) - 1);
+    saved_use_cpu_mem[sizeof(saved_use_cpu_mem) - 1] = '\0';
+  }
+
+  unsetenv("CUOPT_REMOTE_HOST");
+  unsetenv("CUOPT_REMOTE_PORT");
+  unsetenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
+
+  printf("Testing GPU problem rejects remote solve after create...\n");
+  printf("  (read with remote unset, then set CUOPT_REMOTE_* before solve)\n");
+
+  status = cuOptReadProblem(filename, &problem);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error reading problem: %d\n", status);
+    goto DONE;
+  }
+
+  setenv("CUOPT_REMOTE_HOST", "localhost", 1);
+  setenv("CUOPT_REMOTE_PORT", "18500", 1);
+
+  status = cuOptCreateSolverSettings(&settings);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error creating solver settings: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSetParameter(settings, "log_to_console", "true");
+  if (status != CUOPT_SUCCESS) {
+    printf("Error setting log_to_console: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSetIntegerParameter(settings, CUOPT_METHOD, CUOPT_METHOD_PDLP);
+  if (status != CUOPT_SUCCESS) {
+    printf("Error setting method: %d\n", status);
+    goto DONE;
+  }
+
+  status = cuOptSolve(problem, settings, &solution);
+  if (status != CUOPT_VALIDATION_ERROR) {
+    printf("Expected CUOPT_VALIDATION_ERROR (%d), got %d\n", CUOPT_VALIDATION_ERROR, status);
+    status = -1;
+    goto DONE;
+  }
+
+  printf("GPU problem correctly rejected remote solve with CUOPT_VALIDATION_ERROR\n");
+  status = CUOPT_SUCCESS;
+
+DONE:
+  cuOptDestroyProblem(&problem);
+  cuOptDestroySolverSettings(&settings);
+  cuOptDestroySolution(&solution);
+
+  if (host_was_set) {
+    setenv("CUOPT_REMOTE_HOST", saved_remote_host, 1);
+  } else {
+    unsetenv("CUOPT_REMOTE_HOST");
+  }
+  if (port_was_set) {
+    setenv("CUOPT_REMOTE_PORT", saved_remote_port, 1);
+  } else {
+    unsetenv("CUOPT_REMOTE_PORT");
+  }
+  if (use_cpu_mem_was_set) {
+    setenv("CUOPT_USE_CPU_MEM_FOR_LOCAL", saved_use_cpu_mem, 1);
+  } else {
+    unsetenv("CUOPT_USE_CPU_MEM_FOR_LOCAL");
+  }
+
+  return status;
+}

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -16,6 +16,8 @@
 #include <cuopt/mathematical_optimization/cuopt_c.h>
 #include <pdlp/cuopt_c_internal.hpp>
 
+#include <cuda_runtime.h>
+
 #include <utilities/common_utils.hpp>
 #include <utilities/error.hpp>
 
@@ -666,6 +668,18 @@ TEST_F(CpuOnlyWithServerTest, mip_solve)
   const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
   std::string mip_file                    = rapidsDatasetRootDir + "/mip/bb_optimality.mps";
   EXPECT_EQ(test_cpu_only_mip_execution(mip_file.c_str()), CUOPT_SUCCESS);
+}
+
+TEST(c_api, gpu_problem_rejects_remote_after_create)
+{
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0) {
+    GTEST_SKIP() << "Requires a visible CUDA device to create a GPU-backed problem";
+  }
+
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string lp_file = rapidsDatasetRootDir + "/linear_programming/afiro_original.mps";
+  EXPECT_EQ(test_gpu_problem_remote_after_create(lp_file.c_str()), CUOPT_SUCCESS);
 }
 
 // Note: cuopt_cli subprocess tests are in Python (test_cpu_only_execution.py)

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.cpp
@@ -530,6 +530,71 @@ bool tcp_connect_check(int port, int timeout_ms)
 
 }  // namespace
 
+class CpuHostProblemApiTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite()
+  {
+    const char* cv     = getenv("CUDA_VISIBLE_DEVICES");
+    const char* rh     = getenv("CUOPT_REMOTE_HOST");
+    const char* rp     = getenv("CUOPT_REMOTE_PORT");
+    orig_cuda_visible_ = cv ? cv : "";
+    orig_remote_host_  = rh ? rh : "";
+    orig_remote_port_  = rp ? rp : "";
+    cuda_was_set_      = (cv != nullptr);
+    host_was_set_      = (rh != nullptr);
+    port_was_set_      = (rp != nullptr);
+
+    setenv("CUDA_VISIBLE_DEVICES", "", 1);
+    unsetenv("CUOPT_REMOTE_HOST");
+    unsetenv("CUOPT_REMOTE_PORT");
+  }
+
+  static void TearDownTestSuite()
+  {
+    if (cuda_was_set_) {
+      setenv("CUDA_VISIBLE_DEVICES", orig_cuda_visible_.c_str(), 1);
+    } else {
+      unsetenv("CUDA_VISIBLE_DEVICES");
+    }
+    if (host_was_set_) {
+      setenv("CUOPT_REMOTE_HOST", orig_remote_host_.c_str(), 1);
+    } else {
+      unsetenv("CUOPT_REMOTE_HOST");
+    }
+    if (port_was_set_) {
+      setenv("CUOPT_REMOTE_PORT", orig_remote_port_.c_str(), 1);
+    } else {
+      unsetenv("CUOPT_REMOTE_PORT");
+    }
+  }
+
+  static std::string orig_cuda_visible_;
+  static std::string orig_remote_host_;
+  static std::string orig_remote_port_;
+  static bool cuda_was_set_;
+  static bool host_was_set_;
+  static bool port_was_set_;
+};
+
+std::string CpuHostProblemApiTest::orig_cuda_visible_;
+std::string CpuHostProblemApiTest::orig_remote_host_;
+std::string CpuHostProblemApiTest::orig_remote_port_;
+bool CpuHostProblemApiTest::cuda_was_set_ = false;
+bool CpuHostProblemApiTest::host_was_set_ = false;
+bool CpuHostProblemApiTest::port_was_set_ = false;
+
+TEST_F(CpuHostProblemApiTest, read_problem_api)
+{
+  const std::string& rapidsDatasetRootDir = cuopt::test::get_rapids_dataset_root_dir();
+  std::string lp_file = rapidsDatasetRootDir + "/linear_programming/afiro_original.mps";
+  EXPECT_EQ(test_cpu_host_read_problem_api(lp_file.c_str()), CUOPT_SUCCESS);
+}
+
+TEST_F(CpuHostProblemApiTest, create_problem_api)
+{
+  EXPECT_EQ(test_cpu_host_create_problem_api(), CUOPT_SUCCESS);
+}
+
 class CpuOnlyWithServerTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite()

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
@@ -74,6 +74,10 @@ cuopt_int_t test_pdlp_precision_mixed(const char* filename,
 cuopt_int_t test_cpu_only_execution(const char* filename);
 cuopt_int_t test_cpu_only_mip_execution(const char* filename);
 
+/* CPU-host read/create C API (require CUDA_VISIBLE_DEVICES="", no remote, no solve) */
+cuopt_int_t test_cpu_host_read_problem_api(const char* filename);
+cuopt_int_t test_cpu_host_create_problem_api();
+
 /* GPU-backed problem created before remote env is set must reject remote solve */
 cuopt_int_t test_gpu_problem_remote_after_create(const char* filename);
 

--- a/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
+++ b/cpp/tests/linear_programming/c_api_tests/c_api_tests.h
@@ -74,6 +74,9 @@ cuopt_int_t test_pdlp_precision_mixed(const char* filename,
 cuopt_int_t test_cpu_only_execution(const char* filename);
 cuopt_int_t test_cpu_only_mip_execution(const char* filename);
 
+/* GPU-backed problem created before remote env is set must reject remote solve */
+cuopt_int_t test_gpu_problem_remote_after_create(const char* filename);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This change makes the selection of CPU vs GPU memory automatic based on the presence of a GPU. Previously, CPU backed problems were only created when remote execution is enabled. Now, they can be created automatically on a CPU host or on a GPU host with CUDA_VISIBLE_DEVICES="".  This lays the foundation for more flexibility in the future for use of the parser on CPU hosts, etc.