### PR TITLE
Pin PaPILO to flush empty-row fix from akifcorduk/papilo.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -270,14 +270,14 @@ endif ()
 
 FetchContent_Declare(
         papilo
-        GIT_REPOSITORY "https://github.com/nguidotti/papilo.git"
+        GIT_REPOSITORY "https://github.com/akifcorduk/papilo.git"
         # We would want to get the main branch. However, the main branch
         # does not have some of the presolvers and settings that we need
         # Mainly, probing and clique merging.
         # This is the reason we are using the development branch
         # from Oct 12, 2025. Once these changes are merged into the main branch,
         #we can switch to the main branch.
-        GIT_TAG "0cfea20c5655249174dbd04f0fb7bd6b1f6e9a0c"
+        GIT_TAG "32b3a87dbf4955d5a2803be74145c389ea31434d"
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL
         SYSTEM


### PR DESCRIPTION
Change the papilo pin to my fork as Nicolas is on vacation. This fixes the bug by moving the empty-row redundancy check after removeFixedCols.