### PR TITLE
dnm: test wheel ci on cuda base

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,12 +20,12 @@ jobs:
       - compute-matrix-filters
       - changed-files
       - checks
-      - conda-cpp-build
-      - conda-cpp-tests
-      - conda-python-build
-      - conda-python-tests
-      - docs-build
-      - multi-gpu-cpp-tests
+      # - conda-cpp-build
+      # - conda-cpp-tests
+      # - conda-python-build
+      # - conda-python-tests
+      # - docs-build
+      # - multi-gpu-cpp-tests
       - wheel-build-libcuopt
       - wheel-build-cuopt
       - wheel-tests-cuopt
@@ -33,7 +33,7 @@ jobs:
       - wheel-tests-cuopt-server
       - wheel-build-cuopt-sh-client
       - test-self-hosted-server
-      - pr-test-summary
+      # - pr-test-summary
     permissions:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
@@ -330,115 +330,115 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       enable_check_generated_files: false
-  conda-cpp-build:
-    needs: [checks, compute-matrix-filters, changed-files]
-    # Consumed by conda-cpp-tests, conda-python-build, and (transitively) docs-build.
-    if: >-
-      fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp ||
-      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda ||
-      fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_cpp.sh
-  conda-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      script: ci/test_cpp.sh
-    secrets:
-      script-env-secret-1-key: CUOPT_S3_URI
-      script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}
-      script-env-secret-2-key: CUOPT_AWS_ACCESS_KEY_ID
-      script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
-      script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
-      script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
-  multi-gpu-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    uses: ./.github/workflows/multi_gpu_cpp_test.yaml
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      # Non-blocking while the multi-GPU test suite is maturing.
-      continue-on-error: true
-  conda-python-build:
-    needs: [conda-cpp-build, changed-files]
-    # Consumed by conda-python-tests and docs-build.
-    if: >-
-      fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda ||
-      fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_python.sh
-  conda-python-tests:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      run_codecov: false
-      build_type: pull-request
-      script: ci/test_python.sh
-    secrets:
-      script-env-secret-1-key: CUOPT_S3_URI
-      script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}
-      script-env-secret-2-key: CUOPT_AWS_ACCESS_KEY_ID
-      script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
-      script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
-      script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
-  docs-build:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      file_to_upload: "docs/cuopt/build/html/"
-      artifact-name: "cuopt_docs"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/build_docs.sh"
+  # conda-cpp-build:
+  #   needs: [checks, compute-matrix-filters, changed-files]
+  #   # Consumed by conda-cpp-tests, conda-python-build, and (transitively) docs-build.
+  #   if: >-
+  #     fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp ||
+  #     fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda ||
+  #     fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_cpp.sh
+  # conda-cpp-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_cpp.sh
+  #   secrets:
+  #     script-env-secret-1-key: CUOPT_S3_URI
+  #     script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}
+  #     script-env-secret-2-key: CUOPT_AWS_ACCESS_KEY_ID
+  #     script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
+  #     script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
+  #     script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
+  # multi-gpu-cpp-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   uses: ./.github/workflows/multi_gpu_cpp_test.yaml
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     # Non-blocking while the multi-GPU test suite is maturing.
+  #     continue-on-error: true
+  # conda-python-build:
+  #   needs: [conda-cpp-build, changed-files]
+  #   # Consumed by conda-python-tests and docs-build.
+  #   if: >-
+  #     fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda ||
+  #     fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python.sh
+  # conda-python-tests:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     run_codecov: false
+  #     build_type: pull-request
+  #     script: ci/test_python.sh
+  #   secrets:
+  #     script-env-secret-1-key: CUOPT_S3_URI
+  #     script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}
+  #     script-env-secret-2-key: CUOPT_AWS_ACCESS_KEY_ID
+  #     script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
+  #     script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
+  #     script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
+  # docs-build:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     file_to_upload: "docs/cuopt/build/html/"
+  #     artifact-name: "cuopt_docs"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/build_docs.sh"
   wheel-build-libcuopt:
     needs: [compute-matrix-filters, changed-files]
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
@@ -481,7 +481,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -540,7 +540,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -567,25 +567,25 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_self_hosted_service.sh
-  pr-test-summary:
-    needs:
-      - conda-cpp-tests
-      - conda-python-tests
-      - wheel-tests-cuopt
-      - wheel-tests-cuopt-server
-      - test-self-hosted-server
-    if: always()
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: ci/utils/pr_test_summary.py
-          sparse-checkout-cone-mode: false
-      - run: python3 ci/utils/pr_test_summary.py
-        env:
-          GH_TOKEN: ${{ github.token }}
+  # pr-test-summary:
+  #   needs:
+  #     - conda-cpp-tests
+  #     - conda-python-tests
+  #     - wheel-tests-cuopt
+  #     - wheel-tests-cuopt-server
+  #     - test-self-hosted-server
+  #   if: always()
+  #   continue-on-error: true
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: read
+  #     pull-requests: write
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         persist-credentials: false
+  #         sparse-checkout: ci/utils/pr_test_summary.py
+  #         sparse-checkout-cone-mode: false
+  #     - run: python3 ci/utils/pr_test_summary.py
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,6 +154,7 @@ files:
       - test_python_common
       - test_python_cuopt
       - depends_on_rapids_logger
+      - test_cufile
   py_build_cuopt_server:
     output: pyproject
     pyproject_dir: python/cuopt_server
@@ -848,3 +849,18 @@ dependencies:
           - matrix:
             packages:
               - python>=3.11,<3.15
+  test_cufile:
+    specific:
+      # The `cufile` extra was added to the `cuda-toolkit` metapackage in 12.6.3
+      # Adding an explicit test dependency on the cufile package here for
+      # testing on versions before 12.6.3
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              arch: aarch64
+              cuda: "12.*"
+              use_cuda_wheels: "true"
+            packages:
+              - nvidia-cufile-cu12
+          - matrix:
+            packages:


### PR DESCRIPTION
xref rapidsai/build-planning#143
xref rapidsai/ci-imgs#400
xref rapidsai/shared-workflows#521

Test run using the smaller `cuda-base` image as the parent image of `citestwheel`

This shouldn't be merged. If all projects can run wheel tests with this image, we'll swap out the image upstream in `shared-workflows`.
