### PR TITLE
fix: build against rmm 26.10 (use rmm's device_uvector declaration)

### DIFF
--- a/cpp/src/pdlp/utilities/problem_checking.cuh
+++ b/cpp/src/pdlp/utilities/problem_checking.cuh
@@ -10,10 +10,7 @@
 #include <cuopt/mathematical_optimization/optimization_problem.hpp>
 #include <cuopt/mathematical_optimization/pdlp/solver_settings.hpp>
 
-namespace rmm {
-template <typename T>
-class device_uvector;
-}  // namespace rmm
+#include <rmm/device_uvector.hpp>
 
 namespace cuopt::mathematical_optimization {
 


### PR DESCRIPTION
## Description

Building `libcuopt` from source against **rmm 26.10** fails to compile because `cpp/src/pdlp/utilities/problem_checking.cuh` hand-rolls a forward declaration of `rmm::device_uvector` in the plain `rmm` namespace:

```cpp
namespace rmm {
template <typename T>
class device_uvector;
}  // namespace rmm
```

rmm 26.10 places `device_uvector` in an ABI inline namespace (`rmm::RMM_ABI_NAMESPACE`, see `rmm/detail/export.hpp`), so this hand-rolled declaration creates a *second*, distinct `rmm::device_uvector`. Every use then becomes ambiguous:

```
cpp/src/pdlp/utilities/problem_checking.cuh(36): error: "rmm::device_uvector" is ambiguous
cpp/src/utilities/copy_helpers.hpp(82): error: "rmm::device_uvector" is ambiguous
```

with cascading `namespace "cuopt::raft" has no member "add_op"` and thrust `"this pragma must immediately precede a declaration"` errors in the same translation units.

This is the only manual rmm forward declaration in the tree. cuOpt already opts out of thrust's and cub's ABI namespaces (`-DTHRUST_DISABLE_ABI_NAMESPACE` / `-DCUB_DISABLE_NAMESPACE_MAGIC`); rmm's ABI inline namespace is newer and has no such opt-out, so the plain forward declaration no longer matches rmm's real declaration.

## Change

Replace the hand-rolled forward declaration with `#include <rmm/device_uvector.hpp>`, so rmm's own (correctly ABI-namespaced) declaration is used.

## Testing

Built `libcuopt` (LP + MIP) from source against rmm/raft 26.10 + CCCL 3.4.0 (CUDA 13.3, GCC 14, `sm_120a`):
- **Before:** the `device_uvector is ambiguous` errors above.
- **After:** clean compile + link. `solve_LP` returns correct optima — `afiro` → `-464.7531` (known optimum), and a set of small LPs match HiGHS to ≤ 1e-6 relative error — and the MIP path runs.

Fixes #1605.
