### PR TITLE
test(barrier): cap qplib_8515_ruiz_forced_off at the iteration limit

### DIFF
--- a/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
+++ b/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
@@ -261,12 +261,12 @@ TEST(barrier, qplib_8515_ruiz_forced_off)
 
   auto settings                    = pdlp_solver_settings_t<int, double>{};
   settings.method                  = method_t::Barrier;
-  settings.qcqp_ruiz_equilibration = 0;  // force off
+  settings.qcqp_ruiz_equilibration = 0;   // force off
+  settings.iteration_limit         = 50;  // equilibrated needs ~14; forced-off can't finish in 50
 
   auto solution = solve_lp(&handle, mps_data, settings);
 
-  const int iters = solution.get_additional_termination_information().number_of_steps_taken;
-  EXPECT_GT(iters, 50);
+  EXPECT_EQ(solution.get_termination_status(), pdlp_termination_status_t::IterationLimit);
 }
 
 }  // namespace cuopt::mathematical_optimization::simplex::test


### PR DESCRIPTION
The test was flaky because sometimes it never converged. Enforce an iteration limit instead.