### PR TITLE
Removed `b_bar` test for Gomory Cuts

### DIFF
--- a/cpp/src/cuts/cuts.cpp
+++ b/cpp/src/cuts/cuts.cpp
@@ -4384,12 +4384,6 @@ i_t tableau_equality_t<i_t, f_t>::generate_base_equality(
     return -1;
   }
 
-  const f_t f_val = b_bar_[i] - std::floor(b_bar_[i]);
-  if (f_val < 0.01 || f_val > 0.99) {
-    // Skip cuts with rhs has small fractional part
-    return -1;
-  }
-
 #ifdef PRINT_BASE_INEQUALITY
   // Print out the base inequality
   for (i_t k = 0; k < a_bar.i.size(); k++) {


### PR DESCRIPTION
This PR removes the test `b_bar_[i] - std::floor(b_bar_[i])` used for rejecting a Gomory cuts, which let more cuts to be added to the pool. Overall, this improves the lower bound in the root node for `comp21-2idx` and ` pg5_34` and for a customer instance. It is performance neutral for other instances.

MIPLIB2017:
GH200, 10min

```
--------------------------------------------------------------------------------------------------------------------------------------------------------
Outcome cross-reference: 13 instances with |LB Δ%| > 1.0%
P.gap = primal gap %, P.int = primal integral / time, Time = solve time (s), R.gap = relative MIP gap %
(run-2 value green when better/lower, red when worse/higher)
--------------------------------------------------------------------------------------------------------------------------------------------------------
| Instance                 |     LB Δ% |    P.gap% 1 |    P.gap% 2 |     P.int 1 |     P.int 2 |      Time 1 |      Time 2 |    R.gap% 1 |    R.gap% 2 |
--------------------------------------------------------------------------------------------------------------------------------------------------------
| comp07-2idx              |    +5e+10 |       1e-08 |       1e-08 |       22.38 |       6.453 |       524.4 |       100.1 |           0 |           0 |
| comp21-2idx              |      +800 |       39.84 |       28.16 |       45.59 |       31.92 |       600.2 |       600.6 |       95.93 |       61.17 |
| cbs-cta                  |     -50.9 |       1e-08 |       1e-08 |       4.728 |       6.958 |       600.1 |         600 |           0 |           0 |
| nursesched-medium-hint03 |     +8.85 |       91.28 |       75.16 |       92.15 |       79.57 |       602.7 |         600 |       96.13 |        87.9 |
| timtab1                  |     +7.88 |        1.96 |       2.985 |       4.304 |       3.685 |         600 |         600 |        13.1 |       13.69 |
| istanbul-no-cutoff       |     +5.15 |       1e-08 |       1e-08 |      0.8675 |       1.061 |        27.5 |       23.52 |           0 |           0 |
| neos-3381206-awhea       |     +1.65 |      0.4396 |       1e-08 |       1.144 |      0.3994 |       600.1 |       600.1 |        5.05 |        3.09 |
| pg5_34                   |     +1.63 |     0.00902 |   2.406e-05 |     0.07527 |     0.06616 |         600 |       36.64 |        0.29 |        0.01 |
| roll3000                 |     -1.49 |      0.1162 |     0.02327 |      0.8811 |      0.8264 |         600 |         600 |        1.32 |         2.4 |
| csched007                |     +1.28 |      0.8475 |       3.039 |       4.108 |       4.597 |         600 |         600 |        8.19 |        7.18 |
| uct-subprob              |     -1.16 |      0.6329 |       1.567 |      0.9876 |       1.937 |         600 |         600 |        7.28 |        8.15 |
| dws008-01                |     +1.08 |       2.301 |       10.84 |       8.475 |       17.25 |       600.1 |         600 |       52.31 |       57.96 |
| pg                       |     +1.02 |       1e-08 |       1e-08 |      0.2042 |      0.2184 |       600.2 |         600 |        3.77 |        2.61 |
--------------------------------------------------------------------------------------------------------------------------------------------------------
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
