### PR TITLE
Include Q matrix in Ruiz scale computations

### DIFF
--- a/cpp/include/cuopt/mathematical_optimization/io/parser.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/io/parser.hpp
@@ -178,7 +178,7 @@ inline mps_data_model_t<i_t, f_t> read(const std::string& path,
   throw std::logic_error(
     "read: unrecognized input file extension. Supported (case-insensitive): "
     ".mps, .mps.gz, .mps.bz2, .mps.lz4, .qps, .qps.gz, .qps.bz2, .qps.lz4, "
-    ".lp, .lp.gz, .lp.bz2, .lp.lz4. .sif, .sif.gz, .sif.bz2, .sif.lz4,"
+    ".lp, .lp.gz, .lp.bz2, .lp.lz4, .sif, .sif.gz, .sif.bz2, .sif.lz4."
     "Given path: " +
     path);
 }

--- a/cpp/include/cuopt/mathematical_optimization/io/parser.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/io/parser.hpp
@@ -164,7 +164,7 @@ inline mps_data_model_t<i_t, f_t> read(const std::string& path,
       break;
     }
   }
-  if (lower.ends_with(".mps") || lower.ends_with(".qps")) {
+  if (lower.ends_with(".mps") || lower.ends_with(".qps") || lower.ends_with(".sif")) {
     if (mps_reader == mps_reader_type_t::fast_experimental) {
       if (fixed_mps_format) {
         throw std::logic_error(
@@ -178,7 +178,7 @@ inline mps_data_model_t<i_t, f_t> read(const std::string& path,
   throw std::logic_error(
     "read: unrecognized input file extension. Supported (case-insensitive): "
     ".mps, .mps.gz, .mps.bz2, .mps.lz4, .qps, .qps.gz, .qps.bz2, .qps.lz4, "
-    ".lp, .lp.gz, .lp.bz2, .lp.lz4. "
+    ".lp, .lp.gz, .lp.bz2, .lp.lz4. .sif, .sif.gz, .sif.bz2, .sif.lz4,"
     "Given path: " +
     path);
 }

--- a/cpp/src/dual_simplex/scaling.cpp
+++ b/cpp/src/dual_simplex/scaling.cpp
@@ -28,11 +28,10 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
   // =========================================================================
   // Ruiz equilibration for SOCP (and QP) problems
   // =========================================================================
-  // For SOCP problems, apply Ruiz equilibration: alternating row and column
-  // infinity-norm scaling to bring the constraint matrix close to equilibrium.
-  // This dramatically improves the conditioning of the augmented KKT system.
-  // Applied only when the constraint matrix has a large row-norm or
-  // column-norm imbalance.
+  // For SOCP and QP problems, apply Ruiz equilibration to bring the
+  // constraint matrix A and Hessian Q close to equilibrium. This improves
+  // the conditioning of the KKT system. The skip heuristic considers
+  // imbalance in both A and Q.
   if (!unscaled.second_order_cone_dims.empty() || unscaled.Q.n > 0) {
     // col_scale and row_scale accumulate reciprocal scale factors during Ruiz iterations.
     std::vector<f_t> col_scale(n, 1.0);
@@ -73,11 +72,7 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
     }
     f_t col_norm_ratio = (min_col_norm > 0) ? max_col_norm / min_col_norm : 1.0;
 
-    // Also check the coefficient-magnitude spread of Q. A QP can have a
-    // perfectly balanced constraint matrix A but a badly scaled Hessian Q
-    // (e.g. quadratic coefficients spanning many orders of magnitude), which
-    // by itself is enough to badly condition the augmented KKT system even
-    // though A alone looks fine.
+    // Check coefficient-magnitude spread of Q for the skip heuristic.
     f_t max_q_coeff = 0;
     f_t min_q_coeff = std::numeric_limits<f_t>::max();
     if (scaled.Q.n > 0) {
@@ -92,8 +87,8 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
     f_t q_ratio = (min_q_coeff <= max_q_coeff) ? max_q_coeff / min_q_coeff : 1.0;
 
     // qcqp_ruiz_equilibration: -1 automatic (imbalance heuristic), 0 force off, 1 force on.
-    const i_t ruiz_mode = settings.qcqp_ruiz_equilibration;
-    const bool balanced = row_norm_ratio < 100.0 && col_norm_ratio < 5e4 && q_ratio < 100.0;
+    const i_t ruiz_mode  = settings.qcqp_ruiz_equilibration;
+    const bool balanced  = row_norm_ratio < 100.0 && col_norm_ratio < 5e4 && q_ratio < 100.0;
     const bool skip_ruiz = (ruiz_mode == 0) || (ruiz_mode < 0 && balanced);
 
     if (skip_ruiz) {
@@ -101,7 +96,8 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
         settings.log.printf("Skipping Ruiz equilibration (qcqp_hyper_ruiz_equilibration = 0)\n");
       } else {
         settings.log.printf(
-          "Skipping Ruiz equilibration (row norm ratio %.1f, column norm ratio %.1f < 5e4, Q coeff ratio "
+          "Skipping Ruiz equilibration (row norm ratio %.1f, column norm ratio %.1f < 5e4, Q coeff "
+          "ratio "
           "%.1f < 100)\n",
           row_norm_ratio,
           col_norm_ratio,

--- a/cpp/src/dual_simplex/scaling.cpp
+++ b/cpp/src/dual_simplex/scaling.cpp
@@ -73,19 +73,39 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
     }
     f_t col_norm_ratio = (min_col_norm > 0) ? max_col_norm / min_col_norm : 1.0;
 
+    // Also check the coefficient-magnitude spread of Q. A QP can have a
+    // perfectly balanced constraint matrix A but a badly scaled Hessian Q
+    // (e.g. quadratic coefficients spanning many orders of magnitude), which
+    // by itself is enough to badly condition the augmented KKT system even
+    // though A alone looks fine.
+    f_t max_q_coeff = 0;
+    f_t min_q_coeff = std::numeric_limits<f_t>::max();
+    if (scaled.Q.n > 0) {
+      for (i_t p = 0; p < scaled.Q.row_start[scaled.Q.m]; ++p) {
+        f_t a = std::abs(scaled.Q.x[p]);
+        if (a > 0) {
+          max_q_coeff = std::max(max_q_coeff, a);
+          min_q_coeff = std::min(min_q_coeff, a);
+        }
+      }
+    }
+    f_t q_ratio = (min_q_coeff <= max_q_coeff) ? max_q_coeff / min_q_coeff : 1.0;
+
     // qcqp_ruiz_equilibration: -1 automatic (imbalance heuristic), 0 force off, 1 force on.
     const i_t ruiz_mode = settings.qcqp_ruiz_equilibration;
-    const bool skip_ruiz =
-      (ruiz_mode == 0) || (ruiz_mode < 0 && row_norm_ratio < 100.0 && col_norm_ratio < 5e4);
+    const bool balanced = row_norm_ratio < 100.0 && col_norm_ratio < 5e4 && q_ratio < 100.0;
+    const bool skip_ruiz = (ruiz_mode == 0) || (ruiz_mode < 0 && balanced);
 
     if (skip_ruiz) {
       if (ruiz_mode == 0) {
         settings.log.printf("Skipping Ruiz equilibration (qcqp_hyper_ruiz_equilibration = 0)\n");
       } else {
         settings.log.printf(
-          "Skipping Ruiz equilibration (row norm ratio %.1f, column norm ratio %.1f < 5e4)\n",
+          "Skipping Ruiz equilibration (row norm ratio %.1f, column norm ratio %.1f < 5e4, Q coeff ratio "
+          "%.1f < 100)\n",
           row_norm_ratio,
-          col_norm_ratio);
+          col_norm_ratio,
+          q_ratio);
       }
       column_scaling.assign(n, 1.0);
       return 0;
@@ -93,9 +113,10 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
     if (ruiz_mode > 0) {
       settings.log.printf(
         "Applying Ruiz equilibration (qcqp_hyper_ruiz_equilibration = 1, row norm ratio %.1f, "
-        "column norm ratio %.1f)\n",
+        "column norm ratio %.1f, Q coeff ratio %.1f)\n",
         row_norm_ratio,
-        col_norm_ratio);
+        col_norm_ratio,
+        q_ratio);
     }
 
     // Apply Ruiz equilibration
@@ -135,12 +156,21 @@ i_t scaling(const lp_problem_t<i_t, f_t>& unscaled,
       std::vector<f_t> c(n);
       const i_t cone_start = unscaled.second_order_cone_dims.empty() ? n : unscaled.cone_var_start;
 
-      // Linear columns: scale independently
+      // Linear columns: scale independently. Include the Hessian Q's
+      // contribution (row j of Q, symmetric) alongside A's column j, so that
+      // large quadratic coefficients are equilibrated too, not just the
+      // constraint matrix.
       for (i_t j = 0; j < cone_start; ++j) {
         f_t cm = 0.0;
         for (i_t p = scaled.A.col_start[j]; p < scaled.A.col_start[j + 1]; ++p) {
           f_t a = std::abs(scaled.A.x[p]);
           if (a > cm) cm = a;
+        }
+        if (scaled.Q.n > 0) {
+          for (i_t p = scaled.Q.row_start[j]; p < scaled.Q.row_start[j + 1]; ++p) {
+            f_t a = std::abs(scaled.Q.x[p]);
+            if (a > cm) cm = a;
+          }
         }
         c[j]          = cm > 0 ? 1.0 / std::sqrt(cm) : 1.0;
         max_deviation = std::max(max_deviation, std::abs(cm - 1.0));


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

Extends the Ruiz equilibration heuristic to account for the Hessian matrix Q in quadratic programs (QP/QCQP). 

**Changes:**

- Include Q coefficient magnitude spread in the decision to skip Ruiz scaling (alongside A's row/column norms)
- Add Q's contribution to column norm calculations during equilibration iterations

**Benchmark Results:**

- Maros QP: 2 additional optimal (previously suboptimal). CVXQP1_L improves by 7x. 23% runtime degradation overall though there are not much change in iterations, but these are tiny; robustness is prioritized.
- QCQP: QPLIB_8567 and QPLIB_8559 go from suboptimal to optimal. 7% geometric mean speedup.
- SOCP: No regressions or improvements.

**Acknowledgements:** 
This improvement was proposed by the [Hiverge](https://www.hiverge.ai/) AI discovery engine with experiments by [@kerry-hiverge](https://github.com/kerry-hiverge).

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
