### PR TITLE
fix(grpc): cancel active jobs on delete

### DIFF
--- a/cpp/docs/grpc-server-architecture.md
+++ b/cpp/docs/grpc-server-architecture.md
@@ -304,6 +304,8 @@ When `CancelJob` is called:
 2. If the job is **queued** (no worker yet): the worker checks the flag before starting and skips to the next job
 3. If the job is **running** (worker has claimed it): the worker process is killed with `SIGKILL`, the worker-monitor thread detects the exit and posts a `RESULT_CANCELLED` status, and a replacement worker is spawned automatically
 
+`DeleteResult` performs the same cancel for queued/running jobs, then removes all server-side state (tracker entry, pending payload, log file) so the job id is gone.
+
 ## Memory Management
 
 | Resource | Location | Cleanup |

--- a/cpp/src/grpc/client/grpc_client.hpp
+++ b/cpp/src/grpc/client/grpc_client.hpp
@@ -350,6 +350,11 @@ class grpc_client_t {
 
   /**
    * @brief Delete a job and its results from server
+   *
+   * If the job is still queued or running, it is cancelled first (queued jobs
+   * will not run; running workers are killed), then all server-side state is
+   * removed.
+   *
    * @param job_id The job ID to delete
    * @return true if deletion successful
    */

--- a/cpp/src/grpc/server/grpc_job_management.cpp
+++ b/cpp/src/grpc/server/grpc_job_management.cpp
@@ -343,6 +343,39 @@ int cancel_job(const std::string& job_id, JobStatus& job_status_out, std::string
   return 0;
 }
 
+bool delete_job(const std::string& job_id, std::string& message)
+{
+  // Cancel first so a queued job is never run and a running worker is killed.
+  // cancel_job returns 1 only when the job is unknown; other non-zero codes
+  // mean the job is already terminal (completed/failed/cancelled) and we still
+  // remove its stored state below.
+  JobStatus cancel_status = JobStatus::NOT_FOUND;
+  std::string cancel_msg;
+  if (cancel_job(job_id, cancel_status, cancel_msg) == 1) {
+    message = "Job not found: " + job_id;
+    return false;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(tracker_mutex);
+    job_tracker.erase(job_id);
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(pending_data_mutex);
+    pending_job_data.erase(job_id);
+    pending_chunked_data.erase(job_id);
+  }
+
+  // No waiter handling here: cancel_job() already notified and erased any
+  // waiter for a queued/running job, and a job that was already terminal had
+  // its waiters signaled when it reached that state.
+
+  delete_log_file(job_id);
+  message = "Result deleted";
+  return true;
+}
+
 std::string generate_job_id()
 {
   uuid_t uuid;

--- a/cpp/src/grpc/server/grpc_server_types.hpp
+++ b/cpp/src/grpc/server/grpc_server_types.hpp
@@ -373,5 +373,7 @@ std::pair<bool, std::string> submit_chunked_job_async(PendingChunkedUpload&& chu
                                                       uint32_t problem_category);
 JobStatus check_job_status(const std::string& job_id, std::string& message);
 int cancel_job(const std::string& job_id, JobStatus& job_status_out, std::string& message);
+// Cancel if queued/running, then remove all server-side state for the job.
+bool delete_job(const std::string& job_id, std::string& message);
 
 #endif  // CUOPT_ENABLE_GRPC

--- a/cpp/src/grpc/server/grpc_service_impl.cpp
+++ b/cpp/src/grpc/server/grpc_service_impl.cpp
@@ -527,27 +527,21 @@ class CuOptRemoteServiceImpl final : public cuopt::remote::CuOptRemoteService::S
                       const cuopt::remote::DeleteRequest* request,
                       cuopt::remote::DeleteResponse* response) override
   {
+    (void)context;
     std::string job_id = request->job_id();
 
-    size_t erased = 0;
-    {
-      std::lock_guard<std::mutex> lock(tracker_mutex);
-      erased = job_tracker.erase(job_id);
-    }
-
-    if (erased == 0) {
+    std::string message;
+    if (!delete_job(job_id, message)) {
       response->set_status(cuopt::remote::ERROR_NOT_FOUND);
-      response->set_message("Job not found: " + job_id);
+      response->set_message(message);
       if (config.verbose) {
         SERVER_LOG_DEBUG("[gRPC] DeleteResult job not found: %s", job_id.c_str());
       }
       return Status::OK;
     }
 
-    delete_log_file(job_id);
-
     response->set_status(cuopt::remote::SUCCESS);
-    response->set_message("Result deleted");
+    response->set_message(message);
 
     if (config.verbose) { SERVER_LOG_DEBUG("[gRPC] Result deleted for job: %s", job_id.c_str()); }
 

--- a/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_integration_test.cpp
@@ -1125,6 +1125,127 @@ TEST_F(DefaultServerTests, CancelRunningJob)
   client->delete_job(job_id);
 }
 
+// -- Delete should cancel queued / running jobs --
+
+TEST_F(DefaultServerTests, DeleteQueuedJobPreventsRun)
+{
+  auto client = create_client();
+  ASSERT_NE(client, nullptr);
+
+  std::string mps_path = get_test_mip_path("neos5-free-bound.mps");
+  auto problem         = load_problem_from_file(mps_path);
+
+  mip_solver_settings_t<int32_t, double> settings;
+  settings.time_limit = 120.0;
+
+  // Occupy the single worker with a long solve.
+  auto running = client->submit_mip(problem, settings);
+  ASSERT_TRUE(running.success);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  auto queued = client->submit_mip(problem, settings);
+  ASSERT_TRUE(queued.success);
+
+  auto queued_status = client->check_status(queued.job_id);
+  ASSERT_TRUE(queued_status.success);
+  EXPECT_EQ(queued_status.status, job_status_t::QUEUED)
+    << "Second job should still be queued behind the running solve";
+
+  EXPECT_TRUE(client->delete_job(queued.job_id));
+
+  auto after_delete = client->check_status(queued.job_id);
+  EXPECT_EQ(after_delete.status, job_status_t::NOT_FOUND);
+
+  // Prove the worker is still usable and was not consumed by the deleted job:
+  // free it (cancel the long solve) and require a probe job to run to
+  // completion. If the deleted job were still occupying the queue/worker, the
+  // single worker could not pick up and finish the probe. With one worker we
+  // cannot observe the ghost's status once its tracker entry is gone, so we
+  // assert the worker stays functional instead.
+  client->cancel_job(running.job_id);
+
+  mip_solver_settings_t<int32_t, double> probe_settings;
+  probe_settings.time_limit = 10.0;
+  auto probe                = client->submit_mip(problem, probe_settings);
+  ASSERT_TRUE(probe.success);
+
+  wait_for_job_done(client.get(), probe.job_id, 60);
+  auto probe_status = client->check_status(probe.job_id);
+  EXPECT_EQ(probe_status.status, job_status_t::COMPLETED)
+    << "Worker should be free to process a new job after the queued job was deleted";
+
+  client->delete_job(probe.job_id);
+  client->delete_job(running.job_id);
+}
+
+TEST_F(DefaultServerTests, DeleteRunningJobCancelsWorker)
+{
+  auto client = create_client();
+  ASSERT_NE(client, nullptr);
+
+  std::string mps_path = get_test_mip_path("neos5-free-bound.mps");
+  auto problem         = load_problem_from_file(mps_path);
+
+  mip_solver_settings_t<int32_t, double> settings;
+  settings.time_limit = 120.0;
+
+  auto submit_result = client->submit_mip(problem, settings);
+  ASSERT_TRUE(submit_result.success);
+  std::string job_id = submit_result.job_id;
+
+  // Wait until the worker has claimed the job.
+  bool processing = false;
+  for (int i = 0; i < 40; ++i) {
+    auto status = client->check_status(job_id);
+    if (status.status == job_status_t::PROCESSING) {
+      processing = true;
+      break;
+    }
+    if (status.status == job_status_t::COMPLETED || status.status == job_status_t::FAILED ||
+        status.status == job_status_t::CANCELLED) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  }
+  ASSERT_TRUE(processing) << "Job never reached PROCESSING before delete";
+
+  // Measure only the delete latency: killing the worker must return promptly,
+  // not block until the 120s solve finishes.
+  auto delete_start = std::chrono::steady_clock::now();
+  EXPECT_TRUE(client->delete_job(job_id));
+  auto delete_elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+    std::chrono::steady_clock::now() - delete_start);
+  EXPECT_LT(delete_elapsed.count(), 15) << "Delete of a running job should return promptly";
+
+  auto after_delete = client->check_status(job_id);
+  EXPECT_EQ(after_delete.status, job_status_t::NOT_FOUND);
+
+  // Prove the killed worker was actually replaced: a probe job must be picked
+  // up (reach PROCESSING) and run to completion within a bounded interval.
+  mip_solver_settings_t<int32_t, double> probe_settings;
+  probe_settings.time_limit = 10.0;
+  auto probe                = client->submit_mip(problem, probe_settings);
+  ASSERT_TRUE(probe.success);
+
+  bool probe_started = false;
+  for (int i = 0; i < 120; ++i) {  // up to ~30s for the replacement worker
+    auto status = client->check_status(probe.job_id);
+    if (status.status == job_status_t::PROCESSING || status.status == job_status_t::COMPLETED) {
+      probe_started = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  }
+  EXPECT_TRUE(probe_started) << "Replacement worker never picked up the probe job";
+
+  wait_for_job_done(client.get(), probe.job_id, 60);
+  auto probe_status = client->check_status(probe.job_id);
+  EXPECT_EQ(probe_status.status, job_status_t::COMPLETED)
+    << "Replacement worker should process a new job to completion";
+
+  client->delete_job(probe.job_id);
+}
+
 // =============================================================================
 // Chunked Upload Tests (--max-message-mb 256)
 // =============================================================================

--- a/docs/cuopt/source/cuopt-grpc/api.rst
+++ b/docs/cuopt/source/cuopt-grpc/api.rst
@@ -32,7 +32,7 @@ Asynchronous Jobs
    * - ``GetResult``
      - Fetch a completed result (unary, when the payload fits one message).
    * - ``DeleteResult``
-     - Remove a stored result from server memory.
+     - Cancel the job if it is still queued or running, then remove all server-side state for that ``job_id``.
    * - ``CancelJob``
      - Cancel a queued or running job.
    * - ``WaitForCompletion``

--- a/docs/cuopt/source/cuopt-grpc/grpc-server-architecture.md
+++ b/docs/cuopt/source/cuopt-grpc/grpc-server-architecture.md
@@ -28,6 +28,7 @@ Implementation details (IPC layout, C++ source map, chunked transfer internals) 
 
 - If a **worker process crashes**, jobs it was running are marked **FAILED**; the server can spawn replacement workers (see contributor doc for details).
 - **`CancelJob`** cancels **queued** jobs immediately (the worker skips them). If the solver has already started, the **worker process is killed** and the job is marked **CANCELLED**; a replacement worker is spawned automatically.
+- **`DeleteResult`** also cancels a queued or running job (same kill/skip behavior as ``CancelJob``), then removes all server-side state for that ``job_id``.
 
 ## Further reading
 


### PR DESCRIPTION
Fix an oversight in the grpc server. If a job is simply deleted while it is queued or running, the result tracking is removed but the job will continue to run (and might run when it reaches the top of the queue). The correct semantics are to call "cancel" first on non-terminal jobs before running "delete".