### PR TITLE
modify ldconfig in ubi image so nvidia libraries are on path

### DIFF
--- a/ci/docker/Dockerfile.ubi
+++ b/ci/docker/Dockerfile.ubi
@@ -74,6 +74,23 @@ RUN alternatives --install /usr/bin/python python /usr/bin/python3.14 100
 ENV PATH="/usr/local/cuda/bin:/usr/bin:/usr/local/bin:/usr/local/nvidia/bin/:/usr/local/lib64/python3.14/site-packages/libcuopt/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/lib/wsl/lib:/usr/local/lib64/python3.14/site-packages/libcuopt/lib64/:/usr/local/lib64/python3.14/site-packages/rapids_logger/lib64:/usr/local/lib/python3.14/site-packages/nvidia/cu13/lib:${LD_LIBRARY_PATH}"
 
+# libcuopt's RPATH reaches the NVIDIA wheels via $ORIGIN/../../nvidia/<pkg>/lib,
+# which assumes libcuopt and those wheels share one site-packages directory. That
+# holds on Debian/Ubuntu (purelib == platlib == dist-packages) but not on RHEL,
+# where platlib is lib64 and purelib is lib: libcuopt installs to lib64 while the
+# NVIDIA wheels (Root-Is-Purelib: true) install to lib, so every $ORIGIN-relative
+# entry misses. Index the wheel lib dirs with the dynamic linker instead of
+# extending LD_LIBRARY_PATH per package — this covers wheels added later, and
+# keeps a lower lookup precedence than the driver libs the container runtime
+# injects at start. Without it, cuopt_grpc_server dies on libnccl.so.2.
+RUN find /usr/local/lib/python*/site-packages/nvidia \
+         /usr/local/lib64/python*/site-packages/nvidia \
+         -maxdepth 2 -type d -name lib 2>/dev/null \
+      | tee /etc/ld.so.conf.d/cuopt-nvidia-wheels.conf \
+    && grep -q '/nvidia/nccl/lib$' /etc/ld.so.conf.d/cuopt-nvidia-wheels.conf \
+    && ldconfig \
+    && ldconfig -p | grep -qE 'libnccl\.so\.2([.0-9]*)[[:space:]].*/nvidia/nccl/lib/'
+
 # Directory creation, permissions
 RUN mkdir -p /opt/cuopt && \
     chmod 777 /opt/cuopt && \


### PR DESCRIPTION
under rhel, libcuopt and other libs end up under different paths so relative references don't work. This causes the cuopt_grpc_server to fail in the ubi10 image

```bash
$ docker run --rm --gpus=all --network=host -e CUOPT_SERVER_TYPE=grpc nvidia/cuopt:26.8.0a-cu13-ubi10
/usr/local/lib64/python3.14/site-packages/libcuopt/bin/cuopt_grpc_server: error while loading shared libraries: libnccl.so.2: cannot open shared object file: No such file or directory
```

with fix:

```bash
$ docker run --rm --gpus=all --network=host -e CUOPT_SERVER_TYPE=grpc cuopt-ubi10-nccl-fixtest:latest
[2026-07-31 00:01:33.702] cuOpt gRPC Remote Solve Server
[2026-07-31 00:01:33.702] ==============================
[2026-07-31 00:01:33.702] Port: 5001
[2026-07-31 00:01:33.702] Workers: 1
[2026-07-31 00:01:33.730] [Server] 1 GPU(s) available for worker assignment
[2026-07-31 00:01:33.734] [Worker 0] Started (PID: 58)
[2026-07-31 00:01:33.735] [Server] Result retrieval thread started
[2026-07-31 00:01:33.735] [Server] Incumbent retrieval thread started
[2026-07-31 00:01:33.735] [Server] Worker monitor thread started
[2026-07-31 00:01:33.736] [Server] Session reaper thread started (timeout=300s)
[2026-07-31 00:01:33.742] [gRPC Server] Listening on 0.0.0.0:5001
[2026-07-31 00:01:33.742] [gRPC Server] Workers: 1
[2026-07-31 00:01:33.742] [gRPC Server] Max message size: 268435456 bytes (256 MiB)
[2026-07-31 00:01:33.742] [gRPC Server] Press Ctrl+C to shutdown
[2026-07-31 00:01:33.891] [Worker] RMM pool size: 1 GiB
[2026-07-31 00:01:33.891] [Worker 0] Using CUDA device 0 of 1
```