### PR TITLE
Clamp crushed solutions to dual-reduced bounds

### DIFF
--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -21,6 +21,7 @@
 #include <utilities/scope_guard.hpp>
 
 #include <memory>
+#include <numeric>
 
 constexpr bool fj_only_run = false;
 
@@ -202,12 +203,38 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
       }
       std::vector<f_t> h_original = host_copy(init_sol_assignment, sol.handle_ptr->get_stream());
       std::vector<f_t> h_crushed;
-      problem_ptr->presolve_data.papilo_presolve_ptr->crush_primal_solution(h_original, h_crushed);
+      const auto* presolver_ptr = problem_ptr->presolve_data.papilo_presolve_ptr;
+      presolver_ptr->crush_primal_solution(
+        *problem_ptr->original_problem_ptr, h_original, h_crushed);
       init_sol_assignment = cuopt::device_copy(h_crushed, sol.handle_ptr->get_stream());
-      CUOPT_LOG_DEBUG("Crushed initial solution %d through Papilo (%d -> %d vars)",
-                      sol_idx,
-                      papilo_orig_n,
-                      h_crushed.size());
+
+      const auto& reduced_problem       = *problem_ptr->original_problem_ptr;
+      const std::vector<f_t> h_red_obj  = reduced_problem.get_objective_coefficients_host();
+      const std::vector<f_t>& h_ori_obj = presolver_ptr->get_original_objective_coefficients();
+      cuopt_assert(h_ori_obj.size() == h_original.size(),
+                   "original objective size must match input solution dimension");
+      cuopt_assert(h_red_obj.size() == h_crushed.size(),
+                   "reduced objective size must match crushed solution dimension");
+      // Map each solution to user space with its own problem's scale, so the comparison holds even
+      // if the original and reduced objective scales ever diverge.
+      const double input_obj =
+        (double)presolver_ptr->get_original_objective_scaling_factor() *
+        std::inner_product(h_ori_obj.begin(),
+                           h_ori_obj.end(),
+                           h_original.begin(),
+                           (double)presolver_ptr->get_original_objective_offset());
+      const double crushed_obj = (double)reduced_problem.get_objective_scaling_factor() *
+                                 std::inner_product(h_red_obj.begin(),
+                                                    h_red_obj.end(),
+                                                    h_crushed.begin(),
+                                                    (double)reduced_problem.get_objective_offset());
+      CUOPT_LOG_DEBUG(
+        "Crushed initial solution %d through Papilo (%d -> %d vars), objective %g -> %g",
+        sol_idx,
+        papilo_orig_n,
+        h_crushed.size(),
+        input_obj,
+        crushed_obj);
     }
 
     if (problem_ptr->pre_process_assignment(init_sol_assignment)) {

--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -208,6 +208,7 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
         *problem_ptr->original_problem_ptr, h_original, h_crushed);
       init_sol_assignment = cuopt::device_copy(h_crushed, sol.handle_ptr->get_stream());
 
+#if CUOPT_LOG_ACTIVE_LEVEL <= CUOPT_LOG_LEVEL_DEBUG
       const auto& reduced_problem       = *problem_ptr->original_problem_ptr;
       const std::vector<f_t> h_red_obj  = reduced_problem.get_objective_coefficients_host();
       const std::vector<f_t>& h_ori_obj = presolver_ptr->get_original_objective_coefficients();
@@ -235,6 +236,7 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
         h_crushed.size(),
         input_obj,
         crushed_obj);
+#endif
     }
 
     if (problem_ptr->pre_process_assignment(init_sol_assignment)) {

--- a/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
@@ -44,6 +44,7 @@
 
 #include <raft/core/nvtx.hpp>
 
+#include <algorithm>
 #include <unordered_map>
 
 namespace cuopt::mathematical_optimization::mip {
@@ -923,7 +924,7 @@ void third_party_presolve_t<i_t, f_t>::crush_primal_solution(
   cuopt_assert(reduced_primal.size() == lb.size() && reduced_primal.size() == ub.size(),
                "reduced problem must match crush output dimension");
   for (size_t j = 0; j < reduced_primal.size(); ++j) {
-    reduced_primal[j] = std::min(std::max(reduced_primal[j], lb[j]), ub[j]);
+    reduced_primal[j] = std::clamp(reduced_primal[j], lb[j], ub[j]);
   }
 }
 

--- a/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
@@ -688,6 +688,10 @@ third_party_presolve_result_t<i_t, f_t> third_party_presolve_t<i_t, f_t>::apply(
     return apply_pslp(op_problem, time_limit);
   }
 
+  original_objective_coefficients_   = op_problem.get_objective_coefficients_host();
+  original_objective_offset_         = op_problem.get_objective_offset();
+  original_objective_scaling_factor_ = op_problem.get_objective_scaling_factor();
+
   papilo::Problem<f_t> papilo_problem = build_papilo_problem(op_problem, category, maximize_);
 
   CUOPT_LOG_DEBUG("Original problem: %d constraints, %d variables, %d nonzeros",
@@ -886,7 +890,9 @@ void third_party_presolve_t<i_t, f_t>::uncrush_primal_solution(
 
 template <typename i_t, typename f_t>
 void third_party_presolve_t<i_t, f_t>::crush_primal_solution(
-  const std::vector<f_t>& original_primal, std::vector<f_t>& reduced_primal) const
+  const optimization_problem_t<i_t, f_t>& reduced_problem,
+  const std::vector<f_t>& original_primal,
+  std::vector<f_t>& reduced_primal) const
 {
   cuopt_expects(presolver_ == cuopt::mathematical_optimization::presolver_t::Papilo,
                 error_type_t::RuntimeError,
@@ -904,6 +910,21 @@ void third_party_presolve_t<i_t, f_t>::crush_primal_solution(
                              empty_vals,
                              empty_indices,
                              empty_offsets);
+
+  // Dual bound strengthening (e.g. DualFix kVarBoundChange which aren't emitted in primal mode)
+  // can tighten a bound past a value
+  // that was feasible in the original polytope. A simple clamp is often enough to crush a solution
+  // inside the tightened polytope without breaking feasibility (dualfix seems to emit purely dual
+  // based bounds reductions so primality is safe when clamping)
+  cuopt_assert(reduced_problem.get_n_variables() == (i_t)reduced_to_original_map_.size(),
+               "reduced_problem does not match this presolver's reduction");
+  const std::vector<f_t> lb = reduced_problem.get_variable_lower_bounds_host();
+  const std::vector<f_t> ub = reduced_problem.get_variable_upper_bounds_host();
+  cuopt_assert(reduced_primal.size() == lb.size() && reduced_primal.size() == ub.size(),
+               "reduced problem must match crush output dimension");
+  for (size_t j = 0; j < reduced_primal.size(); ++j) {
+    reduced_primal[j] = std::min(std::max(reduced_primal[j], lb[j]), ub[j]);
+  }
 }
 
 /**

--- a/cpp/src/mip_heuristics/presolve/third_party_presolve.hpp
+++ b/cpp/src/mip_heuristics/presolve/third_party_presolve.hpp
@@ -79,7 +79,8 @@ class third_party_presolve_t {
   void uncrush_primal_solution(const std::vector<f_t>& reduced_primal,
                                std::vector<f_t>& full_primal) const;
 
-  void crush_primal_solution(const std::vector<f_t>& original_primal,
+  void crush_primal_solution(const optimization_problem_t<i_t, f_t>& reduced_problem,
+                             const std::vector<f_t>& original_primal,
                              std::vector<f_t>& reduced_primal) const;
 
   void crush_primal_dual_solution(const std::vector<f_t>& x_original,
@@ -93,6 +94,13 @@ class third_party_presolve_t {
                                   const std::vector<i_t>& A_offsets) const;
   const std::vector<i_t>& get_reduced_to_original_map() const { return reduced_to_original_map_; }
   const std::vector<i_t>& get_original_to_reduced_map() const { return original_to_reduced_map_; }
+
+  const std::vector<f_t>& get_original_objective_coefficients() const
+  {
+    return original_objective_coefficients_;
+  }
+  f_t get_original_objective_offset() const { return original_objective_offset_; }
+  f_t get_original_objective_scaling_factor() const { return original_objective_scaling_factor_; }
 
   ~third_party_presolve_t();
 
@@ -120,6 +128,10 @@ class third_party_presolve_t {
 
   std::vector<i_t> reduced_to_original_map_{};
   std::vector<i_t> original_to_reduced_map_{};
+
+  std::vector<f_t> original_objective_coefficients_{};
+  f_t original_objective_offset_{0};
+  f_t original_objective_scaling_factor_{1};
 };
 
 }  // namespace cuopt::mathematical_optimization::mip


### PR DESCRIPTION
Papilo's DualFix presolver performs dual reductions that cut off parts of the polytope, and thus could drop some early-heuristic solutions.

This PR adds a heuristic clamping to preserve such solutions whenever possible. Most dualfix reductions are purely dual and confined to independent variables, so clamping affected variables to the new bounds doesn't affect feasibility and improves the objective. In MIPLIB2017, this covers all known cases of early heuristic solution dropping previously encountered.

To note: some solutions may not be trivially recoverable, based on the specific reductions performed by Papilo. This is an inherent property of dual presolve reductions


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
