### PR TITLE
Make the post solve info logging optional

### DIFF
--- a/cpp/include/cuopt/mathematical_optimization/constants.h
+++ b/cpp/include/cuopt/mathematical_optimization/constants.h
@@ -47,7 +47,7 @@
 #define CUOPT_DUALIZE                              "dualize"
 #define CUOPT_ORDERING                             "ordering"
 #define CUOPT_BARRIER_DUAL_INITIAL_POINT           "barrier_dual_initial_point"
-#define CUOPT_POST_SOLVE_INFO                      "post_solve_info"
+#define CUOPT_POSTSOLVE_INFO                       "postsolve_info"
 #define CUOPT_BARRIER_ITERATIVE_REFINEMENT         "barrier_iterative_refinement"
 #define CUOPT_BARRIER_STEP_SCALE                   "barrier_step_scale"
 #define CUOPT_ELIMINATE_DENSE_COLUMNS              "eliminate_dense_columns"

--- a/cpp/include/cuopt/mathematical_optimization/constants.h
+++ b/cpp/include/cuopt/mathematical_optimization/constants.h
@@ -47,6 +47,7 @@
 #define CUOPT_DUALIZE                              "dualize"
 #define CUOPT_ORDERING                             "ordering"
 #define CUOPT_BARRIER_DUAL_INITIAL_POINT           "barrier_dual_initial_point"
+#define CUOPT_POST_SOLVE_INFO                      "post_solve_info"
 #define CUOPT_BARRIER_ITERATIVE_REFINEMENT         "barrier_iterative_refinement"
 #define CUOPT_BARRIER_STEP_SCALE                   "barrier_step_scale"
 #define CUOPT_ELIMINATE_DENSE_COLUMNS              "eliminate_dense_columns"

--- a/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
@@ -293,7 +293,7 @@ class pdlp_solver_settings_t {
   i_t dualize{-1};
   i_t ordering{-1};
   i_t barrier_dual_initial_point{-1};
-  i_t post_solve_info{-1};
+  i_t postsolve_info{-1};
   // Ruiz equilibration for QCQP (barrier) scaling: -1 automatic (row/column
   // imbalance heuristic), 0 disabled, 1 enabled. Distinct from PDLP's own Ruiz
   // scaling in pdlp_hyper_params_t.

--- a/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
@@ -293,6 +293,7 @@ class pdlp_solver_settings_t {
   i_t dualize{-1};
   i_t ordering{-1};
   i_t barrier_dual_initial_point{-1};
+  i_t post_solve_info{-1};
   // Ruiz equilibration for QCQP (barrier) scaling: -1 automatic (row/column
   // imbalance heuristic), 0 disabled, 1 enabled. Distinct from PDLP's own Ruiz
   // scaling in pdlp_hyper_params_t.

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -1779,7 +1779,10 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
     }
     matrix_transpose_vector_multiply(
       presolve_info.folding_info.A_tilde, 1.0, ytilde, 1.0, dual_residual);
-    settings.log.printf("Unfolded dual residual = %e\n", vector_norm_inf<i_t, f_t>(dual_residual));
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Unfolded dual residual = %e\n",
+                          vector_norm_inf<i_t, f_t>(dual_residual));
+    }
 
     // Now we need to map the solution back to the original problem
     // minimize c^T x
@@ -1799,7 +1802,9 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
 
   const i_t num_free_variables = free_variable_pairs.size() / 2;
   if (num_free_variables > 0) {
-    settings.log.printf("Post-solve: Handling free variables %d\n", num_free_variables);
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Post-solve: Handling free variables %d\n", num_free_variables);
+    }
     // We added free variables so we need to map the crushed solution back to the original variables
     for (i_t k = 0; k < 2 * num_free_variables; k += 2) {
       const i_t u = free_variable_pairs[k];
@@ -1811,8 +1816,10 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   }
 
   if (presolve_info.removed_variables.size() > 0) {
-    settings.log.printf("Post-solve: Handling removed variables %d\n",
-                        presolve_info.removed_variables.size());
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Post-solve: Handling removed variables %d\n",
+                          presolve_info.removed_variables.size());
+    }
     // We removed some variables, so we need to map the crushed solution back to the original
     // variables
     const i_t n = presolve_info.removed_variables.size() + presolve_info.remaining_variables.size();
@@ -1839,8 +1846,10 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   }
 
   if (presolve_info.removed_constraints.size() > 0) {
-    settings.log.printf("Post-solve: Handling removed constraints %d\n",
-                        presolve_info.removed_constraints.size());
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Post-solve: Handling removed constraints %d\n",
+                          presolve_info.removed_constraints.size());
+    }
     // We removed some constraints, so we need to map the crushed solution back to the original
     // constraints
     const i_t m =
@@ -1868,7 +1877,9 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
       if (presolve_info.removed_lower_bounds[j] != 0.0) { num_lower_bounds++; }
       input_x[j] += presolve_info.removed_lower_bounds[j];
     }
-    settings.log.printf("Post-solve: Handling removed lower bounds %d\n", num_lower_bounds);
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Post-solve: Handling removed lower bounds %d\n", num_lower_bounds);
+    }
   }
 
   if (presolve_info.negated_variables.size() > 0) {
@@ -1894,7 +1905,9 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   // z_bar_{j_f} = 0.
   if (!presolve_info.bounded_free_variables.empty()) {
     const i_t num_bfv = static_cast<i_t>(presolve_info.bounded_free_variables.size());
-    settings.log.printf("Post-solve: Correcting duals for %d bounded free variables\n", num_bfv);
+    if (settings.post_solve_info == 1) {
+      settings.log.printf("Post-solve: Correcting duals for %d bounded free variables\n", num_bfv);
+    }
     const csc_matrix_t<i_t, f_t>& A = original_problem.A;
 
     // Traverse in reverse order, to ensure that all z_j = 0 after the correction

--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -1779,7 +1779,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
     }
     matrix_transpose_vector_multiply(
       presolve_info.folding_info.A_tilde, 1.0, ytilde, 1.0, dual_residual);
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Unfolded dual residual = %e\n",
                           vector_norm_inf<i_t, f_t>(dual_residual));
     }
@@ -1802,7 +1802,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
 
   const i_t num_free_variables = free_variable_pairs.size() / 2;
   if (num_free_variables > 0) {
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Post-solve: Handling free variables %d\n", num_free_variables);
     }
     // We added free variables so we need to map the crushed solution back to the original variables
@@ -1816,7 +1816,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   }
 
   if (presolve_info.removed_variables.size() > 0) {
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Post-solve: Handling removed variables %d\n",
                           presolve_info.removed_variables.size());
     }
@@ -1846,7 +1846,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   }
 
   if (presolve_info.removed_constraints.size() > 0) {
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Post-solve: Handling removed constraints %d\n",
                           presolve_info.removed_constraints.size());
     }
@@ -1877,7 +1877,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
       if (presolve_info.removed_lower_bounds[j] != 0.0) { num_lower_bounds++; }
       input_x[j] += presolve_info.removed_lower_bounds[j];
     }
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Post-solve: Handling removed lower bounds %d\n", num_lower_bounds);
     }
   }
@@ -1905,7 +1905,7 @@ void uncrush_solution(const presolve_info_t<i_t, f_t>& presolve_info,
   // z_bar_{j_f} = 0.
   if (!presolve_info.bounded_free_variables.empty()) {
     const i_t num_bfv = static_cast<i_t>(presolve_info.bounded_free_variables.size());
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       settings.log.printf("Post-solve: Correcting duals for %d bounded free variables\n", num_bfv);
     }
     const csc_matrix_t<i_t, f_t>& A = original_problem.A;

--- a/cpp/src/dual_simplex/simplex_solver_settings.hpp
+++ b/cpp/src/dual_simplex/simplex_solver_settings.hpp
@@ -78,6 +78,7 @@ struct simplex_solver_settings_t {
       dualize(-1),
       ordering(-1),
       barrier_dual_initial_point(-1),
+      post_solve_info(-1),
       qcqp_ruiz_equilibration(-1),
       check_Q(false),
       crossover(false),
@@ -172,6 +173,7 @@ struct simplex_solver_settings_t {
   i_t ordering;   // -1 automatic, 0 to use nested dissection, 1 to use AMD
   i_t barrier_dual_initial_point;  // -1 automatic, 0 to use Lustig, Marsten, and Shanno initial
                                    // point, 1 to use initial point form dual least squares problem
+  i_t post_solve_info;             // -1 automatic (disabled), 0 disabled, 1 enabled
   i_t qcqp_ruiz_equilibration;     // -1 automatic (imbalance heuristic), 0 disabled, 1 enabled
   bool check_Q;                    // true to check if Q is positive semidefinite
   bool crossover;                  // true to do crossover, false to not

--- a/cpp/src/dual_simplex/simplex_solver_settings.hpp
+++ b/cpp/src/dual_simplex/simplex_solver_settings.hpp
@@ -78,7 +78,7 @@ struct simplex_solver_settings_t {
       dualize(-1),
       ordering(-1),
       barrier_dual_initial_point(-1),
-      post_solve_info(-1),
+      postsolve_info(-1),
       qcqp_ruiz_equilibration(-1),
       check_Q(false),
       crossover(false),
@@ -173,7 +173,7 @@ struct simplex_solver_settings_t {
   i_t ordering;   // -1 automatic, 0 to use nested dissection, 1 to use AMD
   i_t barrier_dual_initial_point;  // -1 automatic, 0 to use Lustig, Marsten, and Shanno initial
                                    // point, 1 to use initial point form dual least squares problem
-  i_t post_solve_info;             // -1 automatic (disabled), 0 disabled, 1 enabled
+  i_t postsolve_info;              // -1 automatic (disabled), 0 disabled, 1 enabled
   i_t qcqp_ruiz_equilibration;     // -1 automatic (imbalance heuristic), 0 disabled, 1 enabled
   bool check_Q;                    // true to check if Q is positive semidefinite
   bool crossover;                  // true to do crossover, false to not

--- a/cpp/src/dual_simplex/solve.cpp
+++ b/cpp/src/dual_simplex/solve.cpp
@@ -506,9 +506,12 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
         k++;
       }
 
-      // Check the objective and residuals on the primal problem.
-      settings.log.printf("Primal objective: %e\n",
-                          dot<i_t, f_t>(dualize_info.primal_problem.objective, primal_solution.x));
+      if (settings.post_solve_info == 1) {
+        // Check the objective and residuals on the primal problem.
+        settings.log.printf(
+          "Primal objective: %e\n",
+          dot<i_t, f_t>(dualize_info.primal_problem.objective, primal_solution.x));
+      }
 
       std::vector<i_t> inequality_rows(dualize_info.primal_problem.num_rows, 1);
       for (i_t i : dualize_info.equality_rows) {
@@ -559,27 +562,29 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
         problem.num_cols = num_cols;
       }
 
-      std::vector<f_t> primal_residual = dualize_info.primal_problem.rhs;
-      matrix_vector_multiply(
-        dualize_info.primal_problem.A, 1.0, primal_solution.x, -1.0, primal_residual);
+      if (settings.post_solve_info == 1) {
+        std::vector<f_t> primal_residual = dualize_info.primal_problem.rhs;
+        matrix_vector_multiply(
+          dualize_info.primal_problem.A, 1.0, primal_solution.x, -1.0, primal_residual);
 
-      f_t primal_residual_norm     = vector_norm_inf<i_t, f_t>(primal_residual);
-      const f_t norm_b             = vector_norm_inf<i_t, f_t>(dualize_info.primal_problem.rhs);
-      f_t primal_relative_residual = primal_residual_norm / (1.0 + norm_b);
-      settings.log.printf(
-        "Primal residual (abs/rel): %e/%e\n", primal_residual_norm, primal_relative_residual);
+        f_t primal_residual_norm     = vector_norm_inf<i_t, f_t>(primal_residual);
+        const f_t norm_b             = vector_norm_inf<i_t, f_t>(dualize_info.primal_problem.rhs);
+        f_t primal_relative_residual = primal_residual_norm / (1.0 + norm_b);
+        settings.log.printf(
+          "Primal residual (abs/rel): %e/%e\n", primal_residual_norm, primal_relative_residual);
 
-      std::vector<f_t> dual_residual = dualize_info.primal_problem.objective;
-      for (i_t j = 0; j < dualize_info.primal_problem.num_cols; ++j) {
-        dual_residual[j] -= z[j];
+        std::vector<f_t> dual_residual = dualize_info.primal_problem.objective;
+        for (i_t j = 0; j < dualize_info.primal_problem.num_cols; ++j) {
+          dual_residual[j] -= z[j];
+        }
+        matrix_transpose_vector_multiply(
+          dualize_info.primal_problem.A, 1.0, primal_solution.y, -1.0, dual_residual);
+        f_t dual_residual_norm = vector_norm_inf<i_t, f_t>(dual_residual);
+        const f_t norm_c       = vector_norm_inf<i_t, f_t>(dualize_info.primal_problem.objective);
+        f_t dual_relative_residual = dual_residual_norm / (1.0 + norm_c);
+        settings.log.printf(
+          "Dual residual (abs/rel): %e/%e\n", dual_residual_norm, dual_relative_residual);
       }
-      matrix_transpose_vector_multiply(
-        dualize_info.primal_problem.A, 1.0, primal_solution.y, -1.0, dual_residual);
-      f_t dual_residual_norm     = vector_norm_inf<i_t, f_t>(dual_residual);
-      const f_t norm_c           = vector_norm_inf<i_t, f_t>(dualize_info.primal_problem.objective);
-      f_t dual_relative_residual = dual_residual_norm / (1.0 + norm_c);
-      settings.log.printf(
-        "Dual residual (abs/rel): %e/%e\n", dual_residual_norm, dual_relative_residual);
 
       original_lp = dualize_info.primal_problem;
       lp_solution = primal_solution;

--- a/cpp/src/dual_simplex/solve.cpp
+++ b/cpp/src/dual_simplex/solve.cpp
@@ -418,24 +418,26 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
                                unscaled_y,
                                unscaled_z);
 
-    std::vector<f_t> residual = presolved_lp.rhs;
-    matrix_vector_multiply(presolved_lp.A, 1.0, unscaled_x, -1.0, residual);
-    f_t primal_residual = vector_norm_inf<i_t, f_t>(residual);
-    settings.log.printf("Unscaled Primal infeasibility   (abs/rel): %.2e/%.2e\n",
-                        primal_residual,
-                        primal_residual / (1.0 + vector_norm_inf<i_t, f_t>(presolved_lp.rhs)));
-    if (barrier_lp.Q.n == 0) {
-      std::vector<f_t> unscaled_dual_residual = unscaled_z;
-      for (i_t j = 0; j < unscaled_dual_residual.size(); ++j) {
-        unscaled_dual_residual[j] -= presolved_lp.objective[j];
+    if (settings.post_solve_info == 1) {
+      std::vector<f_t> residual = presolved_lp.rhs;
+      matrix_vector_multiply(presolved_lp.A, 1.0, unscaled_x, -1.0, residual);
+      f_t primal_residual = vector_norm_inf<i_t, f_t>(residual);
+      settings.log.printf("Unscaled Primal infeasibility   (abs/rel): %.2e/%.2e\n",
+                          primal_residual,
+                          primal_residual / (1.0 + vector_norm_inf<i_t, f_t>(presolved_lp.rhs)));
+      if (barrier_lp.Q.n == 0) {
+        std::vector<f_t> unscaled_dual_residual = unscaled_z;
+        for (i_t j = 0; j < unscaled_dual_residual.size(); ++j) {
+          unscaled_dual_residual[j] -= presolved_lp.objective[j];
+        }
+        matrix_transpose_vector_multiply(
+          presolved_lp.A, 1.0, unscaled_y, 1.0, unscaled_dual_residual);
+        f_t unscaled_dual_residual_norm = vector_norm_inf<i_t, f_t>(unscaled_dual_residual);
+        settings.log.printf(
+          "Unscaled Dual infeasibility     (abs/rel): %.2e/%.2e\n",
+          unscaled_dual_residual_norm,
+          unscaled_dual_residual_norm / (1.0 + vector_norm_inf<i_t, f_t>(presolved_lp.objective)));
       }
-      matrix_transpose_vector_multiply(
-        presolved_lp.A, 1.0, unscaled_y, 1.0, unscaled_dual_residual);
-      f_t unscaled_dual_residual_norm = vector_norm_inf<i_t, f_t>(unscaled_dual_residual);
-      settings.log.printf(
-        "Unscaled Dual infeasibility     (abs/rel): %.2e/%.2e\n",
-        unscaled_dual_residual_norm,
-        unscaled_dual_residual_norm / (1.0 + vector_norm_inf<i_t, f_t>(presolved_lp.objective)));
     }
 
     // Undo presolve
@@ -449,26 +451,28 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
                      lp_solution.y,
                      lp_solution.z);
 
-    std::vector<f_t> post_solve_residual = original_lp.rhs;
-    matrix_vector_multiply(original_lp.A, 1.0, lp_solution.x, -1.0, post_solve_residual);
-    f_t post_solve_primal_residual = vector_norm_inf<i_t, f_t>(post_solve_residual);
-    settings.log.printf(
-      "Post-solve Primal infeasibility (abs/rel): %.2e/%.2e\n",
-      post_solve_primal_residual,
-      post_solve_primal_residual / (1.0 + vector_norm_inf<i_t, f_t>(original_lp.rhs)));
-
-    if (barrier_lp.Q.n == 0) {
-      std::vector<f_t> post_solve_dual_residual = lp_solution.z;
-      for (i_t j = 0; j < post_solve_dual_residual.size(); ++j) {
-        post_solve_dual_residual[j] -= original_lp.objective[j];
-      }
-      matrix_transpose_vector_multiply(
-        original_lp.A, 1.0, lp_solution.y, 1.0, post_solve_dual_residual);
-      f_t post_solve_dual_residual_norm = vector_norm_inf<i_t, f_t>(post_solve_dual_residual);
+    if (settings.post_solve_info == 1) {
+      std::vector<f_t> post_solve_residual = original_lp.rhs;
+      matrix_vector_multiply(original_lp.A, 1.0, lp_solution.x, -1.0, post_solve_residual);
+      f_t post_solve_primal_residual = vector_norm_inf<i_t, f_t>(post_solve_residual);
       settings.log.printf(
-        "Post-solve Dual infeasibility   (abs/rel): %.2e/%.2e\n",
-        post_solve_dual_residual_norm,
-        post_solve_dual_residual_norm / (1.0 + vector_norm_inf<i_t, f_t>(original_lp.objective)));
+        "Post-solve Primal infeasibility (abs/rel): %.2e/%.2e\n",
+        post_solve_primal_residual,
+        post_solve_primal_residual / (1.0 + vector_norm_inf<i_t, f_t>(original_lp.rhs)));
+
+      if (barrier_lp.Q.n == 0) {
+        std::vector<f_t> post_solve_dual_residual = lp_solution.z;
+        for (i_t j = 0; j < post_solve_dual_residual.size(); ++j) {
+          post_solve_dual_residual[j] -= original_lp.objective[j];
+        }
+        matrix_transpose_vector_multiply(
+          original_lp.A, 1.0, lp_solution.y, 1.0, post_solve_dual_residual);
+        f_t post_solve_dual_residual_norm = vector_norm_inf<i_t, f_t>(post_solve_dual_residual);
+        settings.log.printf(
+          "Post-solve Dual infeasibility   (abs/rel): %.2e/%.2e\n",
+          post_solve_dual_residual_norm,
+          post_solve_dual_residual_norm / (1.0 + vector_norm_inf<i_t, f_t>(original_lp.objective)));
+      }
     }
 
     if (dualize_info.solving_dual) {

--- a/cpp/src/dual_simplex/solve.cpp
+++ b/cpp/src/dual_simplex/solve.cpp
@@ -418,7 +418,7 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
                                unscaled_y,
                                unscaled_z);
 
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       std::vector<f_t> residual = presolved_lp.rhs;
       matrix_vector_multiply(presolved_lp.A, 1.0, unscaled_x, -1.0, residual);
       f_t primal_residual = vector_norm_inf<i_t, f_t>(residual);
@@ -451,7 +451,7 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
                      lp_solution.y,
                      lp_solution.z);
 
-    if (settings.post_solve_info == 1) {
+    if (settings.postsolve_info == 1) {
       std::vector<f_t> post_solve_residual = original_lp.rhs;
       matrix_vector_multiply(original_lp.A, 1.0, lp_solution.x, -1.0, post_solve_residual);
       f_t post_solve_primal_residual = vector_norm_inf<i_t, f_t>(post_solve_residual);
@@ -506,7 +506,7 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
         k++;
       }
 
-      if (settings.post_solve_info == 1) {
+      if (settings.postsolve_info == 1) {
         // Check the objective and residuals on the primal problem.
         settings.log.printf(
           "Primal objective: %e\n",
@@ -562,7 +562,7 @@ lp_status_t solve_linear_program_with_barrier(const user_problem_t<i_t, f_t>& us
         problem.num_cols = num_cols;
       }
 
-      if (settings.post_solve_info == 1) {
+      if (settings.postsolve_info == 1) {
         std::vector<f_t> primal_residual = dualize_info.primal_problem.rhs;
         matrix_vector_multiply(
           dualize_info.primal_problem.A, 1.0, primal_solution.x, -1.0, primal_residual);

--- a/cpp/src/grpc/codegen/field_registry.yaml
+++ b/cpp/src/grpc/codegen/field_registry.yaml
@@ -555,7 +555,7 @@ pdlp_settings:
       # consistency with the other f_t scalars (tolerances, time_limit, ...).
       field_num: 32
       optional: true
-  - post_solve_info:
+  - postsolve_info:
       field_num: 33
       type: int32
       optional: true

--- a/cpp/src/grpc/codegen/field_registry.yaml
+++ b/cpp/src/grpc/codegen/field_registry.yaml
@@ -555,6 +555,10 @@ pdlp_settings:
       # consistency with the other f_t scalars (tolerances, time_limit, ...).
       field_num: 32
       optional: true
+  - post_solve_info:
+      field_num: 33
+      type: int32
+      optional: true
   - save_best_primal_so_far:
       field_num: 28
       type: bool

--- a/cpp/src/grpc/codegen/generated/cuopt_remote_data.proto
+++ b/cpp/src/grpc/codegen/generated/cuopt_remote_data.proto
@@ -193,6 +193,7 @@ message PDLPSolverSettings {
   optional int32 pdlp_precision = 30;
   optional bool barrier_iterative_refinement = 31;
   optional double barrier_step_scale = 32;
+  optional int32 post_solve_info = 33;
   PDLPWarmStartData warm_start_data = 50;
 }
 

--- a/cpp/src/grpc/codegen/generated/cuopt_remote_data.proto
+++ b/cpp/src/grpc/codegen/generated/cuopt_remote_data.proto
@@ -193,7 +193,7 @@ message PDLPSolverSettings {
   optional int32 pdlp_precision = 30;
   optional bool barrier_iterative_refinement = 31;
   optional double barrier_step_scale = 32;
-  optional int32 post_solve_info = 33;
+  optional int32 postsolve_info = 33;
   PDLPWarmStartData warm_start_data = 50;
 }
 

--- a/cpp/src/grpc/codegen/generated/generated_pdlp_settings_to_proto.inc
+++ b/cpp/src/grpc/codegen/generated/generated_pdlp_settings_to_proto.inc
@@ -35,7 +35,7 @@
   pb_settings->set_eliminate_dense_columns(settings.eliminate_dense_columns);
   pb_settings->set_barrier_iterative_refinement(settings.barrier_iterative_refinement);
   pb_settings->set_barrier_step_scale(settings.barrier_step_scale);
-  pb_settings->set_post_solve_info(settings.post_solve_info);
+  pb_settings->set_postsolve_info(settings.postsolve_info);
   pb_settings->set_save_best_primal_so_far(settings.save_best_primal_so_far);
   pb_settings->set_first_primal_feasible(settings.first_primal_feasible);
   pb_settings->set_pdlp_precision(static_cast<int32_t>(settings.pdlp_precision));

--- a/cpp/src/grpc/codegen/generated/generated_pdlp_settings_to_proto.inc
+++ b/cpp/src/grpc/codegen/generated/generated_pdlp_settings_to_proto.inc
@@ -35,6 +35,7 @@
   pb_settings->set_eliminate_dense_columns(settings.eliminate_dense_columns);
   pb_settings->set_barrier_iterative_refinement(settings.barrier_iterative_refinement);
   pb_settings->set_barrier_step_scale(settings.barrier_step_scale);
+  pb_settings->set_post_solve_info(settings.post_solve_info);
   pb_settings->set_save_best_primal_so_far(settings.save_best_primal_so_far);
   pb_settings->set_first_primal_feasible(settings.first_primal_feasible);
   pb_settings->set_pdlp_precision(static_cast<int32_t>(settings.pdlp_precision));

--- a/cpp/src/grpc/codegen/generated/generated_proto_to_pdlp_settings.inc
+++ b/cpp/src/grpc/codegen/generated/generated_proto_to_pdlp_settings.inc
@@ -79,8 +79,8 @@
   if (pb_settings.has_barrier_step_scale()) {
     settings.barrier_step_scale = pb_settings.barrier_step_scale();
   }
-  if (pb_settings.has_post_solve_info()) {
-    settings.post_solve_info = pb_settings.post_solve_info();
+  if (pb_settings.has_postsolve_info()) {
+    settings.postsolve_info = pb_settings.postsolve_info();
   }
   settings.save_best_primal_so_far = pb_settings.save_best_primal_so_far();
   settings.first_primal_feasible = pb_settings.first_primal_feasible();

--- a/cpp/src/grpc/codegen/generated/generated_proto_to_pdlp_settings.inc
+++ b/cpp/src/grpc/codegen/generated/generated_proto_to_pdlp_settings.inc
@@ -79,6 +79,9 @@
   if (pb_settings.has_barrier_step_scale()) {
     settings.barrier_step_scale = pb_settings.barrier_step_scale();
   }
+  if (pb_settings.has_post_solve_info()) {
+    settings.post_solve_info = pb_settings.post_solve_info();
+  }
   settings.save_best_primal_so_far = pb_settings.save_best_primal_so_far();
   settings.first_primal_feasible = pb_settings.first_primal_feasible();
   if (pb_settings.has_pdlp_precision()) {

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -138,7 +138,7 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
     {CUOPT_DUALIZE, &pdlp_settings.dualize, -1, 1, -1},
     {CUOPT_ORDERING, &pdlp_settings.ordering, -1, 1, -1},
     {CUOPT_BARRIER_DUAL_INITIAL_POINT, &pdlp_settings.barrier_dual_initial_point, -1, 1, -1},
-    {CUOPT_POST_SOLVE_INFO, &pdlp_settings.post_solve_info, -1, 1, -1},
+    {CUOPT_POSTSOLVE_INFO, &pdlp_settings.postsolve_info, -1, 1, -1},
     {CUOPT_MIP_CUT_PASSES, &mip_settings.max_cut_passes, -1, std::numeric_limits<i_t>::max(), 10},
     {CUOPT_MIP_MIXED_INTEGER_ROUNDING_CUTS, &mip_settings.mir_cuts, -1, 1, -1},
     {CUOPT_MIP_MIXED_INTEGER_GOMORY_CUTS, &mip_settings.mixed_integer_gomory_cuts, -1, 1, -1},

--- a/cpp/src/math_optimization/solver_settings.cu
+++ b/cpp/src/math_optimization/solver_settings.cu
@@ -138,6 +138,7 @@ solver_settings_t<i_t, f_t>::solver_settings_t() : pdlp_settings(), mip_settings
     {CUOPT_DUALIZE, &pdlp_settings.dualize, -1, 1, -1},
     {CUOPT_ORDERING, &pdlp_settings.ordering, -1, 1, -1},
     {CUOPT_BARRIER_DUAL_INITIAL_POINT, &pdlp_settings.barrier_dual_initial_point, -1, 1, -1},
+    {CUOPT_POST_SOLVE_INFO, &pdlp_settings.post_solve_info, -1, 1, -1},
     {CUOPT_MIP_CUT_PASSES, &mip_settings.max_cut_passes, -1, std::numeric_limits<i_t>::max(), 10},
     {CUOPT_MIP_MIXED_INTEGER_ROUNDING_CUTS, &mip_settings.mir_cuts, -1, 1, -1},
     {CUOPT_MIP_MIXED_INTEGER_GOMORY_CUTS, &mip_settings.mixed_integer_gomory_cuts, -1, 1, -1},

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -504,6 +504,7 @@ std::tuple<simplex::lp_solution_t<i_t, f_t>, simplex::lp_status_t, f_t, f_t, f_t
   barrier_settings.dualize                         = settings.dualize;
   barrier_settings.ordering                        = settings.ordering;
   barrier_settings.barrier_dual_initial_point      = settings.barrier_dual_initial_point;
+  barrier_settings.post_solve_info                 = settings.post_solve_info;
   barrier_settings.barrier                         = true;
   barrier_settings.barrier_presolve                = true;
   barrier_settings.crossover                       = settings.crossover;

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -504,7 +504,7 @@ std::tuple<simplex::lp_solution_t<i_t, f_t>, simplex::lp_status_t, f_t, f_t, f_t
   barrier_settings.dualize                         = settings.dualize;
   barrier_settings.ordering                        = settings.ordering;
   barrier_settings.barrier_dual_initial_point      = settings.barrier_dual_initial_point;
-  barrier_settings.post_solve_info                 = settings.post_solve_info;
+  barrier_settings.postsolve_info                  = settings.postsolve_info;
   barrier_settings.barrier                         = true;
   barrier_settings.barrier_presolve                = true;
   barrier_settings.crossover                       = settings.crossover;

--- a/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
@@ -2033,6 +2033,7 @@ TEST(MapperRoundtrip, PDLPSettingsAllFields)
   orig.eliminate_dense_columns      = true;
   orig.barrier_iterative_refinement = false;  // not the default true, to detect overwrite-on-decode
   orig.barrier_step_scale           = 0.75;   // not the default 0.9
+  orig.post_solve_info              = 1;
   orig.pdlp_precision               = pdlp_precision_t::MixedPrecision;
   orig.save_best_primal_so_far      = true;
   orig.first_primal_feasible        = true;
@@ -2073,6 +2074,7 @@ TEST(MapperRoundtrip, PDLPSettingsAllFields)
   EXPECT_EQ(restored.eliminate_dense_columns, true);
   EXPECT_EQ(restored.barrier_iterative_refinement, false);
   EXPECT_DOUBLE_EQ(restored.barrier_step_scale, 0.75);
+  EXPECT_EQ(restored.post_solve_info, 1);
   EXPECT_EQ(restored.pdlp_precision, pdlp_precision_t::MixedPrecision);
   EXPECT_EQ(restored.save_best_primal_so_far, true);
   EXPECT_EQ(restored.first_primal_feasible, true);

--- a/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
+++ b/cpp/tests/linear_programming/grpc/grpc_client_test.cpp
@@ -2033,7 +2033,7 @@ TEST(MapperRoundtrip, PDLPSettingsAllFields)
   orig.eliminate_dense_columns      = true;
   orig.barrier_iterative_refinement = false;  // not the default true, to detect overwrite-on-decode
   orig.barrier_step_scale           = 0.75;   // not the default 0.9
-  orig.post_solve_info              = 1;
+  orig.postsolve_info               = 1;
   orig.pdlp_precision               = pdlp_precision_t::MixedPrecision;
   orig.save_best_primal_so_far      = true;
   orig.first_primal_feasible        = true;
@@ -2074,7 +2074,7 @@ TEST(MapperRoundtrip, PDLPSettingsAllFields)
   EXPECT_EQ(restored.eliminate_dense_columns, true);
   EXPECT_EQ(restored.barrier_iterative_refinement, false);
   EXPECT_DOUBLE_EQ(restored.barrier_step_scale, 0.75);
-  EXPECT_EQ(restored.post_solve_info, 1);
+  EXPECT_EQ(restored.postsolve_info, 1);
   EXPECT_EQ(restored.pdlp_precision, pdlp_precision_t::MixedPrecision);
   EXPECT_EQ(restored.save_best_primal_so_far, true);
   EXPECT_EQ(restored.first_primal_feasible, true);

--- a/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
+++ b/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
@@ -70,9 +70,9 @@ TEST(SolverSettingsTest, TestSetGet)
   solver_settings.first_primal_feasible = true;
   EXPECT_TRUE(solver_settings.first_primal_feasible);
 
-  EXPECT_EQ(solver_settings.post_solve_info, -1);
-  solver_settings.post_solve_info = 1;
-  EXPECT_EQ(solver_settings.post_solve_info, 1);
+  EXPECT_EQ(solver_settings.postsolve_info, -1);
+  solver_settings.postsolve_info = 1;
+  EXPECT_EQ(solver_settings.postsolve_info, 1);
 }
 
 TEST(SolverSettingsTest, warm_start_smaller_vector)

--- a/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
+++ b/cpp/tests/linear_programming/unit_tests/solver_settings_test.cu
@@ -69,6 +69,10 @@ TEST(SolverSettingsTest, TestSetGet)
   EXPECT_FALSE(solver_settings.first_primal_feasible);
   solver_settings.first_primal_feasible = true;
   EXPECT_TRUE(solver_settings.first_primal_feasible);
+
+  EXPECT_EQ(solver_settings.post_solve_info, -1);
+  solver_settings.post_solve_info = 1;
+  EXPECT_EQ(solver_settings.post_solve_info, 1);
 }
 
 TEST(SolverSettingsTest, warm_start_smaller_vector)


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

Barrier solves currently print several diagnostic lines after the main optimality summary, including unscaled residual checks, post-solve reconstruction messages, post-solve infeasibility, and (when dualization is used) recovered-primal residual checks. These are useful for debugging, but noisy for normal runs.

This change introduces post_solve_info as a tri-state integer parameter:

-1: default (off)
0: off
1: on

When disabled, solver behavior is unchanged; only the optional diagnostic logging is suppressed. The parameter is wired through PDLP/barrier settings, the C API string constant, and gRPC codegen.


```
cuopt_cli QPLIB_10034.mps 

Optimal solution found in 61 iterations and 0.991s
Objective -6.60129271e-02
Primal infeasibility (abs/rel): 2.25e-09/2.13e-09
Dual infeasibility   (abs/rel): 4.56e-18/4.56e-18
Complementarity gap  (abs/rel): 4.88e-09/4.58e-09

Barrier finished in 1.00 seconds
```


```
cuopt_cli QPLIB_10034.mps --postsolve-info 1

Optimal solution found in 61 iterations and 1.021s
Objective -6.60129271e-02
Primal infeasibility (abs/rel): 1.53e-09/1.45e-09
Dual infeasibility   (abs/rel): 1.17e-17/1.17e-17
Complementarity gap  (abs/rel): 4.88e-09/4.58e-09


Unscaled Primal infeasibility   (abs/rel): 1.79e-06/8.95e-07
Post-solve: Handling removed lower bounds 200
Post-solve Primal infeasibility (abs/rel): 1.79e-06/1.79e-06
Barrier finished in 1.03 seconds
```


## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [x] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
