### PR TITLE
feat(pdlp): expose the termination-check stride as a hyperparameter

### DIFF
--- a/benchmarks/linear_programming/cuopt/benchmark_helper.hpp
+++ b/benchmarks/linear_programming/cuopt/benchmark_helper.hpp
@@ -92,6 +92,7 @@ void fill_pdlp_hyper_params(const std::string& pdlp_hyper_params_path,
     {"major_iteration", &params.major_iteration},
     {"min_iteration_restart", &params.min_iteration_restart},
     {"restart_strategy", &params.restart_strategy},
+    {"conditional_major_step", &params.conditional_major_step},
   };
 
   std::map<std::string, bool*> bool_settings = {

--- a/cpp/include/cuopt/mathematical_optimization/pdlp/pdlp_hyper_params.cuh
+++ b/cpp/include/cuopt/mathematical_optimization/pdlp/pdlp_hyper_params.cuh
@@ -53,6 +53,9 @@ struct pdlp_hyper_params_t {
   double restart_k_d                                              = 0.0;
   double restart_i_smooth                                         = 0.3;
   bool use_conditional_major                                      = true;
+  // Iteration stride between full termination/convergence evaluations in the
+  // sub-1000-iteration regime; larger regimes scale it by x10 (see conditional_major).
+  int conditional_major_step = 10;
 };
 
 // TODO most likely we want to get rid of pdlp_solver_mode and just have prebuilt

--- a/cpp/src/pdlp/pdhg.cu
+++ b/cpp/src/pdlp/pdhg.cu
@@ -1359,8 +1359,9 @@ void pdhg_solver_t<i_t, f_t>::take_step(rmm::device_uvector<f_t>& primal_step_si
       primal_step_size,
       dual_step_size,
       bound_rescaling,
-      is_major_iteration ||
-        ((total_pdlp_iterations + 2) % conditional_major<i_t>(total_pdlp_iterations + 2)) == 0);
+      is_major_iteration || ((total_pdlp_iterations + 2) %
+                             conditional_major<i_t>(total_pdlp_iterations + 2,
+                                                    hyper_params_.conditional_major_step)) == 0);
   }
   total_pdhg_iterations_ += 1;
 }

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -2562,7 +2562,9 @@ optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::run_solver(co
     std::vector<int> has_restarted(climber_strategies_.size(), 0);
     bool is_conditional_major =
       (settings_.hyper_params.use_conditional_major)
-        ? (total_pdlp_iterations_ % conditional_major<i_t>(total_pdlp_iterations_)) == 0
+        ? (total_pdlp_iterations_ %
+           conditional_major<i_t>(total_pdlp_iterations_,
+                                  settings_.hyper_params.conditional_major_step)) == 0
         : false;
     if (settings_.hyper_params.artificial_restart_in_main_loop)
       artificial_restart_check_main_loop =

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -125,7 +125,6 @@ static void set_Stable1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient = 1.0;  // TODO test with other values
   hyper_params.use_conditional_major  = false;
-  hyper_params.conditional_major_step = 10;
 }
 
 // Even better general setting due to proper primal gradient handling for KKT restart and initial
@@ -169,7 +168,6 @@ static void set_Stable2(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
-  hyper_params.conditional_major_step                                     = 10;
 }
 
 /* 1 - 1 mapping of cuPDLPx(+) function from Haihao and al.
@@ -228,7 +226,6 @@ static void set_Stable3(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_reflected_primal_dual             = true;
   hyper_params.use_fixed_point_error                 = true;
   hyper_params.use_conditional_major                 = true;
-  hyper_params.conditional_major_step                = 10;
 }
 
 // Legacy/Original/Initial PDLP settings
@@ -271,7 +268,6 @@ static void set_Methodical1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
-  hyper_params.conditional_major_step                                     = 10;
 }
 
 // Can be extremly faster but usually leads to more divergence
@@ -315,7 +311,6 @@ static void set_Fast1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
-  hyper_params.conditional_major_step                                     = 10;
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -125,6 +125,7 @@ static void set_Stable1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient = 1.0;  // TODO test with other values
   hyper_params.use_conditional_major  = false;
+  hyper_params.conditional_major_step = 10;
 }
 
 // Even better general setting due to proper primal gradient handling for KKT restart and initial
@@ -168,6 +169,7 @@ static void set_Stable2(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
+  hyper_params.conditional_major_step                                     = 10;
 }
 
 /* 1 - 1 mapping of cuPDLPx(+) function from Haihao and al.
@@ -226,6 +228,7 @@ static void set_Stable3(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_reflected_primal_dual             = true;
   hyper_params.use_fixed_point_error                 = true;
   hyper_params.use_conditional_major                 = true;
+  hyper_params.conditional_major_step                = 10;
 }
 
 // Legacy/Original/Initial PDLP settings
@@ -268,6 +271,7 @@ static void set_Methodical1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
+  hyper_params.conditional_major_step                                     = 10;
 }
 
 // Can be extremly faster but usually leads to more divergence
@@ -311,6 +315,7 @@ static void set_Fast1(pdlp::pdlp_hyper_params_t& hyper_params)
   hyper_params.use_fixed_point_error                                      = false;
   hyper_params.reflection_coefficient                                     = 1.0;
   hyper_params.use_conditional_major                                      = false;
+  hyper_params.conditional_major_step                                     = 10;
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/utils.cuh
+++ b/cpp/src/pdlp/utils.cuh
@@ -66,7 +66,19 @@ struct max_abs_value {
 template <typename i_t>
 i_t conditional_major(uint64_t total_pdlp_iterations)
 {
-  uint64_t step                       = 10;
+  // `step` is how often (in PDHG iterations) the sub-1000-iteration regime runs a full
+  // termination/convergence evaluation. That evaluation is an un-graphed chain of ~12-15
+  // eager kernel launches plus one blocking cudaStreamSynchronize (termination_strategy.cu),
+  // which is expensive relative to a single graphed PDHG step on small edge/MPC-sized LPs.
+  // At step=10 a controller-sized LP that converges in a few hundred iterations pays ~20-40
+  // such evaluations. Widening the stride trades a handful of extra (cheap, graphed) PDHG
+  // steps of convergence-detection latency for far fewer expensive evaluations — a net win in
+  // the small-problem regime that dominates on-robot use. Larger regimes keep the x10 scaling.
+  //
+  // NOT bit-identical: convergence is detected up to `step-1` iterations later, so a few extra
+  // PDHG steps may run; the reported optimum/termination status are unchanged. Benchmark on the
+  // mpc_H*/assign_* suite and re-tune this constant against measured net solve time.
+  uint64_t step                       = 25;
   uint64_t threshold                  = 1000;
   [[maybe_unused]] uint64_t iteration = 0;
 

--- a/cpp/src/pdlp/utils.cuh
+++ b/cpp/src/pdlp/utils.cuh
@@ -64,21 +64,11 @@ struct max_abs_value {
 };
 
 template <typename i_t>
-i_t conditional_major(uint64_t total_pdlp_iterations)
+i_t conditional_major(uint64_t total_pdlp_iterations, uint64_t base_step)
 {
-  // `step` is how often (in PDHG iterations) the sub-1000-iteration regime runs a full
-  // termination/convergence evaluation. That evaluation is an un-graphed chain of ~12-15
-  // eager kernel launches plus one blocking cudaStreamSynchronize (termination_strategy.cu),
-  // which is expensive relative to a single graphed PDHG step on small edge/MPC-sized LPs.
-  // At step=10 a controller-sized LP that converges in a few hundred iterations pays ~20-40
-  // such evaluations. Widening the stride trades a handful of extra (cheap, graphed) PDHG
-  // steps of convergence-detection latency for far fewer expensive evaluations — a net win in
-  // the small-problem regime that dominates on-robot use. Larger regimes keep the x10 scaling.
-  //
-  // NOT bit-identical: convergence is detected up to `step-1` iterations later, so a few extra
-  // PDHG steps may run; the reported optimum/termination status are unchanged. Benchmark on the
-  // mpc_H*/assign_* suite and re-tune this constant against measured net solve time.
-  uint64_t step                       = 25;
+  cuopt_assert(base_step > 0, "conditional_major step must be strictly positive");
+
+  uint64_t step                       = base_step;
   uint64_t threshold                  = 1000;
   [[maybe_unused]] uint64_t iteration = 0;
 


### PR DESCRIPTION
## What

Expose the termination/convergence-check stride as a PDLP hyperparameter instead of hard-coding it.

`conditional_major()` (`cpp/src/pdlp/utils.cuh`) previously hard-coded the sub-1000-iteration
stride at 10. It now takes the base stride as an argument, sourced from a new
`pdlp_hyper_params_t::conditional_major_step`. Larger regimes keep the existing ×10 scaling.

**The default is 10 — behavior is unchanged for every solver mode.** This is a knob, not a retune.

Per @Kh4ster's suggestion in the review below; this replaces the earlier version of this PR, which
changed the global default 10 → 25.

## Why

The termination evaluation is an un-graphed chain of kernel launches ending in a blocking
`cudaStreamSynchronize` (`termination_strategy.cu:188`), because the host branches on
`termination_status_` to decide whether to leave the loop. That is cheap relative to a PDHG step on
the large, many-iteration LPs cuOpt targets, and expensive relative to one on a small LP that
converges in a few hundred iterations — the edge/MPC regime, where the same A matrix recurs every
control tick but the solves are sequential in time and so can't be batched.

Widening the stride there trades a few extra cheap PDHG steps of convergence-detection latency for
substantially fewer expensive evaluations. That's a favorable trade in that regime and an unfavorable
one in cuOpt's usual regime, which is exactly why it belongs behind a parameter rather than in the
default.

## Correctness

At the default (`conditional_major_step = 10`) this is a pure refactor — bit-identical, same
iteration counts, same kernels.

At a wider stride, convergence is detected up to `step − 1` iterations later, so a few extra PDHG
steps may run; the reported optimum and termination status are unchanged. Verified at stride 25:
every benchmark objective matches the HiGHS reference (rel < 1e-3) across the suite; only the
iteration count moves, usually by a handful.

## What a wider stride buys (context for the default's existence, not a proposed default change)

Measured A/B on an **RTX 5090** (WSL2, CUDA 13.2 conda toolkit) with a resident-solver latency
harness — one persistent handle + RMM pool, 3 warm-up solves, then the timed reps in the same
process. **Interleaved** base/opt invocations (order alternated each round); metric is the
solver-internal GPU `solve_ms`; **n = 120 per cell** (4 rounds × 30 reps). Arms differ by the stride
value alone.

| problem | stride 10 (ms) | stride 25 (ms) | uplift | Welch p |
|---|--:|--:|--:|--:|
| assign_20x100 | 63.0 | 44.9 | **+28.8%** | 4e-29 |
| assign_10x50 | 49.0 | 40.4 | +17.4% | 1e-18 |
| mpc_H10 | 69.7 | 58.2 | +16.4% | 1e-9 |
| mpc_H80 | 164.8 | 138.6 | +15.9% | 1e-23 |
| assign_5x20 | 44.2 | 37.8 | +14.4% | 3e-20 |
| mpc_H160 | 149.5 | 130.2 | +12.9% | 7e-16 |
| mpc_H40 | 203.1 | 181.8 | +10.5% | 2e-10 |
| mpc_H20 | 403.2 | 403.5 | −0.1% | ns |

Median +15.1% across 8 problems (range −0.1% … +28.8%, mean +14.5%), significant on 7 of 8. The
mechanism is visible in the data: the wider stride runs *slightly more* PDHG iterations but far fewer
termination evaluations, netting faster with the same optimum. `mpc_H20` is neutral — its ~700 extra
PDHG iterations exactly offset the evaluation savings.

Caveat on the rig: the single-problem noise floor on this WSL2 box is ≈ ±10%, established separately
with a bit-identical control change. The aggregate significance is what establishes the effect, not
any individual row.

## Notes

- Only `Stable3` sets `use_conditional_major = true`, so the stride is only ever consulted in that
  mode.
- The `set_*` presets deliberately do **not** set the field, so a caller's value survives
  `set_pdlp_solver_mode()` on the default `use_pdlp_solver_mode=true` path. The presets already
  leave `restart_k_p/k_i/k_d`, `restart_i_smooth` and (in `Stable3`) `reflection_coefficient` to the
  struct default the same way.
- Added to the benchmark-harness override map (`benchmark_helper.hpp`) so it can be swept from a
  hyperparameter file without a rebuild.
