### PR TITLE
fix(docker): don't override python3 alternative in UBI10 image

### DIFF
--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -63,10 +63,12 @@ RUN \
 
 FROM install-env AS cuopt-final
 
-# Register python/python3 via alternatives so the system alternatives database
-# is consistent with the /usr/bin/python symlink created in install-env.
-RUN alternatives --install /usr/bin/python  python  /usr/bin/python3.14 100 \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 100
+# Register python via alternatives so the system alternatives database is
+# consistent with the /usr/bin/python symlink created in install-env.
+# NOTE: do NOT register python3 → python3.14 here: /usr/bin/dnf uses
+# #!/usr/bin/python3 and requires the system python3.12 (python3-libs) to
+# find its 'dnf' module; overriding python3 would break dnf at runtime.
+RUN alternatives --install /usr/bin/python python /usr/bin/python3.14 100
 
 # On UBI10: libcuopt, cuopt, rapids_logger install to lib64; cuopt_server to lib.
 ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.14/site-packages/libcuopt/bin:${PATH}"


### PR DESCRIPTION
/usr/bin/dnf uses `#!/usr/bin/python3` and needs the system python3.12 (`python3-libs`) to import its `dnf` module. Registering `python3 → python3.14` via `alternatives` in the `cuopt-final` stage caused `dnf` to fail at runtime with `ModuleNotFoundError: No module named 'dnf'`, breaking `test_image.sh`.

Fix: drop the `python3` alternatives registration. Only `python → python3.14` is registered; system `python3` stays as 3.12, keeping dnf functional — consistent with the existing comment that `python3-libs (3.12)` is intentionally kept for this reason.

Fixes: https://github.com/NVIDIA/cuopt/actions/runs/30333178097/job/90201686850