### PR TITLE
test(mip): Update incumbent callback API test to use a bit more complex problem

### DIFF
--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -441,8 +441,12 @@ def _run_incumbent_solutions(include_set_callback):
 
     prob.solve(settings)
 
-    assert get_callback.n_callbacks > 0
-
+    # Whether the callback fires depends on whether the solver finds an
+    # intermediate incumbent (a solver-behavior question tested in
+    # test_incumbent_callbacks.py). On fast hardware (e.g. GB300), presolve
+    # fixes both variables directly and no branch-and-bound runs, so
+    # n_callbacks may be 0. This test covers API shape only: registration,
+    # argument types, and no crash.
     for sol in get_callback.solutions:
         x_val = sol["solution"][0]
         y_val = sol["solution"][1]

--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -441,12 +441,15 @@ def _run_incumbent_solutions(include_set_callback):
 
     prob.solve(settings)
 
-    # Whether the callback fires depends on whether the solver finds an
-    # intermediate incumbent (a solver-behavior question tested in
-    # test_incumbent_callbacks.py). On fast hardware (e.g. GB300), presolve
-    # fixes both variables directly and no branch-and-bound runs, so
-    # n_callbacks may be 0. This test covers API shape only: registration,
-    # argument types, and no crash.
+    # Incumbent callbacks only fire during branch-and-bound. On fast hardware
+    # (e.g. GB300), presolve fixes both variables directly and no branching
+    # occurs, so skip rather than fail when no callbacks fired.
+    if get_callback.n_callbacks == 0:
+        pytest.skip(
+            "No incumbent callbacks fired; problem was likely solved at the "
+            "root node without branching (e.g. GB300). See #1647."
+        )
+
     for sol in get_callback.solutions:
         x_val = sol["solution"][0]
         y_val = sol["solution"][1]

--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -419,12 +419,21 @@ def _run_incumbent_solutions(include_set_callback):
                     self.get_callback.solutions[-1]["cost"]
                 )
 
+    # 0-1 knapsack: 8 items, capacity 12. The LP relaxation is fractional
+    # (the highest-ratio item doesn't fit exactly), so B&B is required and
+    # the incumbent callback is guaranteed to fire when a feasible integer
+    # solution is found.
+    weights = [4, 3, 5, 2, 6, 1, 4, 3]
+    values = [7, 5, 8, 3, 9, 2, 6, 4]
+    capacity = 12
+    n = len(weights)
+
     prob = Problem()
-    x = prob.addVariable(vtype=VType.INTEGER)
-    y = prob.addVariable(vtype=VType.INTEGER)
-    prob.addConstraint(2 * x + 4 * y >= 230)
-    prob.addConstraint(3 * x + 2 * y <= 190)
-    prob.setObjective(5 * x + 3 * y, sense=sense.MAXIMIZE)
+    xs = [prob.addVariable(lb=0, ub=1, vtype=VType.INTEGER) for _ in range(n)]
+    prob.addConstraint(sum(w * x for w, x in zip(weights, xs)) <= capacity)
+    prob.setObjective(
+        sum(v * x for v, x in zip(values, xs)), sense=sense.MAXIMIZE
+    )
 
     user_data = {"source": "test_incumbent_solutions"}
     get_callback = CustomGetSolutionCallback(user_data)
@@ -437,27 +446,23 @@ def _run_incumbent_solutions(include_set_callback):
     settings.set_mip_callback(get_callback, user_data)
     if include_set_callback:
         settings.set_mip_callback(set_callback, user_data)
-    settings.set_parameter("time_limit", 1)
 
     prob.solve(settings)
 
-    # Incumbent callbacks only fire during branch-and-bound. If presolve
-    # fixes all variables directly, no branching occurs and n_callbacks stays
-    # at 0 — skip rather than fail in that case.
-    if get_callback.n_callbacks == 0:
-        pytest.skip(
-            "No incumbent callbacks fired; problem was likely solved at the "
-            "root node without branching."
-        )
+    assert get_callback.n_callbacks > 0
 
+    tol = 1e-6
     for sol in get_callback.solutions:
-        x_val = sol["solution"][0]
-        y_val = sol["solution"][1]
+        sol_vals = sol["solution"]
         cost = sol["cost"]
-        tol = 1e-6
-        assert 2 * x_val + 4 * y_val >= 230 - tol
-        assert 3 * x_val + 2 * y_val <= 190 + tol
-        assert abs(5 * x_val + 3 * y_val - cost) < tol
+        assert (
+            sum(w * sol_vals[i] for i, w in enumerate(weights))
+            <= capacity + tol
+        )
+        assert (
+            abs(sum(v * sol_vals[i] for i, v in enumerate(values)) - cost)
+            < tol
+        )
 
 
 def test_incumbent_get_solutions():

--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -441,13 +441,13 @@ def _run_incumbent_solutions(include_set_callback):
 
     prob.solve(settings)
 
-    # Incumbent callbacks only fire during branch-and-bound. On fast hardware
-    # (e.g. GB300), presolve fixes both variables directly and no branching
-    # occurs, so skip rather than fail when no callbacks fired.
+    # Incumbent callbacks only fire during branch-and-bound. If presolve
+    # fixes all variables directly, no branching occurs and n_callbacks stays
+    # at 0 — skip rather than fail in that case.
     if get_callback.n_callbacks == 0:
         pytest.skip(
             "No incumbent callbacks fired; problem was likely solved at the "
-            "root node without branching (e.g. GB300). See #1647."
+            "root node without branching."
         )
 
     for sol in get_callback.solutions:

--- a/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_python_API.py
@@ -420,8 +420,8 @@ def _run_incumbent_solutions(include_set_callback):
                 )
 
     # 0-1 knapsack: 8 items, capacity 12. The LP relaxation is fractional
-    # (the highest-ratio item doesn't fit exactly), so B&B is required and
-    # the incumbent callback is guaranteed to fire when a feasible integer
+    # (greedy fill leaves a partial item), so B&B is required and the
+    # incumbent callback is guaranteed to fire when a feasible integer
     # solution is found.
     weights = [4, 3, 5, 2, 6, 1, 4, 3]
     values = [7, 5, 8, 3, 9, 2, 6, 4]
@@ -455,6 +455,10 @@ def _run_incumbent_solutions(include_set_callback):
     for sol in get_callback.solutions:
         sol_vals = sol["solution"]
         cost = sol["cost"]
+        assert len(sol_vals) == n
+        assert all(
+            sol_vals[i] < tol or sol_vals[i] > 1 - tol for i in range(n)
+        )
         assert (
             sum(w * sol_vals[i] for i, w in enumerate(weights))
             <= capacity + tol

--- a/skills/cuopt-developer/SKILL.md
+++ b/skills/cuopt-developer/SKILL.md
@@ -224,7 +224,7 @@ For pre-commit setup, DCO sign-off (`git commit -s`), the fork-based PR workflow
 
 ## Coding Conventions
 
-For C++ naming (`snake_case`, `d_`/`h_` prefixes, `_t` suffix), file extensions (`.hpp`/`.cpp`/`.cu`/`.cuh` and which compiler each uses), include order, Python style, error handling (`CUOPT_EXPECTS`, `RAFT_CUDA_TRY`), memory management (RMM patterns, no raw `new`/`delete`), and test-impact rules, see [references/conventions.md](references/conventions.md).
+For C++ naming (`snake_case`, `d_`/`h_` prefixes, `_t` suffix), file extensions (`.hpp`/`.cpp`/`.cu`/`.cuh` and which compiler each uses), include order, Python style, error handling (`CUOPT_EXPECTS`, `RAFT_CUDA_TRY`), memory management (RMM patterns, no raw `new`/`delete`), test-impact rules, and volatile-comment rules (no PR numbers, commit hashes, issue links, or hardware names in comments or skip messages — these go stale), see [references/conventions.md](references/conventions.md).
 
 ## OpenMP task/runtime compatibility
 

--- a/skills/cuopt-developer/SKILL.md
+++ b/skills/cuopt-developer/SKILL.md
@@ -224,7 +224,7 @@ For pre-commit setup, DCO sign-off (`git commit -s`), the fork-based PR workflow
 
 ## Coding Conventions
 
-For C++ naming (`snake_case`, `d_`/`h_` prefixes, `_t` suffix), file extensions (`.hpp`/`.cpp`/`.cu`/`.cuh` and which compiler each uses), include order, Python style, error handling (`CUOPT_EXPECTS`, `RAFT_CUDA_TRY`), memory management (RMM patterns, no raw `new`/`delete`), test-impact rules, and volatile-comment rules (no PR numbers, commit hashes, issue links, or hardware names in comments or skip messages — these go stale), see [references/conventions.md](references/conventions.md).
+For C++ naming (`snake_case`, `d_`/`h_` prefixes, `_t` suffix), file extensions (`.hpp`/`.cpp`/`.cu`/`.cuh` and which compiler each uses), include order, Python style, error handling (`CUOPT_EXPECTS`, `RAFT_CUDA_TRY`), memory management (RMM patterns, no raw `new`/`delete`), test-impact rules, and volatile-comment rules (hardware names and self-referential issue/PR numbers in comments or skip messages go stale; issue links to a separate tracking issue are fine), see [references/conventions.md](references/conventions.md).
 
 ## OpenMP task/runtime compatibility
 


### PR DESCRIPTION
Fixes #1647

## Root cause

The 2-variable MIP in `_run_incumbent_solutions` can be fully solved by presolve on GB300: `y=39` is determined by bound tightening from the two constraints, then `x=37` follows uniquely. No branch-and-bound runs, so the incumbent callback never fires.


Whether the callback fires for a given problem on a given GPU is tested in `test_incumbent_callbacks.py`.