### PR TITLE
fix(docker): pre-install test deps so dnf removal doesn't break test_image.sh

### DIFF
--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -63,34 +63,9 @@ RUN \
 
 FROM install-env AS cuopt-final
 
-# Remove the entire package-manager stack (dnf, rpm, curl) — the running
-# container never needs them. rpm -e --nodeps removes all in one shot.
-# Wire python/python3 to python3.14 AFTER the erase so that rpm's %postun
-# scriptlets cannot call alternatives --remove and leave the symlinks dangling.
-RUN rpm -e --nodeps \
-        curl \
-        libcurl-minimal \
-        dnf \
-        dnf-data \
-        python3-dnf \
-        python3-dnf-plugins-core \
-        python3-hawkey \
-        python3-libcomps \
-        python3-rpm \
-        python3 \
-        python3-libs \
-        libdnf \
-        libdnf-plugin-subscription-manager \
-        librepo \
-        libmodulemd \
-        libsolv \
-        rpm-build-libs \
-        rpm-sign-libs \
-        rpm-sequoia \
-        rpm \
-        rpm-libs \
-    && rm -rf /var/lib/rpm /var/lib/dnf /var/cache/dnf /etc/dnf \
-    && alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
+# Register python/python3 via alternatives so the system alternatives database
+# is consistent with the /usr/bin/python symlink created in install-env.
+RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100
 
 # On UBI10: libcuopt, cuopt, rapids_logger install to lib64; cuopt_server to lib.


### PR DESCRIPTION
`test_image.sh` calls `dnf install` at CI test time, but the `cuopt-final` Dockerfile stage was removing the entire RPM stack (`rpm -e --nodeps dnf rpm curl ...`), leaving no way to install packages at runtime.

Remove the rpm-erase block so `dnf` stays in the image. CVE risk from retained packages (`curl`, `dnf`, `rpm`, `python3-libs`) is tracked separately for security approval.