### PR TITLE
Revert "Temporarily exclude GB300 from testing (#1648)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -421,8 +421,6 @@ jobs:
       build_type: pull-request
       run_codecov: false
       script: ci/test_python.sh
-      # https://github.com/NVIDIA/cuopt/issues/1647
-      matrix_filter: map(select(.GPU != "gb300"))
   docs-build:
     needs: [conda-python-build, changed-files]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,8 +65,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_python.sh
-      # https://github.com/NVIDIA/cuopt/issues/1647
-      matrix_filter: map(select(.GPU != "gb300"))
     secrets:
       script-env-secret-1-key: CUOPT_S3_URI
       script-env-secret-1-value: ${{ secrets.CUOPT_S3_URI }}


### PR DESCRIPTION
## Description
GB300 has been fixed by https://github.com/NVIDIA/cuopt/pull/1649.

This reverts commit 1637fb023a0db591e59d1fdce8525dc5c3feb110.

## Issue
https://github.com/NVIDIA/cuopt/issues/1647

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
