### PR TITLE
Fix libomp ABI bug

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -69,7 +69,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -84,7 +84,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@release/26.08
     secrets:
       CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
       CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -119,7 +119,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -157,7 +157,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -177,7 +177,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -197,7 +197,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
@@ -218,7 +218,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       node_type: "gpu-l4-latest-1"
@@ -238,7 +238,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -259,7 +259,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@release/26.08
     secrets:
       CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
       RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}

--- a/.github/workflows/multi_gpu_cpp_test.yaml
+++ b/.github/workflows/multi_gpu_cpp_test.yaml
@@ -54,7 +54,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,7 +36,7 @@ jobs:
       - pr-test-summary
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.08
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -64,7 +64,7 @@ jobs:
       contents: read
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@release/26.08
     with:
       files_yaml: |
         build_docs:
@@ -331,7 +331,7 @@ jobs:
   checks:
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@release/26.08
     with:
       enable_check_generated_files: false
   conda-cpp-build:
@@ -348,7 +348,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@release/26.08
     with:
       build_type: pull-request
       script: ci/build_cpp.sh
@@ -360,7 +360,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
@@ -399,7 +399,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@release/26.08
     with:
       build_type: pull-request
       script: ci/build_python.sh
@@ -411,7 +411,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
@@ -428,7 +428,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
       build_type: pull-request
@@ -448,7 +448,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       # build for every combination of arch and CUDA version, but only for the latest Python
       matrix_filter: ${{ needs.compute-matrix-filters.outputs.libcuopt_filter }}
@@ -466,7 +466,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt.sh
@@ -480,7 +480,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -502,7 +502,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt_server.sh
@@ -521,7 +521,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@release/26.08
     with:
       build_type: pull-request
       script: ci/build_wheel_cuopt_sh_client.sh
@@ -539,7 +539,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -57,7 +57,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@release/26.08
     with:
       run_codecov: false
       build_type: ${{ inputs.build_type }}
@@ -80,7 +80,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -102,7 +102,7 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -125,7 +125,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -21,7 +21,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     permissions:
       contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@release/26.08
     secrets:
       slack-webhook-url: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
     with:

--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-branch-26.08
+release/26.08

--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-main
+branch-26.08

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For CUDA 12.x:
 pip install \
   --extra-index-url=https://pypi.nvidia.com \
   nvidia-cuda-runtime-cu12==12.9.* \
-  cuopt-server-cu12==26.6.* cuopt-sh-client==26.6.*
+  cuopt-server-cu12==26.08.* cuopt-sh-client==26.08.*
 ```
 
 Development wheels are available as nightlies, please update `--extra-index-url` to `https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/` to install latest nightly packages.
@@ -101,7 +101,7 @@ Development wheels are available as nightlies, please update `--extra-index-url`
 pip install --pre \
   --extra-index-url=https://pypi.nvidia.com \
   --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
-  cuopt-server-cu12==26.6.* cuopt-sh-client==26.6.*
+  cuopt-server-cu12==26.08.* cuopt-sh-client==26.08.*
 ```
 
 For CUDA 13.x:
@@ -109,7 +109,7 @@ For CUDA 13.x:
 ```bash
 pip install \
   --extra-index-url=https://pypi.nvidia.com \
-  cuopt-server-cu13==26.6.* cuopt-sh-client==26.6.*
+  cuopt-server-cu13==26.08.* cuopt-sh-client==26.08.*
 ```
 
 Development wheels are available as nightlies, please update `--extra-index-url` to `https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/` to install latest nightly packages.
@@ -117,7 +117,7 @@ Development wheels are available as nightlies, please update `--extra-index-url`
 pip install --pre \
   --extra-index-url=https://pypi.nvidia.com \
   --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ \
-  cuopt-server-cu13==26.6.* cuopt-sh-client==26.6.*
+  cuopt-server-cu13==26.08.* cuopt-sh-client==26.08.*
 ```
 
 
@@ -128,7 +128,7 @@ cuOpt can be installed with conda (via [miniforge](https://github.com/conda-forg
 All other dependencies are installed automatically when `cuopt-server` and `cuopt-sh-client` are installed.
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia cuopt-server=26.06.* cuopt-sh-client=26.06.*
+conda install -c rapidsai -c conda-forge -c nvidia cuopt-server=26.08.* cuopt-sh-client=26.08.*
 ```
 
 We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD

--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -2168,9 +2168,14 @@ bool branch_and_bound_t<i_t, f_t>::launch_rins_worker(const std::vector<f_t>& so
   worker->set_active();
   worker->search_strategy = search_strategy_t::SUBMIP;
 
-#pragma omp task priority(CUOPT_DEFAULT_TASK_PRIORITY) affinity(worker) \
-  firstprivate(worker, sol) if (!settings_.inside_submip)
-  rins(worker, sol);
+  if (settings_.inside_submip) {
+    // LLVM libomp's GOMP compatibility path skips GCC's firstprivate copy
+    // function for included tasks.
+    rins(worker, sol);
+  } else {
+#pragma omp task priority(CUOPT_DEFAULT_TASK_PRIORITY) affinity(worker) firstprivate(worker, sol)
+    rins(worker, sol);
+  }
 
   return true;
 }

--- a/cpp/src/io/experimental_mps_fast/fast_parser.cpp
+++ b/cpp/src/io/experimental_mps_fast/fast_parser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // reserved. SPDX-License-Identifier: Apache-2.0
 
 #include "fast_parser.hpp"

--- a/cpp/src/io/experimental_mps_fast/fast_parser.cpp
+++ b/cpp/src/io/experimental_mps_fast/fast_parser.cpp
@@ -2780,6 +2780,7 @@ static void finalize_qcmatrix_constraints(parse_state_t<i_t, f_t>& state)
       qc.cols.push_back(col);
       qc.vals.push_back(val);
     }
+    check_symmetric_offdiagonal_pairs(qc.rows, qc.cols, qc.vals);
     canonicalize_coo_matrix(qc.rows, qc.cols, qc.vals);
     state.problem.quadratic_constraints_.push_back(std::move(qc));
   }

--- a/cpp/src/io/experimental_mps_fast/fast_parser.cpp
+++ b/cpp/src/io/experimental_mps_fast/fast_parser.cpp
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include <file_to_string.hpp>
+#include <mps_parser_internal.hpp>
 
 #define MPS_FAST_COMPACT_ROW_HASH
 #define MPS_FAST_THP_PREFAULT
@@ -2769,6 +2770,7 @@ static void finalize_qcmatrix_constraints(parse_state_t<i_t, f_t>& state)
       return std::get<1>(ea) < std::get<1>(eb);
     });
 
+    // Match reference ingest: canonicalize MPS symmetric halves to upper-triangular COO.
     qc.rows.reserve(block.entries.size());
     qc.cols.reserve(block.entries.size());
     qc.vals.reserve(block.entries.size());
@@ -2778,6 +2780,7 @@ static void finalize_qcmatrix_constraints(parse_state_t<i_t, f_t>& state)
       qc.cols.push_back(col);
       qc.vals.push_back(val);
     }
+    canonicalize_coo_matrix(qc.rows, qc.cols, qc.vals);
     state.problem.quadratic_constraints_.push_back(std::move(qc));
   }
 

--- a/cpp/src/io/mps_parser.cpp
+++ b/cpp/src/io/mps_parser.cpp
@@ -1711,6 +1711,19 @@ template class mps_parser_t<int, float>;
 
 template class mps_parser_t<int, double>;
 
+template void check_symmetric_offdiagonal_pairs<int, float>(const std::vector<int>&,
+                                                            const std::vector<int>&,
+                                                            const std::vector<float>&);
+template void check_symmetric_offdiagonal_pairs<int, double>(const std::vector<int>&,
+                                                             const std::vector<int>&,
+                                                             const std::vector<double>&);
+template void check_symmetric_offdiagonal_pairs<int64_t, float>(const std::vector<int64_t>&,
+                                                                const std::vector<int64_t>&,
+                                                                const std::vector<float>&);
+template void check_symmetric_offdiagonal_pairs<int64_t, double>(const std::vector<int64_t>&,
+                                                                 const std::vector<int64_t>&,
+                                                                 const std::vector<double>&);
+
 template void canonicalize_coo_matrix<int, float>(std::vector<int>&,
                                                   std::vector<int>&,
                                                   std::vector<float>&);

--- a/cpp/src/io/mps_parser.cpp
+++ b/cpp/src/io/mps_parser.cpp
@@ -1717,5 +1717,11 @@ template void canonicalize_coo_matrix<int, float>(std::vector<int>&,
 template void canonicalize_coo_matrix<int, double>(std::vector<int>&,
                                                    std::vector<int>&,
                                                    std::vector<double>&);
+template void canonicalize_coo_matrix<int64_t, float>(std::vector<int64_t>&,
+                                                      std::vector<int64_t>&,
+                                                      std::vector<float>&);
+template void canonicalize_coo_matrix<int64_t, double>(std::vector<int64_t>&,
+                                                       std::vector<int64_t>&,
+                                                       std::vector<double>&);
 
 }  // namespace cuopt::mathematical_optimization::io

--- a/cpp/src/pdlp/utilities/problem_checking.cuh
+++ b/cpp/src/pdlp/utilities/problem_checking.cuh
@@ -10,10 +10,7 @@
 #include <cuopt/mathematical_optimization/optimization_problem.hpp>
 #include <cuopt/mathematical_optimization/pdlp/solver_settings.hpp>
 
-namespace rmm {
-template <typename T>
-class device_uvector;
-}  // namespace rmm
+#include <rmm/device_uvector.hpp>
 
 namespace cuopt::mathematical_optimization {
 

--- a/cpp/src/pdlp/utilities/problem_checking.cuh
+++ b/cpp/src/pdlp/utilities/problem_checking.cuh
@@ -10,7 +10,10 @@
 #include <cuopt/mathematical_optimization/optimization_problem.hpp>
 #include <cuopt/mathematical_optimization/pdlp/solver_settings.hpp>
 
-#include <rmm/device_uvector.hpp>
+namespace rmm {
+template <typename T>
+class device_uvector;
+}  // namespace rmm
 
 namespace cuopt::mathematical_optimization {
 

--- a/cpp/tests/linear_programming/experimental_mps_fast/fast_parser_edge_test.cpp
+++ b/cpp/tests/linear_programming/experimental_mps_fast/fast_parser_edge_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fast_parser.hpp"

--- a/cpp/tests/linear_programming/experimental_mps_fast/fast_parser_edge_test.cpp
+++ b/cpp/tests/linear_programming/experimental_mps_fast/fast_parser_edge_test.cpp
@@ -853,6 +853,7 @@ TEST(FastMpsParserEdgeTest, QcMatrixRowsMatchReferenceBitwise)
                          "QCMATRIX   QC1\n"
                          " X1 X1 1.25\n"
                          " X1 X2 -2.5\n"
+                         " X2 X1 -2.5\n"
                          "QCMATRIX   QC2\n"
                          " X2 X2 3.75\n"
                          "ENDATA\n");

--- a/python/cuopt/cuopt/tests/linear_programming/test_incumbent_callbacks.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_incumbent_callbacks.py
@@ -110,21 +110,9 @@ def _run_incumbent_solver_callback(file_name, include_set_callback):
         )
 
 
-_BAD_ARRAY_SKIP = pytest.mark.skip(
-    reason=(
-        "Temporarily disabled: aborts with std::bad_array_new_length "
-        "in wheel builds after the fast MPS parser landed (#1429). "
-        "Tracked in https://github.com/NVIDIA/cuopt/issues/1592."
-    )
-)
-
-
 @pytest.mark.parametrize(
     "file_name",
-    [
-        pytest.param("/mip/swath1.mps", marks=_BAD_ARRAY_SKIP),
-        pytest.param("/mip/neos5-free-bound.mps", marks=_BAD_ARRAY_SKIP),
-    ],
+    ["/mip/swath1.mps", "/mip/neos5-free-bound.mps"],
 )
 def test_incumbent_get_callback(file_name):
     _run_incumbent_solver_callback(file_name, include_set_callback=False)
@@ -132,10 +120,7 @@ def test_incumbent_get_callback(file_name):
 
 @pytest.mark.parametrize(
     "file_name",
-    [
-        pytest.param("/mip/swath1.mps", marks=_BAD_ARRAY_SKIP),
-        pytest.param("/mip/neos5-free-bound.mps", marks=_BAD_ARRAY_SKIP),
-    ],
+    ["/mip/swath1.mps", "/mip/neos5-free-bound.mps"],
 )
 def test_incumbent_get_set_callback(file_name):
     _run_incumbent_solver_callback(file_name, include_set_callback=True)

--- a/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
@@ -676,13 +676,6 @@ def test_solved_by():
     assert solution.get_solved_by() == SolverMethod.Barrier
 
 
-@pytest.mark.skip(
-    reason=(
-        "Temporarily disabled: swath1 aborts with std::bad_array_new_length "
-        "in wheel builds after the fast MPS parser landed (#1429). "
-        "Tracked in https://github.com/NVIDIA/cuopt/issues/1592."
-    )
-)
 def test_heuristics_only():
     file_path = RAPIDS_DATASET_ROOT_DIR + "/mip/swath1.mps"
     data_model_obj = Read(file_path)

--- a/skills/cuopt-developer/SKILL.md
+++ b/skills/cuopt-developer/SKILL.md
@@ -223,6 +223,12 @@ For pre-commit setup, DCO sign-off (`git commit -s`), the fork-based PR workflow
 
 For C++ naming (`snake_case`, `d_`/`h_` prefixes, `_t` suffix), file extensions (`.hpp`/`.cpp`/`.cu`/`.cuh` and which compiler each uses), include order, Python style, error handling (`CUOPT_EXPECTS`, `RAFT_CUDA_TRY`), memory management (RMM patterns, no raw `new`/`delete`), and test-impact rules, see [references/conventions.md](references/conventions.md).
 
+## OpenMP task/runtime compatibility
+
+Treat `#pragma omp task if(...) firstprivate(...)` with a non-trivial C++ capture as runtime-ABI-sensitive. In affected LLVM libomp versions, the GCC `GOMP_task` compatibility path skips the GCC copy function for an included (`if(false)`) task, so the task body can observe an unconstructed object. Branch explicitly instead: create the OpenMP task only when deferral is wanted, and call the body synchronously otherwise.
+
+When diagnosing OpenMP-only failures, test compiler/runtime pairs separately. A Clang + libomp pass exercises the `__kmpc_*` ABI and does not cover GCC + libomp's `GOMP_*` path; reduce suspicious cases to a direct runtime-ABI probe before attributing them to solver logic.
+
 ## Troubleshooting & CI
 
 For build/test pitfalls (Cython rebuild, OOM, CUDA driver mismatch, missing `nvcc`) and CI failure diagnostics (style checks, DCO failures, dependency drift), see [references/troubleshooting.md](references/troubleshooting.md).


### PR DESCRIPTION
This PR adds a workaround resolving a buggy interaction between GCC's generated OMP helpers and LLVM's OpenMP runtime.
This was introduced as a latent issue in the Recursive RINS PR, and then exposed by the fast MPS PR which moved the wheel's runtime to LLVM OpenMP.

In more details:
> The failure was caused by an LLVM libomp bug in its GCC GOMP_task compatibility layer: for an included OpenMP task (if(false)), libomp skipped GCC’s generated
  firstprivate copy function, leaving a captured non-trivial C++ object unconstructed; the RINS sub-MIP path then read this invalid object and eventually threw
  std::bad_array_new_length. The unrelated merge merely exposed the latent runtime-dependent bug in libomp-linked wheels; explicitly executing the included-task
  path synchronously avoids the faulty compatibility path.

I will file a min repro and bug to LLVM later.

closes #1592 

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
