### PR TITLE
Fix cuts not obeying timer

### DIFF
--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -2212,6 +2212,11 @@ auto branch_and_bound_t<i_t, f_t>::do_cut_pass(
     }
     return {cut_pass_action_t::RETURN, mip_status_t::INFEASIBLE};
   }
+  if (toc(exploration_stats_.start_time) >= settings_.time_limit) {
+    solver_status_ = mip_status_t::TIME_LIMIT;
+    set_final_solution(solution, root_objective_);
+    return {cut_pass_action_t::RETURN, solver_status_};
+  }
   f_t cut_generation_time = toc(cut_start_time);
   if (cut_generation_time > 1.0) {
     settings_.log.debug("Cut generation time %.2f seconds\n", cut_generation_time);
@@ -2322,6 +2327,12 @@ auto branch_and_bound_t<i_t, f_t>::do_cut_pass(
     original_lp_.write_mps("bound_strengthening_infeasible.mps");
 #endif
     return {cut_pass_action_t::RETURN, mip_status_t::INFEASIBLE};
+  }
+
+  if (toc(exploration_stats_.start_time) >= settings_.time_limit) {
+    solver_status_ = mip_status_t::TIME_LIMIT;
+    set_final_solution(solution, root_objective_);
+    return {cut_pass_action_t::RETURN, solver_status_};
   }
 
   i_t iter                    = 0;
@@ -2707,6 +2718,16 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
   f_t cut_generation_start_time = tic();
   i_t cut_pool_size             = 0;
   for (i_t cut_pass = 0; cut_pass < settings_.max_cut_passes; cut_pass++) {
+    if (toc(exploration_stats_.start_time) >= settings_.time_limit) {
+      solver_status_ = mip_status_t::TIME_LIMIT;
+      set_final_solution(solution, root_objective_);
+      if (settings_.benchmark_info_ptr != nullptr) {
+        settings_.benchmark_info_ptr->cut_generation_time_sec = toc(cut_generation_start_time);
+      }
+      signal_extend_cliques_.store(true, std::memory_order_release);
+#pragma omp taskwait depend(in : *clique_signal)
+      return mip_status_t::TIME_LIMIT;
+    }
     if (num_fractional == 0) {
       // LP relaxation is already integer-feasible — solved at the root
       // by the cuts added so far (possibly zero). Publish the with-cuts

--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -2726,7 +2726,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
       }
       signal_extend_cliques_.store(true, std::memory_order_release);
 #pragma omp taskwait depend(in : *clique_signal)
-      return mip_status_t::TIME_LIMIT;
+      return solver_status_;
     }
     if (num_fractional == 0) {
       // LP relaxation is already integer-feasible — solved at the root

--- a/cpp/src/cuts/cuts.cpp
+++ b/cpp/src/cuts/cuts.cpp
@@ -3338,9 +3338,18 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 {
   // Generate Gomory and CG Cuts
   if (settings.mixed_integer_gomory_cuts != 0 || settings.strong_chvatal_gomory_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
-    generate_gomory_cuts(
-      lp, settings, Arow, new_slacks, var_types, basis_update, xstar, basic_list, nonbasic_list);
+    generate_gomory_cuts(lp,
+                         settings,
+                         Arow,
+                         new_slacks,
+                         var_types,
+                         basis_update,
+                         xstar,
+                         basic_list,
+                         nonbasic_list,
+                         start_time);
     f_t cut_generation_time = toc(cut_start_time);
     if (cut_generation_time > 1.0) {
       settings.log.debug("Gomory and CG cut generation time %.2f seconds\n", cut_generation_time);
@@ -3349,6 +3358,7 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 
   // Generate Knapsack cuts
   if (settings.knapsack_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
     generate_knapsack_cuts(lp, settings, Arow, new_slacks, var_types, xstar, start_time);
     f_t cut_generation_time = toc(cut_start_time);
@@ -3359,6 +3369,7 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 
   // Generate Flow Cover cuts
   if (settings.flow_cover_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
     generate_flow_cover_cuts(lp, settings, Arow, var_types, xstar, variable_bounds, start_time);
     f_t cut_generation_time = toc(cut_start_time);
@@ -3369,8 +3380,10 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 
   // Generate MIR and CG cuts
   if (settings.mir_cuts != 0 || settings.strong_chvatal_gomory_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
-    generate_mir_cuts(lp, settings, Arow, new_slacks, var_types, xstar, ystar, variable_bounds);
+    generate_mir_cuts(
+      lp, settings, Arow, new_slacks, var_types, xstar, ystar, variable_bounds, start_time);
     f_t cut_generation_time = toc(cut_start_time);
     if (cut_generation_time > 1.0) {
       settings.log.debug("MIR and CG cut generation time %.2f seconds\n", cut_generation_time);
@@ -3379,6 +3392,7 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 
   // Generate implied bound cuts
   if (settings.implied_bound_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
     generate_implied_bound_cuts(lp, settings, var_types, xstar, start_time);
     f_t cut_generation_time = toc(cut_start_time);
@@ -3393,10 +3407,12 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
   // each recomputing them. Done here, after the cut routines that don't
   // need the clique table, to give the background clique-table thread as
   // much time as possible to finish before we join it.
+  if (toc(start_time) >= settings.time_limit) { return true; }
   prepare_fractional_sub_conflict_graph(settings, xstar, start_time);
 
   // Generate Clique cuts (last to give background clique table generation maximum time)
   if (settings.clique_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     f_t cut_start_time = tic();
     bool feasible      = generate_clique_cuts(lp, settings, var_types, xstar, zstar, start_time);
     if (!feasible) {
@@ -3411,6 +3427,7 @@ bool cut_generation_t<i_t, f_t>::generate_cuts(const lp_problem_t<i_t, f_t>& lp,
 
   // Generate Zero-half (odd-cycle / odd-wheel) cuts; reuses the clique table built above
   if (settings.zero_half_cuts != 0) {
+    if (toc(start_time) >= settings.time_limit) { return true; }
     ZERO_HALF_DEBUG("generate_cuts: about to call generate_zero_half_cuts");
     f_t cut_start_time = tic();
     bool feasible      = generate_zero_half_cuts(lp, settings, var_types, xstar, zstar, start_time);
@@ -3857,7 +3874,8 @@ void cut_generation_t<i_t, f_t>::generate_mir_cuts(
   const std::vector<variable_type_t>& var_types,
   const std::vector<f_t>& xstar,
   const std::vector<f_t>& ystar,
-  variable_bounds_t<i_t, f_t>& variable_bounds)
+  variable_bounds_t<i_t, f_t>& variable_bounds,
+  f_t start_time)
 {
   f_t mir_start_time     = tic();
   constexpr bool verbose = false;
@@ -3887,6 +3905,10 @@ void cut_generation_t<i_t, f_t>::generate_mir_cuts(
   f_t work_estimate  = 0.0;
   i_t num_cuts       = 0;
   while (num_cuts < max_cuts && !score_queue.empty()) {
+    // Coarse deadline check: MIR aggregation dominates cut generation on large
+    // models, so honor the global time limit here rather than only at the LP
+    // re-solve that follows cut generation.
+    if (toc(start_time) >= settings.time_limit) { break; }
     // Get the row with the highest score from the queue
     auto [max_score, i] = score_queue.top();
     score_queue.pop();
@@ -4131,7 +4153,8 @@ void cut_generation_t<i_t, f_t>::generate_gomory_cuts(
   basis_update_mpf_t<i_t, f_t>& basis_update,
   const std::vector<f_t>& xstar,
   const std::vector<i_t>& basic_list,
-  const std::vector<i_t>& nonbasic_list)
+  const std::vector<i_t>& nonbasic_list,
+  f_t start_time)
 {
   tableau_equality_t<i_t, f_t> tableau(lp, basis_update, nonbasic_list);
   mixed_integer_gomory_cut_t<i_t, f_t> gomory_cut;
@@ -4144,6 +4167,7 @@ void cut_generation_t<i_t, f_t>::generate_gomory_cuts(
   complemented_mir.bound_substitution(lp, variable_bounds, var_types, xstar, transformed_xstar);
 
   for (i_t i = 0; i < lp.num_rows; i++) {
+    if (toc(start_time) >= settings.time_limit) { break; }
     inequality_t<i_t, f_t> inequality(lp.num_cols);
     const i_t j = basic_list[i];
     if (var_types[j] != variable_type_t::INTEGER) { continue; }

--- a/cpp/src/cuts/cuts.cpp
+++ b/cpp/src/cuts/cuts.cpp
@@ -3905,9 +3905,6 @@ void cut_generation_t<i_t, f_t>::generate_mir_cuts(
   f_t work_estimate  = 0.0;
   i_t num_cuts       = 0;
   while (num_cuts < max_cuts && !score_queue.empty()) {
-    // Coarse deadline check: MIR aggregation dominates cut generation on large
-    // models, so honor the global time limit here rather than only at the LP
-    // re-solve that follows cut generation.
     if (toc(start_time) >= settings.time_limit) { break; }
     // Get the row with the highest score from the queue
     auto [max_score, i] = score_queue.top();

--- a/cpp/src/cuts/cuts.hpp
+++ b/cpp/src/cuts/cuts.hpp
@@ -669,7 +669,8 @@ class cut_generation_t {
                             simplex::basis_update_mpf_t<i_t, f_t>& basis_update,
                             const std::vector<f_t>& xstar,
                             const std::vector<i_t>& basic_list,
-                            const std::vector<i_t>& nonbasic_list);
+                            const std::vector<i_t>& nonbasic_list,
+                            f_t start_time);
 
   // Generate all mixed integer rounding cuts
   void generate_mir_cuts(const simplex::lp_problem_t<i_t, f_t>& lp,
@@ -679,7 +680,8 @@ class cut_generation_t {
                          const std::vector<simplex::variable_type_t>& var_types,
                          const std::vector<f_t>& xstar,
                          const std::vector<f_t>& ystar,
-                         variable_bounds_t<i_t, f_t>& variable_bounds);
+                         variable_bounds_t<i_t, f_t>& variable_bounds,
+                         f_t start_time);
 
   // Generate all knapsack cuts
   void generate_knapsack_cuts(const simplex::lp_problem_t<i_t, f_t>& lp,


### PR DESCRIPTION
Root cut generation could run well past the global time limit on large instances because MIR and Gomory cuts had no wall-clock checks and the root cut loop only checked the time limitt at LP phase2.

Add coarse deadline checks at cut generation boundaries and in the root cut pass loop.

On bab2 with --time-limit 60, solve time drops from ~120s to ~60s.