### PR TITLE
Add a log-once macro

### DIFF
--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -351,14 +351,6 @@ void return_gpu_to_the_queue(std::unordered_map<pid_t, int>& pid_gpu_map,
 
 int main(int argc, char* argv[])
 {
-  // TEMP: manual smoke test of the rate-limited logging macros (CUOPT_LOG_ONCE /
-  // CUOPT_LOG_FIRST_N / CUOPT_LOG_EVERY_N). Remove before merging.
-  for (int i = 0; i < 10; ++i) {
-    CUOPT_LOG_ONCE(INFO, "LOG_ONCE: should appear exactly once (iteration %d)", i);
-    CUOPT_LOG_FIRST_N(INFO, 3, "LOG_FIRST_N(3): should appear on i=0,1,2 (iteration %d)", i);
-    CUOPT_LOG_EVERY_N(INFO, 4, "LOG_EVERY_N(4): should appear on i=0,4,8 (iteration %d)", i);
-  }
-
   argparse::ArgumentParser program("solve_MIP");
 
   // Define all arguments with appropriate defaults and help messages

--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -351,6 +351,14 @@ void return_gpu_to_the_queue(std::unordered_map<pid_t, int>& pid_gpu_map,
 
 int main(int argc, char* argv[])
 {
+  // TEMP: manual smoke test of the rate-limited logging macros (CUOPT_LOG_ONCE /
+  // CUOPT_LOG_FIRST_N / CUOPT_LOG_EVERY_N). Remove before merging.
+  for (int i = 0; i < 10; ++i) {
+    CUOPT_LOG_ONCE(INFO, "LOG_ONCE: should appear exactly once (iteration %d)", i);
+    CUOPT_LOG_FIRST_N(INFO, 3, "LOG_FIRST_N(3): should appear on i=0,1,2 (iteration %d)", i);
+    CUOPT_LOG_EVERY_N(INFO, 4, "LOG_EVERY_N(4): should appear on i=0,4,8 (iteration %d)", i);
+  }
+
   argparse::ArgumentParser program("solve_MIP");
 
   // Define all arguments with appropriate defaults and help messages

--- a/cpp/src/pdlp/backend_selection.cpp
+++ b/cpp/src/pdlp/backend_selection.cpp
@@ -10,7 +10,6 @@
 
 #include <cuda_runtime.h>
 
-#include <atomic>
 #include <cstdlib>
 
 namespace cuopt::mathematical_optimization {
@@ -43,16 +42,13 @@ memory_backend_t get_memory_backend_type()
   // intentionally hidden GPU. This query is invoked at both problem creation and
   // solve time; the decision is fixed for the life of the process, so log only once
   // to avoid duplicate lines.
-  static std::atomic<bool> already_logged{false};
-  if (!already_logged.exchange(true)) {
-    CUOPT_LOG_INFO(
-      "cuOpt selected CPU memory backend: no usable CUDA device "
-      "(cudaGetDeviceCount err=%d (%s) count=%d, CUDA_VISIBLE_DEVICES=%s)",
-      static_cast<int>(err),
-      cudaGetErrorString(err),
-      cuda_count,
-      std::getenv("CUDA_VISIBLE_DEVICES") ? std::getenv("CUDA_VISIBLE_DEVICES") : "(unset)");
-  }
+  CUOPT_LOG_ONCE(INFO,
+    "cuOpt selected CPU memory backend: no usable CUDA device "
+    "(cudaGetDeviceCount err=%d (%s) count=%d, CUDA_VISIBLE_DEVICES=%s)",
+    static_cast<int>(err),
+    cudaGetErrorString(err),
+    cuda_count,
+    std::getenv("CUDA_VISIBLE_DEVICES") ? std::getenv("CUDA_VISIBLE_DEVICES") : "(unset)");
   return memory_backend_t::CPU;
 }
 

--- a/cpp/src/pdlp/backend_selection.cpp
+++ b/cpp/src/pdlp/backend_selection.cpp
@@ -42,7 +42,8 @@ memory_backend_t get_memory_backend_type()
   // intentionally hidden GPU. This query is invoked at both problem creation and
   // solve time; the decision is fixed for the life of the process, so log only once
   // to avoid duplicate lines.
-  CUOPT_LOG_ONCE(INFO,
+  CUOPT_LOG_ONCE(
+    INFO,
     "cuOpt selected CPU memory backend: no usable CUDA device "
     "(cudaGetDeviceCount err=%d (%s) count=%d, CUDA_VISIBLE_DEVICES=%s)",
     static_cast<int>(err),

--- a/cpp/src/utilities/logger.hpp
+++ b/cpp/src/utilities/logger.hpp
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/utilities/logger.hpp
+++ b/cpp/src/utilities/logger.hpp
@@ -11,10 +11,13 @@
 
 #include <rapids_logger/logger.hpp>
 
+#include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace cuopt {
@@ -42,4 +45,51 @@ class init_logger_t {
   init_logger_t(std::string log_file, bool log_to_console);
 };
 
+namespace detail {
+
+// Returns true for the first N calls sharing this counter.
+template <auto N>
+inline bool log_first_n_should_emit(std::atomic<uint64_t>& counter)
+{
+  static_assert(std::is_integral_v<decltype(N)>,
+                "CUOPT_LOG_FIRST_N/CUOPT_LOG_ONCE requires an integral N");
+  static_assert(N > 0, "CUOPT_LOG_FIRST_N/CUOPT_LOG_ONCE requires N > 0");
+  constexpr uint64_t threshold = (uint64_t)N;
+
+  if (counter.load(std::memory_order_relaxed) >= threshold) { return false; }
+  return counter.fetch_add(1, std::memory_order_relaxed) < threshold;
+}
+
+// Returns true on calls 1, N+1, 2N+1, ...
+template <auto N>
+inline bool log_every_n_should_emit(std::atomic<uint64_t>& counter)
+{
+  static_assert(std::is_integral_v<decltype(N)>, "CUOPT_LOG_EVERY_N requires an integral N");
+  static_assert(N > 0, "CUOPT_LOG_EVERY_N requires N > 0");
+  return counter.fetch_add(1, std::memory_order_relaxed) % (uint64_t)N == 0;
+}
+
+}  // namespace detail
+
 }  // namespace cuopt
+
+// Rate-limited logging built on the generated CUOPT_LOG_<level> macros. `level` is one of
+// TRACE/DEBUG/INFO/WARN/ERROR/CRITICAL; `n` must be a positive compile-time constant. Each
+// call site owns its own counter, so throttling is independent per use.
+#define CUOPT_LOG_FIRST_N(level, n, ...)                                   \
+  do {                                                                     \
+    static std::atomic<uint64_t> _cuopt_log_counter{0};                    \
+    if (cuopt::detail::log_first_n_should_emit<(n)>(_cuopt_log_counter)) { \
+      CUOPT_LOG_##level(__VA_ARGS__);                                      \
+    }                                                                      \
+  } while (0)
+
+#define CUOPT_LOG_EVERY_N(level, n, ...)                                   \
+  do {                                                                     \
+    static std::atomic<uint64_t> _cuopt_log_counter{0};                    \
+    if (cuopt::detail::log_every_n_should_emit<(n)>(_cuopt_log_counter)) { \
+      CUOPT_LOG_##level(__VA_ARGS__);                                      \
+    }                                                                      \
+  } while (0)
+
+#define CUOPT_LOG_ONCE(level, ...) CUOPT_LOG_FIRST_N(level, 1, __VA_ARGS__)


### PR DESCRIPTION
This PR implements a LOG_ONCE macro, along with LOG_EVERY_N and LOG_FIRST_N macros.

```cpp
#include <utilities/logger.hpp>

// Log exactly once per process (per call site), regardless of how often this runs.
CUOPT_LOG_ONCE(INFO, "CPU memory backend selected (no usable CUDA device)");

// Log only the first N times this line is hit.
CUOPT_LOG_FIRST_N(WARN, 5, "solver restart #%d exceeded soft limit", restart_id);

// Log on the 1st, then every Nth hit (calls 1, N+1, 2N+1, ...).
for (int it = 0; it < num_iterations; ++it) {
  CUOPT_LOG_EVERY_N(INFO, 100, "iteration %d, primal residual = %g", it, residual);
}
```

closes #1523

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
