### PR TITLE
developer skills: size PARALLEL_LEVEL from cgroup limits in containers

### DIFF
--- a/skills/cuopt-developer/references/build_and_test.md
+++ b/skills/cuopt-developer/references/build_and_test.md
@@ -10,6 +10,22 @@ Read this for component-level build commands, run-test commands, and `PARALLEL_L
 export PARALLEL_LEVEL=8   # adjust based on available RAM
 ```
 
+**Inside a container (Docker / Kubernetes), `nproc` and `free` report the *host's* cores and RAM, not the container's limits.** Sizing `PARALLEL_LEVEL` from them over-subscribes a memory-capped pod and gets the build OOM-killed (exit 137), while a CPU quota silently throttles the surplus jobs. First detect whether you are containerized, then read the real caps from the cgroup and budget from whichever is tighter — ~4–8 GB per CUDA job against `memory.max`, and no more jobs than `cpu.max` grants:
+
+```bash
+# 1. Detect containerization — any hit means nproc/free report the host, not your limits.
+grep -qaE 'kubepods|docker|containerd|libpod|lxc' /proc/1/cgroup 2>/dev/null && echo containerized
+[ -f /.dockerenv ] && echo docker                     # Docker
+[ -n "$KUBERNETES_SERVICE_HOST" ] && echo kubernetes  # Kubernetes (also: kubepods in the grep above)
+
+# 2. Read the real caps from the cgroup (v2). If memory.max is absent at the mount
+#    root you are seeing the host root cgroup, so resolve your leaf via /proc/self/cgroup.
+CG=/sys/fs/cgroup
+[ -f "$CG/memory.max" ] || CG=/sys/fs/cgroup$(awk -F: '/^0::/{print $3}' /proc/self/cgroup)
+cat "$CG/memory.max"   # bytes, or "max" = no limit
+cat "$CG/cpu.max"      # "<quota> <period>"; effective cores = quota / period
+```
+
 ## Build Everything
 
 ```bash


### PR DESCRIPTION
In a Docker/Kubernetes container, nproc and free report the host's cores and RAM, not the container's limits, so the default PARALLEL_LEVEL=$(nproc) can OOM-kill the build (exit 137) on a memory-capped pod. Add a detection + cgroup-read recipe to build_and_test.md so PARALLEL_LEVEL is budgeted from memory.max and cpu.max instead.