### PR TITLE
docs:  release notes for 26.08

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,14 +37,14 @@
 - Remove `cuda-python` as an explicit dependency
 - gRPC: `objective_scaling_factor` is now optional in requests
 - gRPC: assign workers to distinct GPUs via `cudaSetDevice`
-  
+
 ### Bug Fixes (26.08)
 
 - Allow zero-valued coefficient updates in the LP Python model
 - Fix an issue in PDLP with cublas error capture and hang on infeasible solutions
 - Fix an exception in concurrent LP cleanup
 - Fix bug in barrier solver where cuDSS descriptors were being freed before their backing buffers
-- Fix a bug in MIP where the lower bound was incorrect when using a single thread 
+- Fix a bug in MIP where the lower bound was incorrect when using a single thread
 - Fix a bug in MIP where nodes were lost in branch and bound
 - Fix a bug in MIP where root cut pass CPU feasibility-jump solutions were dropped by GPU heuristics
 - Add guard in MIP for huge bounds in bounds propagation

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,20 +4,18 @@
 
 ### New Features (26.08)
 
-- Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning and NCCL; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
-- Add sparsity exploitation for large-dimensional SOC constraints in the barrier solver
-- Fast free-format MPS parser with reduced parse time on large models
-- Recursive RINS heuristic for MIP
-- Zero-half (odd-cycle) cuts for MIP
-- Conflict graph improvements: incorporate non-binary rows and probing implications
-- Papilo-based primal/dual crush in MIP presolve
-- Vector length diving and Farkas diving heuristics for MIP
-- UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)
+- New Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
+- Exploit sparsity in Barrier's augmented system on problems with large second order cone constraints
+- New free-format MPS parser with faster parse time on large models
+- New recursive RINS heuristic for MIP
+- New zero-half (odd-cycle) cuts for MIP
+- New vector length diving and Farkas diving heuristics for MIP
 - Routing: accept NumPy and pandas inputs in the routing Python `DataModel` in addition to cuDF
-- gRPC: Python interface to the C++ gRPC async client
-- gRPC: allow TLS arguments in the Python gRPC async API
 - C API: extend getters with additional query functions
 - C API: automatic CPU/GPU memory selection for problem construction
+- gRPC: Python interface to the C++ gRPC async client
+- gRPC: allow TLS arguments in the Python gRPC async API
+- UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)
 
 ### Breaking Changes (26.08)
 
@@ -25,10 +23,13 @@
 
 ### Improvements (26.08)
 
+- Conflict graph improvements: incorporate non-binary rows and probing implications
 - Reduce latency in LP concurrent mode
 - Reduce memory footprint of PDLP
 - Reduce QP solver overhead
+- Improve Ruiz equilibration heuristic to also check column imbalance on QPs
 - Run feasibility-jump (CPU-FJ) heuristics at the root node
+- Papilo-based primal/dual crush in MIP presolve
 - Expose diving hyperparameters for MIP solver configuration
 - Unify threading model in the MIP solver using OpenMP tasks
 - MIP log cleanup and improved readability
@@ -39,36 +40,36 @@
   
 ### Bug Fixes (26.08)
 
-- Fix lower bound being incorrect in MIP single-thread mode
-- Fix concurrent LP exception cleanup
+- Allow zero-valued coefficient updates in the LP Python model
+- Fix an issue in PDLP with cublas error capture and hang on infeasible solutions
+- Fix an exception in concurrent LP cleanup
+- Fix bug in barrier solver where cuDSS descriptors were being freed before their backing buffers
+- Fix a bug in MIP where the lower bound was incorrect when using a singlethread 
+- Fix a bug in MIP where nodes were lost in branch and bound
+- Fix a bug in MIP where root cut pass CPU feasibility-jump solutions were dropped by GPU heuristics
+- Add guard in MIP for huge bounds in bounds propagation
+- Fix a bug in MIP with incorrect GF2 presolve constraint addressing
+- Fix a bug in MIP in variable fixing for initial solutions
+- Fix issue in MIP in clique size computation and numerical issues
+- Fix an issue in MIP where cut generation did not obey the time limit
+- Fix an issue on QPs where maximization was not supported
+- Fix rotated second-order cone detection: canonicalize quadratic constraint Q matrix in triplet formt
+- Fix nonconvex quadratic constraint detection bug
+- Fix a bug on QCQP models that incorrectly threw an unsupported exception
+- Fix second-order cone index collision and incorrect quadratic constraint to cone conversion for rotated cone constraints
+- Validate MPS row type byte before enum cast to avoid undefined behavior
 - Fix destruction order and by-reference capture bugs in solve.cu
 - Fix route priority sort indexing in routing
-- Fix lost nodes in branch and bound
-- Fix vehicle fixed cost accounting in fragment-vs-route deltas
-- Fix PDLP cublas error capture and hang on infeasible solutions
-- Add guard for huge bounds in bounds propagation
-- gRPC: fix race condition in gRPC with log streaming
+- Fix vehicle fixed cost accounting in fragment-vs-route deltas in routing
 - Fix routing min-vehicles bug
-- Fix nonconvex quadratic constraint detection bug
-- Fix rotated SOC detection: canonicalize QC Q COO
-- Validate MPS row type byte before enum cast to avoid undefined behavior
-- Fix root-cut CPU feasibility-jump solutions being dropped by GPU heuristics
-- Fix incorrect GF2 presolve constraint addressing
-- Remove wrong unsupported-QCQP exception
-- Fix cuDSS descriptors being freed before their backing buffers in the barrier solver
-- Fix cuts not obeying the time limit
-- Fix variable fixing for initial solutions in MIP
-- Fix clique size computation and numerical issues in MIP
 - Fix libomp ABI incompatibility
-- Fix SOC index collision and incorrect QC-to-SOC conversion for rotated SOC constraints
+- gRPC: fix race condition in gRPC with log streaming
 - gRPC: cancel active jobs on delete
 - gRPC: terminate workers cleanly on server shutdown
 - gRPC: drain all remaining log lines at job completion in `StreamLogs`
-- Fix Ruiz equilibration skip heuristic to also check column imbalance
 - Fix row-major layout not preserved when resizing routing capacity routes
-- Allow zero-valued coefficient updates in the LP Python model
 - Fix routing YAML best-results export
-- Fix double `va_start` undefined behavior in C error handling
+- Fix double `va_start` undefined behavior in C API error handling
 
 ### Documentation (26.08)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,9 +13,7 @@
 - Papilo-based primal/dual crush in MIP presolve
 - Vector length diving and Farkas diving heuristics for MIP
 - UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)
-- Routing: `cuopt.routing` is now importable without a GPU (CPU-only environments and gRPC clients)
 - Routing: accept NumPy and pandas inputs in the routing Python `DataModel` in addition to cuDF
-- Routing: export the recorded routing problem to a host representation
 - gRPC: Python interface to the C++ gRPC async client
 - gRPC: allow TLS arguments in the Python gRPC async API
 - C API: extend getters with additional query functions
@@ -35,12 +33,10 @@
 - Unify threading model in the MIP solver using OpenMP tasks
 - MIP log cleanup and improved readability
 - Add short `cu12`/`cu13` Docker tag aliases
-- Build and test with CUDA 13.3.0
 - Remove `cuda-python` as an explicit dependency
 - gRPC: `objective_scaling_factor` is now optional in requests
 - gRPC: assign workers to distinct GPUs via `cudaSetDevice`
-- Routing: cost matrix validation check is now optional
-
+  
 ### Bug Fixes (26.08)
 
 - Fix lower bound being incorrect in MIP single-thread mode
@@ -51,7 +47,7 @@
 - Fix vehicle fixed cost accounting in fragment-vs-route deltas
 - Fix PDLP cublas error capture and hang on infeasible solutions
 - Add guard for huge bounds in bounds propagation
-- gRPC: fix race condition with log streaming
+- gRPC: fix race condition in gRPC with log streaming
 - Fix routing min-vehicles bug
 - Fix nonconvex quadratic constraint detection bug
 - Fix rotated SOC detection: canonicalize QC Q COO

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,7 +44,7 @@
 - Fix an issue in PDLP with cublas error capture and hang on infeasible solutions
 - Fix an exception in concurrent LP cleanup
 - Fix bug in barrier solver where cuDSS descriptors were being freed before their backing buffers
-- Fix a bug in MIP where the lower bound was incorrect when using a singlethread 
+- Fix a bug in MIP where the lower bound was incorrect when using a single thread 
 - Fix a bug in MIP where nodes were lost in branch and bound
 - Fix a bug in MIP where root cut pass CPU feasibility-jump solutions were dropped by GPU heuristics
 - Add guard in MIP for huge bounds in bounds propagation
@@ -53,7 +53,7 @@
 - Fix issue in MIP in clique size computation and numerical issues
 - Fix an issue in MIP where cut generation did not obey the time limit
 - Fix an issue on QPs where maximization was not supported
-- Fix rotated second-order cone detection: canonicalize quadratic constraint Q matrix in triplet formt
+- Fix rotated second-order cone detection: make canonical quadratic constraint Q matrix in triplet form
 - Fix nonconvex quadratic constraint detection bug
 - Fix a bug on QCQP models that incorrectly threw an unsupported exception
 - Fix second-order cone index collision and incorrect quadratic constraint to cone conversion for rotated cone constraints

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,6 @@
 ### New Features (26.08)
 
 - New Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
-- Exploit sparsity in Barrier's augmented system on problems with large second order cone constraints
 - New free-format MPS parser with faster parse time on large models
 - New recursive RINS heuristic for MIP
 - New zero-half (odd-cycle) cuts for MIP
@@ -22,7 +21,8 @@
 - Routing `DataModel` now defers GPU device construction to solve time; applications that accessed device-side data between `DataModel` construction and the solve call must be updated
 
 ### Improvements (26.08)
-Include Q matrix in Ruiz scaling to improve convergence
+- Include Q matrix in Ruiz scaling to improve convergence
+- Exploit sparsity in Barrier's augmented system on problems with large second order cone constraints
 - Conflict graph improvements: incorporate non-binary rows and probing implications
 - Reduce latency in LP concurrent mode
 - Reduce memory footprint of PDLP

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,7 +11,7 @@
 - New vector length diving and Farkas diving heuristics for MIP
 - Routing: accept NumPy and pandas inputs in the routing Python `DataModel` in addition to cuDF
 - C API: extend getters with additional query functions
-- C API: automatic CPU/GPU memory selection for problem construction
+- C API: automatic CPU/GPU memory selection for problem construction (supports remote solve via gRPC from CPU host)
 - gRPC: Python interface to the C++ gRPC async client
 - gRPC: allow TLS arguments in the Python gRPC async API
 - UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@
 - Routing `DataModel` now defers GPU device construction to solve time; applications that accessed device-side data between `DataModel` construction and the solve call must be updated
 
 ### Improvements (26.08)
-
+Include Q matrix in Ruiz scaling to improve convergence 
 - Conflict graph improvements: incorporate non-binary rows and probing implications
 - Reduce latency in LP concurrent mode
 - Reduce memory footprint of PDLP

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,76 +4,90 @@
 
 ### New Features (26.08)
 
-- Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning and NCCL communication; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
-- Fast free-format MPS parser with significantly reduced parse time on large models
-- Recursive RINS heuristic for MIP to find better feasible solutions earlier in the search
+- Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning and NCCL; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
+- Add sparsity exploitation for large-dimensional SOC constraints in the barrier solver
+- Fast free-format MPS parser with reduced parse time on large models
+- Recursive RINS heuristic for MIP
 - Zero-half (odd-cycle) cuts for MIP
-- Implied bound cuts, extended knapsack cuts, and lifted knapsack cuts
 - Conflict graph improvements: incorporate non-binary rows and probing implications
-- MIP row and objective scaling
-- Papilo-based primal/dual crush for MIP presolve
-- `UnboundedOrInfeasible` termination status for LP/MIP
-- Expose GPU heuristics tuning parameters via configuration files
-- Race batch PDLP against dual simplex in strong branching and reliability branching
-- Dump presolved problem to file for debugging
+- Papilo-based primal/dual crush in MIP presolve
+- Vector length diving and Farkas diving heuristics for MIP
 - UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)
-- Routing: `cuopt.routing` is now importable without a GPU present (CPU-only environments and gRPC clients)
+- Routing: `cuopt.routing` is now importable without a GPU (CPU-only environments and gRPC clients)
 - Routing: accept NumPy and pandas inputs in the routing Python `DataModel` in addition to cuDF
-- Routing: export the recorded routing problem to a host representation (Phase 3)
-- Routing: defer device construction to solve time (`DataModel` store-then-build)
+- Routing: export the recorded routing problem to a host representation
 - gRPC: Python interface to the C++ gRPC async client
 - gRPC: allow TLS arguments in the Python gRPC async API
-- gRPC: assign gRPC workers to distinct GPUs via `cudaSetDevice`
 - C API: extend getters with additional query functions
 - C API: automatic CPU/GPU memory selection for problem construction
 
 ### Breaking Changes (26.08)
 
-None.
+- Routing `DataModel` now defers GPU device construction to solve time; applications that accessed device-side data between `DataModel` construction and the solve call must be updated
 
 ### Improvements (26.08)
 
 - Reduce latency in LP concurrent mode
-- Improve crossover dual simplex performance and accuracy
-- Reliability branching candidates are now ranked using a dual simplex single-pivot estimate
-- Build CUDA 13 wheels with CTK 13.3.0
+- Reduce memory footprint of PDLP
+- Reduce QP solver overhead
+- Run feasibility-jump (CPU-FJ) heuristics at the root node
+- Expose diving hyperparameters for MIP solver configuration
+- Unify threading model in the MIP solver using OpenMP tasks
+- MIP log cleanup and improved readability
+- Add short `cu12`/`cu13` Docker tag aliases
+- Build and test with CUDA 13.3.0
 - Remove `cuda-python` as an explicit dependency
-- Clamp crushed solutions to dual-reduced bounds for better feasibility
-- `objective_scaling_factor` is now optional in gRPC requests
-- MIP log output cleanup and improved readability
-- Print diagnostic logs when exceptions are caught during solves
+- gRPC: `objective_scaling_factor` is now optional in requests
+- gRPC: assign workers to distinct GPUs via `cudaSetDevice`
+- Routing: cost matrix validation check is now optional
 
 ### Bug Fixes (26.08)
 
-- Fix routing YAML best-results export writing incorrect values
-- Allow zero-valued coefficient updates in the LP Python model
-- Fix row-major layout not preserved when resizing capacity routes in routing
-- Fix libomp ABI incompatibility causing crashes in some environments
-- Fix variable fixing for initial solutions in MIP
-- Fix cuts ignoring the solver time limit
-- Fix clique size computation and associated numerical issues in MIP
-- Fix cuDSS descriptors being freed before their backing buffers in the barrier solver
-- Fix SOC index collision and incorrect QC-to-SOC conversion for rotated SOC constraints
+- Fix lower bound being incorrect in MIP single-thread mode
+- Fix concurrent LP exception cleanup
+- Fix destruction order and by-reference capture bugs in solve.cu
+- Fix route priority sort indexing in routing
+- Fix lost nodes in branch and bound
+- Fix vehicle fixed cost accounting in fragment-vs-route deltas
+- Fix PDLP cublas error capture and hang on infeasible solutions
+- Add guard for huge bounds in bounds propagation
+- gRPC: fix race condition with log streaming
+- Fix routing min-vehicles bug
+- Fix nonconvex quadratic constraint detection bug
+- Fix rotated SOC detection: canonicalize QC Q COO
+- Validate MPS row type byte before enum cast to avoid undefined behavior
 - Fix root-cut CPU feasibility-jump solutions being dropped by GPU heuristics
 - Fix incorrect GF2 presolve constraint addressing
-- Validate MPS row type byte before enum cast to avoid undefined behavior
-- Fix nonconvex quadratic constraint detection bug
-- Fix Ruiz equilibration skip heuristic to also check column imbalance
-- Fix race condition in CUDA graph capture when `set_simplex_solution()` is called
-- Fix infinite lower bounds handling in barrier when bounding free variables
-- Fix lower bound being incorrect in MIP single-thread mode
-- Add exception handling for PDLP failures in concurrent mode
-- Fix double `va_start` undefined behavior in C error handling
-- gRPC: terminate worker threads cleanly on server shutdown
-- gRPC: cancel active jobs when a job is deleted
+- Remove wrong unsupported-QCQP exception
+- Fix cuDSS descriptors being freed before their backing buffers in the barrier solver
+- Fix cuts not obeying the time limit
+- Fix variable fixing for initial solutions in MIP
+- Fix clique size computation and numerical issues in MIP
+- Fix libomp ABI incompatibility
+- Fix SOC index collision and incorrect QC-to-SOC conversion for rotated SOC constraints
+- gRPC: cancel active jobs on delete
+- gRPC: terminate workers cleanly on server shutdown
 - gRPC: drain all remaining log lines at job completion in `StreamLogs`
-- gRPC: constrain server data file paths to prevent path traversal
-- Fix papilo probing cache synchronization bug
-- Fix Gomory cut generation when `b_bar` test is active
+- Fix Ruiz equilibration skip heuristic to also check column imbalance
+- Fix row-major layout not preserved when resizing routing capacity routes
+- Allow zero-valued coefficient updates in the LP Python model
+- Fix routing YAML best-results export
+- Fix double `va_start` undefined behavior in C error handling
 
 ### Documentation (26.08)
 
 - Align cuOpt documentation branding and update Doxygen configuration
+- Update cuOpt MIP positioning documentation
+
+### New Contributors (26.08)
+
+- @jolorunyomi
+- @cafzal
+- @Sylendran95
+- @jackthepunished
+- @fallintoplace
+- @arhag23
+- @divyegala
 
 ## Release Notes 26.06
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -22,7 +22,7 @@
 - Routing `DataModel` now defers GPU device construction to solve time; applications that accessed device-side data between `DataModel` construction and the solve call must be updated
 
 ### Improvements (26.08)
-Include Q matrix in Ruiz scaling to improve convergence 
+Include Q matrix in Ruiz scaling to improve convergence
 - Conflict graph improvements: incorporate non-binary rows and probing implications
 - Reduce latency in LP concurrent mode
 - Reduce memory footprint of PDLP

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,80 @@
 # Release Notes
 
+## Release Notes 26.08
+
+### New Features (26.08)
+
+- Multi-GPU PDLP: distribute LP solves across multiple GPUs using METIS partitioning and NCCL communication; 2.5x–8.8x speedup on 8 NVLink-connected B200 GPUs
+- Fast free-format MPS parser with significantly reduced parse time on large models
+- Recursive RINS heuristic for MIP to find better feasible solutions earlier in the search
+- Zero-half (odd-cycle) cuts for MIP
+- Implied bound cuts, extended knapsack cuts, and lifted knapsack cuts
+- Conflict graph improvements: incorporate non-binary rows and probing implications
+- MIP row and objective scaling
+- Papilo-based primal/dual crush for MIP presolve
+- `UnboundedOrInfeasible` termination status for LP/MIP
+- Expose GPU heuristics tuning parameters via configuration files
+- Race batch PDLP against dual simplex in strong branching and reliability branching
+- Dump presolved problem to file for debugging
+- UBI10 (Red Hat Universal Base Image) container variant for FIPS 140-3 compliant environments; image tags use `-ubi10` suffix (e.g. `latest-cu13-ubi10`)
+- Routing: `cuopt.routing` is now importable without a GPU present (CPU-only environments and gRPC clients)
+- Routing: accept NumPy and pandas inputs in the routing Python `DataModel` in addition to cuDF
+- Routing: export the recorded routing problem to a host representation (Phase 3)
+- Routing: defer device construction to solve time (`DataModel` store-then-build)
+- gRPC: Python interface to the C++ gRPC async client
+- gRPC: allow TLS arguments in the Python gRPC async API
+- gRPC: assign gRPC workers to distinct GPUs via `cudaSetDevice`
+- C API: extend getters with additional query functions
+- C API: automatic CPU/GPU memory selection for problem construction
+
+### Breaking Changes (26.08)
+
+None.
+
+### Improvements (26.08)
+
+- Reduce latency in LP concurrent mode
+- Improve crossover dual simplex performance and accuracy
+- Reliability branching candidates are now ranked using a dual simplex single-pivot estimate
+- Build CUDA 13 wheels with CTK 13.3.0
+- Remove `cuda-python` as an explicit dependency
+- Clamp crushed solutions to dual-reduced bounds for better feasibility
+- `objective_scaling_factor` is now optional in gRPC requests
+- MIP log output cleanup and improved readability
+- Print diagnostic logs when exceptions are caught during solves
+
+### Bug Fixes (26.08)
+
+- Fix routing YAML best-results export writing incorrect values
+- Allow zero-valued coefficient updates in the LP Python model
+- Fix row-major layout not preserved when resizing capacity routes in routing
+- Fix libomp ABI incompatibility causing crashes in some environments
+- Fix variable fixing for initial solutions in MIP
+- Fix cuts ignoring the solver time limit
+- Fix clique size computation and associated numerical issues in MIP
+- Fix cuDSS descriptors being freed before their backing buffers in the barrier solver
+- Fix SOC index collision and incorrect QC-to-SOC conversion for rotated SOC constraints
+- Fix root-cut CPU feasibility-jump solutions being dropped by GPU heuristics
+- Fix incorrect GF2 presolve constraint addressing
+- Validate MPS row type byte before enum cast to avoid undefined behavior
+- Fix nonconvex quadratic constraint detection bug
+- Fix Ruiz equilibration skip heuristic to also check column imbalance
+- Fix race condition in CUDA graph capture when `set_simplex_solution()` is called
+- Fix infinite lower bounds handling in barrier when bounding free variables
+- Fix lower bound being incorrect in MIP single-thread mode
+- Add exception handling for PDLP failures in concurrent mode
+- Fix double `va_start` undefined behavior in C error handling
+- gRPC: terminate worker threads cleanly on server shutdown
+- gRPC: cancel active jobs when a job is deleted
+- gRPC: drain all remaining log lines at job completion in `StreamLogs`
+- gRPC: constrain server data file paths to prevent path traversal
+- Fix papilo probing cache synchronization bug
+- Fix Gomory cut generation when `b_bar` test is active
+
+### Documentation (26.08)
+
+- Align cuOpt documentation branding and update Doxygen configuration
+
 ## Release Notes 26.06
 
 ### New Features (26.06)


### PR DESCRIPTION
## Summary

Draft release notes for **26.08** based on ~456 commits since `v26.06.00a`. This is a team review PR — please add, remove, or update entries before we merge.

Sections covered:

- **New Features** — multi-GPU PDLP, fast MPS parser, recursive RINS, zero-half cuts, MIP scaling, Papilo crush, UBI10 FIPS container, routing CPU import + NumPy/pandas inputs, gRPC async client, C API getters
- **Breaking Changes** — none identified; please flag anything missed
- **Improvements** — concurrent mode latency, crossover dual simplex, CTK 13.3 wheels, cuda-python dep removal, gRPC GPU assignment
- **Bug Fixes** — routing layout, libomp ABI, barrier cuDSS, MIP cuts timer, GF2 presolve, gRPC shutdown/cancel/log drain
- **Documentation** — branding and Doxygen alignment

## Review checklist

- [ ] Verify each entry is worded correctly for the audience (users, not developers)
- [ ] Remove any entries that are internal/infra only and not user-visible
- [ ] Add any entries for commits that were missed
- [ ] Confirm or update the "Breaking Changes" section
- [ ] Add new contributors section if applicable