### PR TITLE
fix(deps): add cufile to test dependencies for cuda12

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -154,6 +154,7 @@ files:
       - test_python_common
       - test_python_cuopt
       - depends_on_rapids_logger
+      - test_cufile
   py_build_cuopt_server:
     output: pyproject
     pyproject_dir: python/cuopt_server
@@ -848,3 +849,17 @@ dependencies:
           - matrix:
             packages:
               - python>=3.11,<3.15
+  test_cufile:
+    specific:
+      # The `cufile` extra was added to the `cuda-toolkit` metapackage in 12.6.3
+      # Adding an explicit test dependency on the cufile package here for
+      # testing on versions before 12.6.3
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.[012345]"
+              use_cuda_wheels: "true"
+            packages:
+              - nvidia-cufile-cu12
+          - matrix:
+            packages:


### PR DESCRIPTION
## Description

Testing a smaller base CI image for wheel tests in #1548 -- that image does not
have cuda toolkit installed and we rely on installing all dependencies from
wheels.

In rapidsai/kvikio#1000 and rapidsai/kvikio#1003 we added handling for loading
`cufile` from an installed wheel -- but we add that dependency to `libkvikio`
wheels as `cuda-toolkit[cufile]` and there was no `cufile` extra available
before `cuda-toolkit==12.6.3`, so for the testing setup here, we explicitly
install `nvidia-cufile-cu12` for earlier versions of `cuda-toolkit` so that
`libcufile` is available for tests.

(cuOpt doesn't have a direct dependency on `cufile`, but instead is running into this in `libkvikio` via `pylibcudf`.)

xref rapidsai/build-planning#143

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
