### PR TITLE
fix(deps): add explicit cufile dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,6 +154,7 @@ files:
       - test_python_common
       - test_python_cuopt
       - depends_on_rapids_logger
+      - test_cufile
   py_build_cuopt_server:
     output: pyproject
     pyproject_dir: python/cuopt_server
@@ -736,6 +737,10 @@ dependencies:
 
 
   cuda_wheels:
+    common:
+      - output_types: [requirements, pyproject]
+        packages:
+          - cuda-pathfinder
     specific:
       # cuOpt needs 'nvJitLink>={whatever-cuopt-was-built-against}' at runtime, and mixing
       # old-CTK with new-nvJitLink is supported, so maintain 1 entry here per CUDA major.minor
@@ -754,14 +759,14 @@ dependencies:
               cuda: "12.*"
               use_cuda_wheels: "true"
             packages:
-              - cuda-toolkit[cublas,cudart,curand,cusolver,cusparse,nvtx]==12.*
+              - cuda-toolkit[cublas,cudart,cufile,curand,cusolver,cusparse,nvtx]==12.*
               - nvidia-cudss-cu12>=0.7,<0.8
               - nvidia-nvjitlink-cu12>=12.9,<13
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "true"
             packages:
-              - &ctk_cu13 cuda-toolkit[cublas,cudart,curand,cusolver,cusparse,nvtx]==13.*
+              - &ctk_cu13 cuda-toolkit[cublas,cudart,cufile,curand,cusolver,cusparse,nvtx]==13.*
               - &cudss_cu13 nvidia-cudss-cu13>=0.7,<0.8
               - &nvjitlink_cu13 nvidia-nvjitlink>=13.0,<14
           # if no matching matrix selectors passed, list the CUDA 13 requirement
@@ -848,3 +853,17 @@ dependencies:
           - matrix:
             packages:
               - python>=3.11,<3.15
+  test_cufile:
+    specific:
+      # The `cufile` extra was added to the `cuda-toolkit` metapackage in 12.6.3
+      # Adding an explicit test dependency on the cufile package here for
+      # testing on versions before 12.6.3
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              use_cuda_wheels: "true"
+            packages:
+              - nvidia-cufile-cu12
+          - matrix:
+            packages:

--- a/python/libcuopt/libcuopt/load.py
+++ b/python/libcuopt/libcuopt/load.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -41,10 +41,16 @@ def load_library():
         import libraft
         import librmm
         import rapids_logger
+        from cuda.pathfinder import load_nvidia_dynamic_lib
 
         rapids_logger.load_library()
         librmm.load_library()
         libraft.load_library()
+        # We manually load librt.so.1 here to workaround a bad dynamic link
+        # in nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl
+        # https://nvbugspro.nvidia.com/bug/6425783
+        ctypes.CDLL("librt.so.1", mode=ctypes.RTLD_GLOBAL)
+        load_nvidia_dynamic_lib("cufile")
     except ModuleNotFoundError:
         pass
 

--- a/python/libcuopt/pyproject.toml
+++ b/python/libcuopt/pyproject.toml
@@ -30,7 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "cuda-toolkit[cublas,cudart,curand,cusolver,cusparse,nvtx]==13.*",
+    "cuda-pathfinder",
+    "cuda-toolkit[cublas,cudart,cufile,curand,cusolver,cusparse,nvtx]==13.*",
     "librmm==26.8.*,>=0.0.0a0",
     "nvidia-cudss-cu13>=0.7,<0.8",
     "nvidia-nvjitlink>=13.0,<14",


### PR DESCRIPTION
## Description

Testing a smaller base CI image for wheel tests in #1548 -- that image does not have cuda toolkit installed and we rely on installing all dependencies from wheels.
That test bubbled up a missing `cufile` dependency (which was previously satisfied by the `libcufile.so` that was present on the CI image already).

I've also added in a workaround for a bug with the `cufile` wheels on ARM64, where they fail to load required dynamic libraries.

We had to make the same changes in rapidsai/kvikio#1000

xref rapidsai/build-planning#143

CI run before this change: https://github.com/NVIDIA/cuopt/actions/runs/29044331506/job/86218256034?pr=1548

And after this change: https://github.com/NVIDIA/cuopt/actions/runs/29054246782/job/86246625279?pr=1548


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
