### PR TITLE
ci: enable codecov for Python test coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -416,9 +416,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_python.sh
-    secrets:
-      script-env-secret-4-key: CODECOV_TOKEN
-      script-env-secret-4-value: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit # zizmor: ignore[secrets-inherit]
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -416,13 +416,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_python.sh
-    secrets:
-      script-env-secret-1-key: CUOPT_S3_URI
-      script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}
-      script-env-secret-2-key: CUOPT_AWS_ACCESS_KEY_ID
-      script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
-      script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
-      script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
+    secrets: inherit # zizmor: ignore[secrets-inherit]
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,6 +97,7 @@ jobs:
           - '!.github/workflows/trigger-breaking-change-alert.yaml'
           - '!.gitignore'
           - '!.pre-commit-config.yaml'
+          - '!codecov.yml'
           - '!AGENTS.md'
           - '!CHANGELOG.md'
           - '!CONTRIBUTING.md'
@@ -155,6 +156,7 @@ jobs:
           - '!.github/workflows/trigger-breaking-change-alert.yaml'
           - '!.gitignore'
           - '!.pre-commit-config.yaml'
+          - '!codecov.yml'
           - '!AGENTS.md'
           - '!CONTRIBUTING.md'
           - '!LICENSE'
@@ -224,6 +226,7 @@ jobs:
           - '!.github/workflows/trigger-breaking-change-alert.yaml'
           - '!.gitignore'
           - '!.pre-commit-config.yaml'
+          - '!codecov.yml'
           - '!AGENTS.md'
           - '!CONTRIBUTING.md'
           - '!LICENSE'
@@ -290,6 +293,7 @@ jobs:
           - '!.github/workflows/trigger-breaking-change-alert.yaml'
           - '!.gitignore'
           - '!.pre-commit-config.yaml'
+          - '!codecov.yml'
           - '!AGENTS.md'
           - '!CONTRIBUTING.md'
           - '!LICENSE'
@@ -410,7 +414,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
-      run_codecov: false
       build_type: pull-request
       script: ci/test_python.sh
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -416,7 +416,9 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_python.sh
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+    secrets:
+      script-env-secret-4-key: CODECOV_TOKEN
+      script-env-secret-4-value: ${{ secrets.CODECOV_TOKEN }}
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -416,9 +416,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_python.sh
-    secrets:
-      script-env-secret-1-key: CODECOV_TOKEN
-      script-env-secret-1-value: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit # zizmor: ignore[secrets-inherit]
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -416,7 +416,9 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_python.sh
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+    secrets:
+      script-env-secret-1-key: CODECOV_TOKEN
+      script-env-secret-1-value: ${{ secrets.CODECOV_TOKEN }}
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
       pull-requests: read
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
+      run_codecov: false
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
       pull-requests: read
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
+      run_codecov: false
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -71,8 +72,6 @@ jobs:
       script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
       script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
       script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
-      script-env-secret-4-key: CODECOV_TOKEN
-      script-env-secret-4-value: ${{ secrets.CODECOV_TOKEN }}
 
   wheel-tests-cuopt:
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,6 @@ jobs:
       pull-requests: read
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
-      run_codecov: false
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -72,6 +71,8 @@ jobs:
       script-env-secret-2-value: ${{ secrets.CUOPT_AWS_ACCESS_KEY_ID }}
       script-env-secret-3-key: CUOPT_AWS_SECRET_ACCESS_KEY
       script-env-secret-3-value: ${{ secrets.CUOPT_AWS_SECRET_ACCESS_KEY }}
+      script-env-secret-4-key: CODECOV_TOKEN
+      script-env-secret-4-value: ${{ secrets.CODECOV_TOKEN }}
 
   wheel-tests-cuopt:
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,6 @@ jobs:
       pull-requests: read
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
-      run_codecov: false
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+# Configuration File for CodeCov
+comment: false
+coverage:
+  status:
+    project: off
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+github_checks:
+  annotations: true

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -4,3 +4,5 @@ include = cuopt/cuopt/*
           cuopt_server/cuopt_server/*
 omit = cuopt_server/cuopt_server/tests/*
        cuopt/cuopt/tests/*
+disable_warnings = module-not-measured
+                   no-data-collected


### PR DESCRIPTION
Removes the explicit `run_codecov: false` override, adds `codecov.yml` (patch checks informational, never blocks), suppresses spurious coverage.py warnings, and excludes `codecov.yml` from changed-files triggers.

Requires `CODECOV_TOKEN` to be set as a repo/org secret.