### PR TITLE
Increase cuSparse version requierment for SpMVOp from 12.7 to 12.8

### DIFF
--- a/cpp/src/pdlp/cusparse_view.cu
+++ b/cpp/src/pdlp/cusparse_view.cu
@@ -270,51 +270,30 @@ void my_cusparsespmm_preprocess(cusparseHandle_t handle,
 }
 #endif
 
-#if CUOPT_CUSPARSE_VER_12_7_UP
-// SpMVOp symbols. Resolved at runtime via dlsym, because the runtime cuSPARSE version
-// might not match the headers used at compile time. cuSPARSE 12.7 corresponds to CUDA
-// Toolkit 13.2; cuSPARSE 12.8 corresponds to CUDA Toolkit 13.3. We can go back to
-// direct linking once CUDA 14 is adopted.
-using cusparseSpMVOp_destroyDescr_sig     = cusparse_sig<cusparseSpMVOpDescr_t>;
-using cusparseSpMVOp_destroyPlan_sig      = cusparse_sig<cusparseSpMVOpPlan_t>;
-using cusparseSpMVOp_bufferSize_12_7_sig  = cusparse_sig<cusparseHandle_t,
-                                                         cusparseOperation_t,
-                                                         cusparseSpMatDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cudaDataType,
-                                                         size_t*>;
-using cusparseSpMVOp_createDescr_12_7_sig = cusparse_sig<cusparseHandle_t,
-                                                         cusparseSpMVOpDescr_t*,
-                                                         cusparseOperation_t,
-                                                         cusparseSpMatDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cudaDataType,
-                                                         void*>;
 #if CUOPT_CUSPARSE_VER_12_8_UP
-using cusparseSpMVOp_bufferSize_12_8_sig  = cusparse_sig<cusparseHandle_t,
-                                                         cusparseOperation_t,
-                                                         cusparseConstSpMatDescr_t,
-                                                         cusparseConstDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cudaDataType,
-                                                         cusparseSpMVOpAlg_t,
-                                                         size_t*>;
-using cusparseSpMVOp_createDescr_12_8_sig = cusparse_sig<cusparseHandle_t,
-                                                         cusparseSpMVOpDescr_t*,
-                                                         cusparseOperation_t,
-                                                         cusparseConstSpMatDescr_t,
-                                                         cusparseConstDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cusparseDnVecDescr_t,
-                                                         cudaDataType,
-                                                         cusparseSpMVOpAlg_t,
-                                                         void*>;
-#endif  // CUOPT_CUSPARSE_VER_12_8_UP
+// SpMVOp symbols. Resolved at runtime via dlsym, because the runtime minor version might not match
+// the compiled minor version. We can go back to direct linking once CUDA 14 is adopted
+using cusparseSpMVOp_destroyDescr_sig = cusparse_sig<cusparseSpMVOpDescr_t>;
+using cusparseSpMVOp_destroyPlan_sig  = cusparse_sig<cusparseSpMVOpPlan_t>;
+using cusparseSpMVOp_bufferSize_sig   = cusparse_sig<cusparseHandle_t,
+                                                     cusparseOperation_t,
+                                                     cusparseConstSpMatDescr_t,
+                                                     cusparseConstDnVecDescr_t,
+                                                     cusparseDnVecDescr_t,
+                                                     cusparseDnVecDescr_t,
+                                                     cudaDataType,
+                                                     cusparseSpMVOpAlg_t,
+                                                     size_t*>;
+using cusparseSpMVOp_createDescr_sig  = cusparse_sig<cusparseHandle_t,
+                                                     cusparseSpMVOpDescr_t*,
+                                                     cusparseOperation_t,
+                                                     cusparseConstSpMatDescr_t,
+                                                     cusparseConstDnVecDescr_t,
+                                                     cusparseDnVecDescr_t,
+                                                     cusparseDnVecDescr_t,
+                                                     cudaDataType,
+                                                     cusparseSpMVOpAlg_t,
+                                                     void*>;
 using cusparseSpMVOp_createPlan_sig =
   cusparse_sig<cusparseHandle_t, cusparseSpMVOpDescr_t, cusparseSpMVOpPlan_t*, char*, size_t>;
 using cusparseSpMVOp_sig = cusparse_sig<cusparseHandle_t,
@@ -324,43 +303,6 @@ using cusparseSpMVOp_sig = cusparse_sig<cusparseHandle_t,
                                         cusparseDnVecDescr_t,
                                         cusparseDnVecDescr_t,
                                         cusparseDnVecDescr_t>;
-
-namespace {
-
-bool is_cusparse_runtime_12_8_or_newer()
-{
-  // cuSPARSE 12.8 is the version shipped with CUDA Toolkit 13.3.
-  int major = 0, minor = 0;
-  auto status = cusparseGetProperty(libraryPropertyType_t::MAJOR_VERSION, &major);
-  if (status != CUSPARSE_STATUS_SUCCESS) { return false; }
-  status = cusparseGetProperty(libraryPropertyType_t::MINOR_VERSION, &minor);
-  if (status != CUSPARSE_STATUS_SUCCESS) { return false; }
-  return (major > 12) || (major == 12 && minor >= 8);
-}
-
-cusparseStatus_t cusparse_spmvop_buffer_size(cusparseHandle_t handle,
-                                             cusparseOperation_t opA,
-                                             cusparseSpMatDescr_t matA,
-                                             cusparseDnVecDescr_t vecX,
-                                             cusparseDnVecDescr_t vecY,
-                                             cusparseDnVecDescr_t vecZ,
-                                             cudaDataType computeType,
-                                             size_t* bufferSize)
-{
-#if CUOPT_CUSPARSE_VER_12_8_UP
-  if (is_cusparse_runtime_12_8_or_newer()) {
-    static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_12_8_sig>(
-      "cusparseSpMVOp_bufferSize");
-    return (*fn)(
-      handle, opA, matA, vecX, vecY, vecZ, computeType, CUSPARSE_SPMVOP_ALG_DEFAULT, bufferSize);
-  }
-#endif  // CUOPT_CUSPARSE_VER_12_8_UP
-  static const auto fn =
-    dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_12_7_sig>("cusparseSpMVOp_bufferSize");
-  return (*fn)(handle, opA, matA, vecX, vecY, vecZ, computeType, bufferSize);
-}
-
-}  // namespace
 
 cusparseStatus_t cusparse_spmvop_descr_wrapper_t::dlsym_create(cusparseHandle_t handle,
                                                                cusparseSpMVOpDescr_t* descr,
@@ -372,17 +314,10 @@ cusparseStatus_t cusparse_spmvop_descr_wrapper_t::dlsym_create(cusparseHandle_t 
                                                                cudaDataType computeType,
                                                                void* buffer)
 {
-#if CUOPT_CUSPARSE_VER_12_8_UP
-  if (is_cusparse_runtime_12_8_or_newer()) {
-    static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_createDescr_12_8_sig>(
-      "cusparseSpMVOp_createDescr");
-    return (*fn)(
-      handle, descr, opA, matA, vecX, vecY, vecZ, computeType, CUSPARSE_SPMVOP_ALG_DEFAULT, buffer);
-  }
-#endif  // CUOPT_CUSPARSE_VER_12_8_UP
-  static const auto fn = dynamic_load_runtime::function<cusparseSpMVOp_createDescr_12_7_sig>(
-    "cusparseSpMVOp_createDescr");
-  return (*fn)(handle, descr, opA, matA, vecX, vecY, vecZ, computeType, buffer);
+  static const auto fn =
+    dynamic_load_runtime::function<cusparseSpMVOp_createDescr_sig>("cusparseSpMVOp_createDescr");
+  return (*fn)(
+    handle, descr, opA, matA, vecX, vecY, vecZ, computeType, CUSPARSE_SPMVOP_ALG_DEFAULT, buffer);
 }
 
 cusparseStatus_t cusparse_spmvop_descr_wrapper_t::dlsym_destroy(cusparseSpMVOpDescr_t descr)
@@ -504,7 +439,7 @@ void cusparse_spmvop_run(cusparseHandle_t handle,
   RAFT_CUSPARSE_TRY(cusparseSetStream(handle, stream));
   RAFT_CUSPARSE_TRY((*func)(handle, plan, alpha, beta, vecX, vecY, vecZ));
 }
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 
 // This cstr is used in pdhg, step size strategy and in cuPDLPx infeasible detection
 // A_T is owned by the scaled problem
@@ -1428,38 +1363,36 @@ bool is_cusparse_runtime_mixed_precision_supported()
 
 bool is_cusparse_runtime_spmvop_supported()
 {
-#if CUOPT_CUSPARSE_VER_12_7_UP
-#if !CUOPT_CUSPARSE_VER_12_8_UP
-  // Headers older than cuSPARSE 12.8 (CUDA Toolkit 13.3) cannot name the newer SpMVOp
-  // descriptor types, so do not call the older 12.7 signature against a 12.8+ runtime.
-  if (is_cusparse_runtime_12_8_or_newer()) { return false; }
-#endif  // !CUOPT_CUSPARSE_VER_12_8_UP
-  // Probe the runtime to ensure cusparseSpMVOp is supported.
+#if CUOPT_CUSPARSE_VER_12_8_UP
+  // Probe the runtimme to ensure cusparseSpMVOp is supported
   static const bool supported =
     dynamic_load_runtime::function<cusparseSpMVOp_sig>("cusparseSpMVOp").has_value();
   return supported;
 #else
   return false;
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 }
 
 // Creates SpMVOp plans. Must be called after scale_problem() so plans use the scaled matrix.
 template <typename i_t, typename f_t>
 void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
 {
-#if CUOPT_CUSPARSE_VER_12_7_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
   if (!is_cusparse_runtime_spmvop_supported() || !(std::is_same_v<f_t, double>)) { return; }
+  static const auto buffer_size =
+    dynamic_load_runtime::function<cusparseSpMVOp_bufferSize_sig>("cusparseSpMVOp_bufferSize");
   CUSPARSE_CHECK(cusparseSetStream(handle_ptr_->get_cusparse_handle(), handle_ptr_->get_stream()));
   // Prepare buffers for At_y SpMVOp
   size_t buffer_size_transpose = 0;
-  RAFT_CUSPARSE_TRY(cusparse_spmvop_buffer_size(handle_ptr_->get_cusparse_handle(),
-                                                CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                A_T,
-                                                dual_solution,
-                                                current_AtY,
-                                                current_AtY,
-                                                CUDA_R_64F,
-                                                &buffer_size_transpose));
+  RAFT_CUSPARSE_TRY((*buffer_size)(handle_ptr_->get_cusparse_handle(),
+                                   CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                   A_T,
+                                   dual_solution,
+                                   current_AtY,
+                                   current_AtY,
+                                   CUDA_R_64F,
+                                   CUSPARSE_SPMVOP_ALG_DEFAULT,
+                                   &buffer_size_transpose));
   buffer_transpose_spmvop.resize(buffer_size_transpose, handle_ptr_->get_stream());
 
   spmv_op_descr_A_t_.create(handle_ptr_->get_cusparse_handle(),
@@ -1476,14 +1409,15 @@ void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
   // Only prepare buffers for A_x if we are using reflected_halpern
   if (is_reflected) {
     size_t buffer_size_non_transpose = 0;
-    RAFT_CUSPARSE_TRY(cusparse_spmvop_buffer_size(handle_ptr_->get_cusparse_handle(),
-                                                  CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                                  A,
-                                                  reflected_primal_solution,
-                                                  dual_gradient,
-                                                  dual_gradient,
-                                                  CUDA_R_64F,
-                                                  &buffer_size_non_transpose));
+    RAFT_CUSPARSE_TRY((*buffer_size)(handle_ptr_->get_cusparse_handle(),
+                                     CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                     A,
+                                     reflected_primal_solution,
+                                     dual_gradient,
+                                     dual_gradient,
+                                     CUDA_R_64F,
+                                     CUSPARSE_SPMVOP_ALG_DEFAULT,
+                                     &buffer_size_non_transpose));
     buffer_non_transpose_spmvop.resize(buffer_size_non_transpose, handle_ptr_->get_stream());
 
     spmv_op_descr_A_.create(handle_ptr_->get_cusparse_handle(),
@@ -1497,7 +1431,7 @@ void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
 
     spmv_op_plan_A_.create(handle_ptr_->get_cusparse_handle(), spmv_op_descr_A_);
   }
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 }
 
 #if MIP_INSTANTIATE_FLOAT || PDLP_INSTANTIATE_FLOAT

--- a/cpp/src/pdlp/cusparse_view.hpp
+++ b/cpp/src/pdlp/cusparse_view.hpp
@@ -20,8 +20,6 @@
 
 #include <cusparse_v2.h>
 
-// cuSPARSE 12.7 ships with CUDA Toolkit 13.2
-#define CUOPT_CUSPARSE_VER_12_7_UP (CUSPARSE_VERSION >= 12700)
 // cuSPARSE 12.8 ships with CUDA Toolkit 13.3
 #define CUOPT_CUSPARSE_VER_12_8_UP (CUSPARSE_VERSION >= 12800)
 
@@ -84,7 +82,7 @@ class cusparse_dn_mat_descr_wrapper_t {
   bool need_destruction_;
 };
 
-#if CUOPT_CUSPARSE_VER_12_7_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
 // RAII wrapper around cusparse SpMVOp objects. All the buffers are owned by the cusparse_view_t.
 class cusparse_spmvop_descr_wrapper_t {
  public:
@@ -152,7 +150,7 @@ class cusparse_spmvop_plan_wrapper_t {
   cusparseSpMVOpPlan_t plan_;
   bool need_destruction_;
 };
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 
 template <typename i_t, typename f_t>
 class cusparse_view_t {
@@ -251,13 +249,13 @@ class cusparse_view_t {
   rmm::device_uvector<uint8_t> buffer_non_transpose_spmvop{0, handle_ptr_->get_stream()};
   rmm::device_uvector<uint8_t> buffer_transpose_spmvop{0, handle_ptr_->get_stream()};
 
-#if CUOPT_CUSPARSE_VER_12_7_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
   // SpMVOp descriptors and plans for A and A_T (descr before plan so dtor destroys plan first)
   cusparse_spmvop_descr_wrapper_t spmv_op_descr_A_;
   cusparse_spmvop_plan_wrapper_t spmv_op_plan_A_;
   cusparse_spmvop_descr_wrapper_t spmv_op_descr_A_t_;
   cusparse_spmvop_plan_wrapper_t spmv_op_plan_A_t_;
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
   // reuse buffers for cusparse spmm
   rmm::device_uvector<uint8_t> buffer_transpose_batch;
   rmm::device_uvector<uint8_t> buffer_non_transpose_batch;
@@ -356,10 +354,10 @@ void my_cusparsespmm_preprocess(cusparseHandle_t handle,
 
 bool is_cusparse_runtime_mixed_precision_supported();
 
-// False if the cuSPARSE headers/runtime do not support SpMVOp symbols. True otherwise.
+// False if cuSparse version < 12.8 or runtime cuSPARSE does not export SpMVOp symbols. True otherwise.
 bool is_cusparse_runtime_spmvop_supported();
 
-#if CUOPT_CUSPARSE_VER_12_7_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
 // Dispatches to the runtime cusparseSpMVOp via dlsym so callers (e.g., pdhg.cu) never
 // reference the symbol statically. Caller must have verified
 // is_cusparse_runtime_spmvop_supported().
@@ -371,6 +369,6 @@ void cusparse_spmvop_run(cusparseHandle_t handle,
                          cusparseDnVecDescr_t vecY,
                          cusparseDnVecDescr_t vecZ,
                          cudaStream_t stream);
-#endif  // CUOPT_CUSPARSE_VER_12_7_UP
+#endif  // CUOPT_CUSPARSE_VER_12_8_UP
 
 }  // namespace cuopt::mathematical_optimization::pdlp

--- a/cpp/src/pdlp/cusparse_view.hpp
+++ b/cpp/src/pdlp/cusparse_view.hpp
@@ -354,7 +354,8 @@ void my_cusparsespmm_preprocess(cusparseHandle_t handle,
 
 bool is_cusparse_runtime_mixed_precision_supported();
 
-// False if cuSparse version < 12.8 or runtime cuSPARSE does not export SpMVOp symbols. True otherwise.
+// False if cuSparse version < 12.8 or runtime cuSPARSE does not export SpMVOp symbols. True
+// otherwise.
 bool is_cusparse_runtime_spmvop_supported();
 
 #if CUOPT_CUSPARSE_VER_12_8_UP

--- a/cpp/src/pdlp/pdhg.cu
+++ b/cpp/src/pdlp/pdhg.cu
@@ -447,7 +447,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_dual_solution(rmm::device_uvector<f_t
 template <typename i_t, typename f_t>
 void pdhg_solver_t<i_t, f_t>::spmvop_At_y()
 {
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
   if (is_cusparse_runtime_spmvop_supported()) {
     cusparse_spmvop_run(handle_ptr_->get_cusparse_handle(),
                         cusparse_view_.spmv_op_plan_A_t_,
@@ -475,7 +475,7 @@ void pdhg_solver_t<i_t, f_t>::spmvop_At_y()
 template <typename i_t, typename f_t>
 void pdhg_solver_t<i_t, f_t>::spmvop_A_x()
 {
-#if CUDA_VER_13_2_UP
+#if CUOPT_CUSPARSE_VER_12_8_UP
   if (is_cusparse_runtime_spmvop_supported()) {
     cusparse_spmvop_run(handle_ptr_->get_cusparse_handle(),
                         cusparse_view_.spmv_op_plan_A_,


### PR DESCRIPTION
# Problem 

When running (and compiling) cuOpt with an env that has cuSparse 12.7, solving a problem creates a memory leak.

# Cause

The experimental API cuSparse_SpMVOp causes memory leaks in version 12.7 on the SpMVOpCreateDescr call.
This problem is solved in cuSparse 12.8.

# Solution

This PR increases the cuSparse version requierment for SpMVOp from 12.7 to 12.8. The memory leak is gone, and it results in simpler code because there is no need to do dlsym dispatching depending on the version. 

Disclaimer : cuSparse version **!=** cuda version. 
- cuSparse 12.7 is associated with cuda 13.2
- cuSparse 12.8 is associated with cuda 13.3