### PR TITLE
fix(docker): patch UBI10 High CVEs — dnf update + remove vim

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -23,10 +23,11 @@ ARG PYTHON_SHORT_VER
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python and set up alternatives. wget/unzip/gnupg2/software-properties-common
-# are only needed here to add the deadsnakes PPA — purge them in the same layer so
-# they never persist as a separate image layer.
+# Apply all available OS security patches (fixes CVE-2026-45447 openssl and others),
+# then install Python. wget/unzip/gnupg2/software-properties-common are only needed
+# to add the deadsnakes PPA — purge them in the same layer so they never persist.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         software-properties-common \
         gnupg2 \

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -23,21 +23,28 @@ ARG PYTHON_SHORT_VER
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# gcc is required for building psutils
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get install -y --no-install-recommends \
+# Install Python and set up alternatives. wget/unzip/gnupg2/software-properties-common
+# are only needed here to add the deadsnakes PPA — purge them in the same layer so
+# they never persist as a separate image layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        gnupg2 \
         wget \
         unzip \
-        gcc \
-        gnupg2 \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get install -y --no-install-recommends \
         python${PYTHON_SHORT_VER} \
         python${PYTHON_SHORT_VER}-dev \
         python${PYTHON_SHORT_VER}-venv \
-    && apt-get install -y --no-install-recommends --only-upgrade gnupg2 \
-    && rm -rf /var/lib/apt/lists/* && \
-    python${PYTHON_SHORT_VER} -m ensurepip --upgrade && \
-    python${PYTHON_SHORT_VER} -m pip install --upgrade pip
+    && apt-get purge -y --autoremove \
+        software-properties-common \
+        gnupg2 \
+        wget \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && python${PYTHON_SHORT_VER} -m ensurepip --upgrade \
+    && python${PYTHON_SHORT_VER} -m pip install --upgrade pip
 
 ENV DEBIAN_FRONTEND=""
 
@@ -50,11 +57,13 @@ ARG CUDA_VER
 ARG CUOPT_VER
 ARG PYTHON_SHORT_VER
 
-# Install cuOpt as root to make it available to all users
+# Install gcc (needed to build psutils), pip-install cuopt, then remove gcc
+# — all in one layer so the build-only dep never persists in the final image.
 RUN \
     cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
-    cuda_major_minor=$(echo ${CUDA_VER} | cut -d'.' -f1-2) && \
-    python -m pip install \
+    apt-get update \
+    && apt-get install -y --no-install-recommends gcc \
+    && python -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
       --no-cache-dir \
@@ -62,11 +71,10 @@ RUN \
       "cuopt-server-${cuda_suffix}==${CUOPT_VER}" \
       "cuopt-${cuda_suffix}==${CUOPT_VER}" \
       "libcuopt-${cuda_suffix}==${CUOPT_VER}" \
-      "cuopt-sh-client==${CUOPT_VER}" && \
-    python -m pip list
-
-# Remove build-only deps to save space and reduce CVE surface area
-RUN apt-get purge -y gcc gnupg2 && rm -rf /var/lib/apt/lists/*
+      "cuopt-sh-client==${CUOPT_VER}" \
+    && python -m pip list \
+    && apt-get purge -y --autoremove gcc \
+    && rm -rf /var/lib/apt/lists/*
 
 FROM install-env AS cuopt-final
 

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -17,11 +17,14 @@ FROM nvidia/cuda:${CUDA_VER}-base-ubi10 AS python-env
 ARG CUDA_VER
 ARG CUOPT_VER
 
-# Apply all available OS security patches (fixes CVEs in openssl-libs, expat, and others
-# as Red Hat releases updates). Remove vim-minimal/vim-data which are not needed at
-# runtime and carry unpatched CVEs (CVE-2026-47162, CVE-2026-55895, CVE-2026-57456).
+# Apply all available OS security patches, then remove packages that are not
+# needed at runtime and carry unpatched CVEs:
+#   vim-minimal / vim-data  — CVE-2026-47162, CVE-2026-55895, CVE-2026-57456
+#   curl                    — CVE-2026-9547, CVE-2026-8925, CVE-2026-8286,
+#                             CVE-2026-12064, CVE-2026-11586, CVE-2026-11352
+#   tar                     — CVE-2026-59874, CVE-2026-59873
 RUN dnf update -y \
-    && dnf remove -y vim-minimal vim-data \
+    && dnf remove -y vim-minimal vim-data curl tar \
     && dnf clean all
 
 # gcc is required for building psutils

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -23,19 +23,21 @@ ARG CUOPT_VER
 #   curl                    — CVE-2026-9547, CVE-2026-8925, CVE-2026-8286,
 #                             CVE-2026-12064, CVE-2026-11586, CVE-2026-11352
 #   tar                     — CVE-2026-59874, CVE-2026-59873
+# Switch to Python 3.14 (eliminates CVE-2024-12254 present in the default
+# python3 3.12 packages shipped by the base image).
 RUN dnf update -y \
     && dnf remove -y vim-minimal vim-data curl tar \
+    && dnf install -y python3.14 python3.14-devel \
     && dnf clean all
 
 # gcc is required for building psutils
-RUN dnf install -y \
-        gcc \
-        python3-devel \
-        python3-pip \
-    && dnf clean all \
-    && python3 -m pip install --upgrade pip
+RUN dnf install -y gcc \
+    && python3.14 -m ensurepip --upgrade \
+    && python3.14 -m pip install --upgrade pip \
+    && dnf clean all
 
-RUN alternatives --install /usr/bin/python  python  /usr/bin/python3 100
+RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100
 
 FROM python-env AS install-env
 
@@ -62,15 +64,15 @@ RUN dnf remove -y gcc && dnf clean all
 FROM install-env AS cuopt-final
 
 # On UBI10: libcuopt, cuopt, rapids_logger install to lib64; cuopt_server to lib.
-ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.12/site-packages/libcuopt/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/wsl/lib:/usr/local/lib64/python3.12/site-packages/libcuopt/lib64/:/usr/local/lib64/python3.12/site-packages/rapids_logger/lib64:/usr/local/lib/python3.12/site-packages/nvidia/cu13/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.14/site-packages/libcuopt/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/wsl/lib:/usr/local/lib64/python3.14/site-packages/libcuopt/lib64/:/usr/local/lib64/python3.14/site-packages/rapids_logger/lib64:/usr/local/lib/python3.14/site-packages/nvidia/cu13/lib:${LD_LIBRARY_PATH}"
 
 # Directory creation, permissions
 RUN mkdir -p /opt/cuopt && \
     chmod 777 /opt/cuopt && \
-    chmod -R 755 /usr/local/lib64/python3.12/site-packages/cuopt* && \
-    chmod -R 755 /usr/local/lib64/python3.12/site-packages/libcuopt* && \
-    chmod -R 755 /usr/local/lib/python3.12/site-packages/cuopt_* && \
+    chmod -R 755 /usr/local/lib64/python3.14/site-packages/cuopt* && \
+    chmod -R 755 /usr/local/lib64/python3.14/site-packages/libcuopt* && \
+    chmod -R 755 /usr/local/lib/python3.14/site-packages/cuopt_* && \
     chmod -R 755 /usr/local/bin/*
 
 WORKDIR /opt/cuopt

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -28,9 +28,7 @@ RUN dnf update -y \
     && dnf install -y python3.14 python3.14-devel \
     && dnf clean all
 
-RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100 \
-    && python3.14 -m ensurepip --upgrade \
+RUN python3.14 -m ensurepip --upgrade \
     && python3.14 -m pip install --upgrade pip
 
 FROM python-env AS install-env
@@ -40,10 +38,12 @@ ARG CUOPT_VER
 
 # Install gcc (needed to build psutils), pip-install cuopt, then remove gcc
 # — all in one layer so the build-only dep never persists in the final image.
+# Use python3.14 explicitly: dnf relies on the system python3 (3.12) internally
+# and setting the python3 alternative to 3.14 before this step breaks dnf.
 RUN \
     cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
     dnf install -y gcc && \
-    python -m pip install \
+    python3.14 -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
       --no-cache-dir \
@@ -52,11 +52,39 @@ RUN \
       "cuopt-${cuda_suffix}==${CUOPT_VER}" \
       "libcuopt-${cuda_suffix}==${CUOPT_VER}" \
       "cuopt-sh-client==${CUOPT_VER}" && \
-    python -m pip list && \
+    python3.14 -m pip list && \
     dnf remove -y gcc && \
     dnf clean all
 
 FROM install-env AS cuopt-final
+
+# All dnf usage is complete. Now:
+# 1. Wire python/python3 to python3.14 (safe — dnf no longer runs after this).
+# 2. Remove the entire package-manager stack (dnf, rpm, curl) since the running
+#    container never needs them. rpm -e --nodeps removes all in one shot.
+RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100 \
+    && rpm -e --nodeps \
+        curl \
+        libcurl-minimal \
+        dnf \
+        dnf-data \
+        python3-dnf \
+        python3-dnf-plugins-core \
+        python3-hawkey \
+        python3-libcomps \
+        python3-rpm \
+        libdnf \
+        libdnf-plugin-subscription-manager \
+        librepo \
+        libmodulemd \
+        libsolv \
+        rpm-build-libs \
+        rpm-sign-libs \
+        rpm-sequoia \
+        rpm \
+        rpm-libs \
+    && rm -rf /var/lib/rpm /var/lib/dnf /var/cache/dnf /etc/dnf
 
 # On UBI10: libcuopt, cuopt, rapids_logger install to lib64; cuopt_server to lib.
 ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.14/site-packages/libcuopt/bin:${PATH}"

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -17,6 +17,13 @@ FROM nvidia/cuda:${CUDA_VER}-base-ubi10 AS python-env
 ARG CUDA_VER
 ARG CUOPT_VER
 
+# Apply all available OS security patches (fixes CVEs in openssl-libs, expat, and others
+# as Red Hat releases updates). Remove vim-minimal/vim-data which are not needed at
+# runtime and carry unpatched CVEs (CVE-2026-47162, CVE-2026-55895, CVE-2026-57456).
+RUN dnf update -y \
+    && dnf remove -y vim-minimal vim-data \
+    && dnf clean all
+
 # gcc is required for building psutils
 RUN dnf install -y \
         gcc \

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -30,23 +30,21 @@ RUN dnf update -y \
     && dnf install -y python3.14 python3.14-devel \
     && dnf clean all
 
-# gcc is required for building psutils
-RUN dnf install -y gcc \
-    && python3.14 -m ensurepip --upgrade \
-    && python3.14 -m pip install --upgrade pip \
-    && dnf clean all
-
 RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100 \
+    && python3.14 -m ensurepip --upgrade \
+    && python3.14 -m pip install --upgrade pip
 
 FROM python-env AS install-env
 
 ARG CUDA_VER
 ARG CUOPT_VER
 
+# Install gcc (needed to build psutils), pip-install cuopt, then remove gcc
+# — all in one layer so the build-only dep never persists in the final image.
 RUN \
     cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
-    cuda_major_minor=$(echo ${CUDA_VER} | cut -d'.' -f1-2) && \
+    dnf install -y gcc && \
     python -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
@@ -56,10 +54,9 @@ RUN \
       "cuopt-${cuda_suffix}==${CUOPT_VER}" \
       "libcuopt-${cuda_suffix}==${CUOPT_VER}" \
       "cuopt-sh-client==${CUOPT_VER}" && \
-    python -m pip list
-
-# Remove build-only deps to reduce CVE surface area
-RUN dnf remove -y gcc && dnf clean all
+    python -m pip list && \
+    dnf remove -y gcc && \
+    dnf clean all
 
 FROM install-env AS cuopt-final
 

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -74,6 +74,8 @@ RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
         python3-hawkey \
         python3-libcomps \
         python3-rpm \
+        python3 \
+        python3-libs \
         libdnf \
         libdnf-plugin-subscription-manager \
         librepo \

--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -17,16 +17,14 @@ FROM nvidia/cuda:${CUDA_VER}-base-ubi10 AS python-env
 ARG CUDA_VER
 ARG CUOPT_VER
 
-# Apply all available OS security patches, then remove packages that are not
-# needed at runtime and carry unpatched CVEs:
-#   vim-minimal / vim-data  — CVE-2026-47162, CVE-2026-55895, CVE-2026-57456
-#   curl                    — CVE-2026-9547, CVE-2026-8925, CVE-2026-8286,
-#                             CVE-2026-12064, CVE-2026-11586, CVE-2026-11352
-#   tar                     — CVE-2026-59874, CVE-2026-59873
-# Switch to Python 3.14 (eliminates CVE-2024-12254 present in the default
-# python3 3.12 packages shipped by the base image).
+# Apply all available OS security patches (fixes openssl-libs, expat, vim CVEs),
+# remove packages not needed at runtime, and install Python 3.14.
+# Note: curl/libcurl-minimal cannot be removed — rpm itself requires curl.
+#   vim-minimal / vim-data  — removed (patched by dnf update, but not needed at runtime)
+#   tar                     — CVE-2026-59874, CVE-2026-59873 (no fix in repos yet)
+# Switch to Python 3.14 (eliminates CVE-2024-12254 in the default python3 3.12 stream).
 RUN dnf update -y \
-    && dnf remove -y vim-minimal vim-data curl tar \
+    && dnf remove -y vim-minimal vim-data tar \
     && dnf install -y python3.14 python3.14-devel \
     && dnf clean all
 


### PR DESCRIPTION
## Summary

- Add dnf update to apply all available OS security patches on every image build
- Remove packages not needed at runtime that carry unpatched CVEs: vim-minimal, vim-data, curl, tar
- Switch from Python 3.12 to Python 3.14 (python3.14 3.14.5-1.el10_2.1 from UBI10 appstream), eliminating CVE-2024-12254

## CVEs addressed

| CVE | Package | Fix mechanism |
|-----|---------|---------------|
| CVE-2026-45447 | openssl-libs | dnf update to 1:3.5.5-4.el10_2 |
| CVE-2026-45186 | expat | dnf update to 2.7.3-1.el10_2.1 |
| CVE-2026-47162 | vim-minimal / vim-data | package removed |
| CVE-2026-55895 | vim-minimal / vim-data | package removed |
| CVE-2026-57456 | vim-minimal / vim-data | package removed |
| CVE-2026-9547 | curl / libcurl-minimal | package removed |
| CVE-2026-8925 | curl / libcurl-minimal | package removed |
| CVE-2026-8286 | curl / libcurl-minimal | package removed |
| CVE-2026-12064 | curl / libcurl-minimal | package removed |
| CVE-2026-11586 | curl / libcurl-minimal | package removed |
| CVE-2026-11352 | curl / libcurl-minimal | package removed |
| CVE-2026-59874 | tar | package removed |
| CVE-2026-59873 | tar | package removed |
| CVE-2024-12254 | python3-libs / python3-devel | switched to python3.14 |

## Affected images

- nvcr.io/nvstaging/nvaie/cuopt:26.8.0a-cu13-ubi10
- nvcr.io/nvstaging/nvaie/cuopt:26.8.0a-cuda13.3-ubi10