### PR TITLE
[BUG] Fix variable fixing for initial solutions

### DIFF
--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -240,12 +240,6 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
     }
 
     if (problem_ptr->pre_process_assignment(init_sol_assignment)) {
-      // Seed the solution with the provided assignment BEFORE fixing integers and running the
-      // completion LP. Otherwise the fix uses the solution_t constructor's default assignment
-      // (the variable lower bounds), which is -inf for free variables; fixing such a variable
-      // makes fix_given_variables compute a NaN constraint bound (inf - inf) and trips the
-      // problem-representation validation. Seeding first also lets us keep the LP's repaired
-      // continuous values (previously overwritten by a post-LP copy).
       raft::copy(sol.assignment.data(),
                  init_sol_assignment.data(),
                  init_sol_assignment.size(),
@@ -261,6 +255,14 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
                              lp_settings,
                              static_cast<bound_presolve_t<i_t, f_t>*>(nullptr));
       bool is_feasible = sol.compute_feasibility();
+      if (!is_feasible) {
+        raft::copy(sol.assignment.data(),
+                   init_sol_assignment.data(),
+                   init_sol_assignment.size(),
+                   sol.handle_ptr->get_stream());
+        is_feasible = sol.compute_feasibility();
+      }
+
       cuopt_func_call(sol.test_variable_bounds(true));
       CUOPT_LOG_DEBUG("Adding initial solution success! feas %d objective %f excess %f",
                       is_feasible,
@@ -270,9 +272,8 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
       initial_sol_vector.emplace_back(std::move(sol));
     } else {
       CUOPT_LOG_ERROR(
-        "Error cannot add the provided initial solution! \
-    Assignment size %lu \
-    initial solution size %lu",
+        "Error cannot add the provided initial solution! Assignment size %lu initial solution size "
+        "%lu",
         sol.assignment.size(),
         init_sol_assignment.size());
     }

--- a/cpp/src/mip_heuristics/diversity/diversity_manager.cu
+++ b/cpp/src/mip_heuristics/diversity/diversity_manager.cu
@@ -240,6 +240,16 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
     }
 
     if (problem_ptr->pre_process_assignment(init_sol_assignment)) {
+      // Seed the solution with the provided assignment BEFORE fixing integers and running the
+      // completion LP. Otherwise the fix uses the solution_t constructor's default assignment
+      // (the variable lower bounds), which is -inf for free variables; fixing such a variable
+      // makes fix_given_variables compute a NaN constraint bound (inf - inf) and trips the
+      // problem-representation validation. Seeding first also lets us keep the LP's repaired
+      // continuous values (previously overwritten by a post-LP copy).
+      raft::copy(sol.assignment.data(),
+                 init_sol_assignment.data(),
+                 init_sol_assignment.size(),
+                 sol.handle_ptr->get_stream());
       relaxed_lp_settings_t lp_settings;
       lp_settings.time_limit            = std::min(60., timer.remaining_time() / 2);
       lp_settings.tolerance             = problem_ptr->tolerances.absolute_tolerance;
@@ -250,10 +260,6 @@ void diversity_manager_t<i_t, f_t>::add_user_given_solutions(
                              problem_ptr->integer_indices,
                              lp_settings,
                              static_cast<bound_presolve_t<i_t, f_t>*>(nullptr));
-      raft::copy(sol.assignment.data(),
-                 init_sol_assignment.data(),
-                 init_sol_assignment.size(),
-                 sol.handle_ptr->get_stream());
       bool is_feasible = sol.compute_feasibility();
       cuopt_func_call(sol.test_variable_bounds(true));
       CUOPT_LOG_DEBUG("Adding initial solution success! feas %d objective %f excess %f",

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -1706,6 +1706,18 @@ void problem_t<i_t, f_t>::fix_given_variables(problem_t<i_t, f_t>& original_prob
                    variables_to_fix.end(),
                    [variable_fix_mask = make_span(fixing_helpers.variable_fix_mask)] __device__(
                      i_t x) { variable_fix_mask[x] = 1; });
+  // Guard: fixing a variable to a non-finite value corrupts the constraint RHS below
+  // (coeff * floor(+-inf) = +-inf, then original_bound - inf can be inf - inf = NaN), which
+  // otherwise surfaces much later as an opaque "Constraints bounds are invalid" validation
+  // error. Fail loudly at the source instead. Callers must seed a finite assignment before
+  // fixing (e.g. free variables must not be left at their -inf lower-bound default).
+  cuopt_func_call(thrust::for_each(handle_ptr->get_thrust_policy(),
+                                   variables_to_fix.begin(),
+                                   variables_to_fix.end(),
+                                   [assignment = make_span(assignment)] __device__(i_t x) {
+                                     cuopt_assert(isfinite(assignment[x]),
+                                                  "Fixing a variable to a non-finite value");
+                                   }));
   const i_t num_segments = original_problem.n_constraints;
   f_t initial_value{0.};
 

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -1706,11 +1706,6 @@ void problem_t<i_t, f_t>::fix_given_variables(problem_t<i_t, f_t>& original_prob
                    variables_to_fix.end(),
                    [variable_fix_mask = make_span(fixing_helpers.variable_fix_mask)] __device__(
                      i_t x) { variable_fix_mask[x] = 1; });
-  // Guard: fixing a variable to a non-finite value corrupts the constraint RHS below
-  // (coeff * floor(+-inf) = +-inf, then original_bound - inf can be inf - inf = NaN), which
-  // otherwise surfaces much later as an opaque "Constraints bounds are invalid" validation
-  // error. Fail loudly at the source instead. Callers must seed a finite assignment before
-  // fixing (e.g. free variables must not be left at their -inf lower-bound default).
   cuopt_func_call(thrust::for_each(handle_ptr->get_thrust_policy(),
                                    variables_to_fix.begin(),
                                    variables_to_fix.end(),


### PR DESCRIPTION
When feeding initial solutions to the population, the diversity manager was fixing the variables on a default constructed problem. If the problem has free variables, it means that it was fixed to an infinity bound.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
