### PR TITLE
normalize MILP to MIP in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 
 
-NVIDIA® cuOpt™ is a GPU-accelerated optimization engine that excels in linear programming (LP), quadratic programming (QP), and vehicle routing problems (VRP), with support for quadratically constrained quadratic programming (QCQP) (beta), second-order cone programming (SOCP) (beta), and mixed integer linear programming (MILP) (beta). cuOpt enables near real-time solutions for large-scale LPs with millions of variables and constraints and offers easy integration into existing modeling languages with seamless deployment across hybrid and multi-cloud environments.
+NVIDIA® cuOpt™ is a GPU-accelerated optimization engine that excels in linear programming (LP), quadratic programming (QP), and vehicle routing problems (VRP), with support for quadratically constrained quadratic programming (QCQP) (beta), second-order cone programming (SOCP) (beta), and mixed integer programming (MIP) (beta). cuOpt enables near real-time solutions for large-scale LPs with millions of variables and constraints and offers easy integration into existing modeling languages with seamless deployment across hybrid and multi-cloud environments.
 
 The cuOpt MIP solver is in beta and under active development. The solver currently excels at finding high-quality feasible solutions quickly with GPU-accelerated primal heuristics. Proving feasible solutions optimal remains under active development.
 
@@ -35,7 +35,7 @@ cuOpt supports the following APIs:
     - Quadratic Programming (QP)
     - Quadratically Constrained Quadratic Programming (QCQP) (beta)
     - Second-Order Cone Programming (SOCP) (beta)
-    - Mixed Integer Linear Programming (MILP) (beta)
+    - Mixed Integer Programming (MIP) (beta)
 - C++ API support
     - cuOpt is written in C++ and includes a native C++ API. However, we do not provide documentation for the C++ API at this time. We anticipate that the C++ API will change significantly in the future. Use it at your own risk.
 - Python support
@@ -44,12 +44,12 @@ cuOpt supports the following APIs:
     - Quadratic Programming (QP)
     - Quadratically Constrained Quadratic Programming (QCQP) (beta)
     - Second-Order Cone Programming (SOCP) (beta)
-    - Mixed Integer Linear Programming (MILP) (beta)
+    - Mixed Integer Programming (MIP) (beta)
     - Algebraic modeling Python API allows users to easily build constraints and objectives
 - Server support
     - Linear Programming (LP)
     - Routing (TSP, VRP, and PDP)
-    - Mixed Integer Linear Programming (MILP) (beta)
+    - Mixed Integer Programming (MIP) (beta)
 
 This repo is also hosted as a [COIN-OR](http://github.com/coin-or/cuopt/) project.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -198,10 +198,10 @@
 
 ### Documentation (25.12)
 
-- Missing parameters added to the documentation for LP and MILP.
+- Missing parameters added to the documentation for LP and MIP.
 - Release notes added to the main repository for easy access.
 - Examples in the documentation improved.
-- The openapi spec for the service showed the 'status' value for LP/MILP results as an int but it is actually a string.
+- The openapi spec for the service showed the 'status' value for LP/MIP results as an int but it is actually a string.
 
 ## Release Notes 25.10
 
@@ -249,7 +249,7 @@
 - Add support for nightly ``cuopt-examples`` notebook testing
 - Reduce hard-coded version usage in repo
 - Container to work on all different users including root
-- Changes to download LP and MILP datasets, and also disable cvxpy testing for 3.10
+- Changes to download LP and MIP datasets, and also disable cvxpy testing for 3.10
 - Faster engine compile time
 - Fix pre-commit for trailing whitespace and end of file
 - Merge update version and fix version format bugs
@@ -287,7 +287,7 @@
 
 ### New Features (25.08)
 
-- Added Python API for LP and MILP ([#223](https://github.com/NVIDIA/cuopt/pull/223))
+- Added Python API for LP and MIP ([#223](https://github.com/NVIDIA/cuopt/pull/223))
 
 ### Breaking Changes (25.08)
 
@@ -353,7 +353,7 @@
 
 - Added concurrent mode that runs PDLP and Dual Simplex together
 - Added crossover from PDLP to Dual Simplex
-- Added a C API for LP and MILP
+- Added a C API for LP and MIP
 - PDLP: Faster iterations and new more robust default PDLPSolverMode Stable2
 - Added support for writing out mps file containing user problem. Useful for debugging
 
@@ -364,15 +364,15 @@
 
 ### Improvements (25.05)
 
-- Hook up MILP Gap parameters and add info about number of nodes explored and simplex iterations
+- Hook up MIP Gap parameters and add info about number of nodes explored and simplex iterations
 - FJ bug fixes, tests and improvements
-- Allow no time limit in MILP
+- Allow no time limit in MIP
 - Refactor routing
 - Probing cache optimization
 - Diversity improvements for routing
 - Enable more compile warnings and faster compile by bypassing rapids fetch
 - Constraint prop based on load balanced bounds update
-- Logger file handling and bug fixes on MILP
+- Logger file handling and bug fixes on MIP
 - Add shellcheck to pre-commit and fix warnings
 
 ### Bug Fixes (25.05)
@@ -386,7 +386,7 @@
 - Improve breaks to allow dimensions at arbitrary places in the route.
 - Free var elimination with a substitute variable for each free variable.
 - Fixed race condition when resetting vehicle IDs in heterogenous mode.
-- cuOpt self-hosted client, some MILPs do not have all fields in ``lp_stats``.
+- cuOpt self-hosted client, some MIPs do not have all fields in ``lp_stats``.
 - Fixed RAPIDS logger usage.
 - Handle LP state more cleanly, per solution.
 - Fixed routing solver intermittent failures.

--- a/docs/cuopt/source/convex-settings.rst
+++ b/docs/cuopt/source/convex-settings.rst
@@ -11,7 +11,7 @@ This page describes the parameter settings available for cuOpt's convex optimiza
 Common Parameters
 -----------------
 
-We begin by describing parameters common to both the MILP and LP solvers
+We begin by describing parameters common to both the MIP and LP solvers
 
 
 Time Limit

--- a/docs/cuopt/source/cuopt-c/convex/examples/Makefile
+++ b/docs/cuopt/source/cuopt-c/convex/examples/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -7,7 +7,7 @@
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Makefile for cuOpt C API LP/MILP Examples
+# Makefile for cuOpt C API LP/MIP Examples
 #
 # This Makefile automatically discovers all .c files in the current directory
 # and builds corresponding executables.
@@ -115,7 +115,7 @@ list:
 
 # Show help
 help:
-	@echo "cuOpt C API LP/MILP Examples Makefile"
+	@echo "cuOpt C API LP/MIP Examples Makefile"
 	@echo "======================================"
 	@echo ""
 	@echo "This Makefile automatically discovers all .c files and builds them."

--- a/docs/cuopt/source/cuopt-c/mip/examples/milp_mps_example.c
+++ b/docs/cuopt/source/cuopt-c/mip/examples/milp_mps_example.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /*
- * Example program for solving MPS files with cuOpt MILP solver
+ * Example program for solving MPS files with cuOpt MIP solver
  */
 
 #include <cuopt/mathematical_optimization/cuopt_c.h>

--- a/docs/cuopt/source/cuopt-c/mip/examples/simple_milp_example.c
+++ b/docs/cuopt/source/cuopt-c/mip/examples/simple_milp_example.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /*
- * Simple test program for cuOpt MILP solver
+ * Simple test program for cuOpt MIP solver
  */
 
 // Include the cuOpt linear programming solver header
@@ -36,14 +36,14 @@ const char* termination_status_to_string(cuopt_int_t termination_status)
   }
 }
 
-// Test simple MILP problem
+// Test simple MIP problem
 cuopt_int_t test_simple_milp()
 {
   cuOptOptimizationProblem problem = NULL;
   cuOptSolverSettings settings     = NULL;
   cuOptSolution solution           = NULL;
 
-  /* Solve the following MILP:
+  /* Solve the following MIP:
      minimize -0.2*x1 + 0.1*x2
      subject to:
      3.0*x1 + 4.0*x2 <= 5.4
@@ -95,7 +95,7 @@ cuopt_int_t test_simple_milp()
   cuopt_int_t termination_status;
   cuopt_float_t objective_value;
 
-  printf("Creating and solving simple MILP problem...\n");
+  printf("Creating and solving simple MIP problem...\n");
 
   // Create the problem
   status = cuOptCreateRangedProblem(num_constraints,

--- a/docs/cuopt/source/cuopt-c/mip/mip-examples.rst
+++ b/docs/cuopt/source/cuopt-c/mip/mip-examples.rst
@@ -41,7 +41,7 @@ You should see the following output:
 .. code-block:: bash
   :caption: Output
 
-   Creating and solving simple LP problem...
+   Creating and solving simple MIP problem...
    Solving a problem with 2 constraints 2 variables (1 integers) and 4 nonzeros
    Objective offset 0.000000 scaling_factor 1.000000
    After trivial presolve updated 2 constraints 2 variables

--- a/docs/cuopt/source/cuopt-c/mip/mip-examples.rst
+++ b/docs/cuopt/source/cuopt-c/mip/mip-examples.rst
@@ -1,11 +1,11 @@
-MILP C API Examples
+MIP C API Examples
 ===================
 
 
 Example With Data
 -----------------
 
-This example demonstrates how to use the MILP solver in C. More details on the API can be found in :doc:`MIP C API <mip-c-api>`.
+This example demonstrates how to use the MIP solver in C. More details on the API can be found in :doc:`MIP C API <mip-c-api>`.
 
 The example code is available at ``../lp-milp/examples/simple_milp_example.c`` (:download:`download <examples/simple_milp_example.c>`):
 
@@ -98,7 +98,7 @@ If you have built it locally, libcuopt.so will be in the build directory ``cpp/b
    # Find the libcuopt library directory and assign to LIBCUOPT_LIBRARY_PATH
    LIBCUOPT_LIBRARY_PATH=$(dirname $(find / -name "libcuopt.so" 2>/dev/null))
 
-A sample MILP MPS file (:download:`download mip_sample.mps <https://raw.githubusercontent.com/coin-or/SYMPHONY/master/Datasets/sample.mps>`):
+A sample MIP MPS file (:download:`download mip_sample.mps <https://raw.githubusercontent.com/coin-or/SYMPHONY/master/Datasets/sample.mps>`):
 
 .. literalinclude:: examples/mip_sample.mps
    :language: text

--- a/docs/cuopt/source/cuopt-c/quick-start.rst
+++ b/docs/cuopt/source/cuopt-c/quick-start.rst
@@ -2,7 +2,7 @@
 Quickstart Guide
 =================
 
-NVIDIA cuOpt provides C API for LP, QP and MILP. This section will show you how to install cuOpt C API and how to use it to solve LP, QP and MILP problems.
+NVIDIA cuOpt provides C API for LP, QP and MIP. This section will show you how to install cuOpt C API and how to use it to solve LP, QP and MIP problems.
 
 
 Installation

--- a/docs/cuopt/source/cuopt-cli/examples/lp/examples/basic_lp_example.sh
+++ b/docs/cuopt/source/cuopt-cli/examples/lp/examples/basic_lp_example.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Basic LP Example using cuopt_cli
 #
 # This example demonstrates how to solve a simple LP problem using cuopt_cli.
-# cuopt_cli is a standalone command-line tool that solves LP/MILP problems
+# cuopt_cli is a standalone command-line tool that solves LP/MIP problems
 # from MPS files without requiring a server.
 #
 # Requirements:

--- a/docs/cuopt/source/cuopt-cli/examples/milp/examples/basic_milp_example.sh
+++ b/docs/cuopt/source/cuopt-cli/examples/milp/examples/basic_milp_example.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Basic MILP Example using cuopt_cli
+# Basic MIP Example using cuopt_cli
 #
 # This example demonstrates how to solve a Mixed Integer Programming (MIP)
 # problem using cuopt_cli. The main difference from LP is that variables
@@ -12,7 +12,7 @@
 #   - cuopt_cli installed and available in PATH
 #
 
-# Create MILP problem MPS file
+# Create MIP problem MPS file
 echo "* Optimal solution -28
 NAME          MIP_SAMPLE
 ROWS

--- a/docs/cuopt/source/cuopt-cli/index.rst
+++ b/docs/cuopt/source/cuopt-cli/index.rst
@@ -1,7 +1,7 @@
 Command Line Interface
 ======================
 
-The cuopt_cli is a command-line interface for LP/MILP solvers that accepts MPS, QPS, or LP format files as input models. The format is dispatched automatically from the file extension (case-insensitive): ``.lp`` (with optional ``.gz`` / ``.bz2``) goes to the LP parser, ``.mps`` / ``.qps`` (with optional ``.gz`` / ``.bz2``) goes to the MPS parser, and unknown extensions are rejected. It provides command-line arguments to control all solver settings and parameters when solving linear and mixed-integer programming problems.
+The cuopt_cli is a command-line interface for LP/MIP solvers that accepts MPS, QPS, or LP format files as input models. The format is dispatched automatically from the file extension (case-insensitive): ``.lp`` (with optional ``.gz`` / ``.bz2``) goes to the LP parser, ``.mps`` / ``.qps`` (with optional ``.gz`` / ``.bz2``) goes to the MPS parser, and unknown extensions are rejected. It provides command-line arguments to control all solver settings and parameters when solving linear and mixed-integer programming problems.
 
 The cuOpt MIP solver is in **beta** and under active development. The solver
 currently excels at finding high-quality feasible solutions quickly with

--- a/docs/cuopt/source/cuopt-cli/index.rst
+++ b/docs/cuopt/source/cuopt-cli/index.rst
@@ -1,7 +1,7 @@
 Command Line Interface
 ======================
 
-The cuopt_cli is a command-line interface for LP/MIP solvers that accepts MPS, QPS, or LP format files as input models. The format is dispatched automatically from the file extension (case-insensitive): ``.lp`` (with optional ``.gz`` / ``.bz2``) goes to the LP parser, ``.mps`` / ``.qps`` (with optional ``.gz`` / ``.bz2``) goes to the MPS parser, and unknown extensions are rejected. It provides command-line arguments to control all solver settings and parameters when solving linear and mixed-integer programming problems.
+The cuopt_cli is a command-line interface for LP/QP/MIP solvers that accepts MPS, QPS, or LP format files as input models. The format is dispatched automatically from the file extension (case-insensitive): ``.lp`` (with optional ``.gz`` / ``.bz2``) goes to the LP parser, ``.mps`` / ``.qps`` (with optional ``.gz`` / ``.bz2``) goes to the MPS parser, and unknown extensions are rejected. It provides command-line arguments to control all solver settings and parameters when solving linear and mixed-integer programming problems.
 
 The cuOpt MIP solver is in **beta** and under active development. The solver
 currently excels at finding high-quality feasible solutions quickly with

--- a/docs/cuopt/source/cuopt-python/convex/convex-examples.rst
+++ b/docs/cuopt/source/cuopt-python/convex/convex-examples.rst
@@ -247,7 +247,7 @@ Working with PDLP Warmstart Data
 Warmstart data allows to restart PDLP with a previous solution context. This should be used when you solve a new problem which is similar to the previous one.
 
 .. note::
-    Warmstart data is only available for Linear Programming (LP) problems, not for Mixed Integer Linear Programming (MILP) problems.
+    Warmstart data is only available for Linear Programming (LP) problems, not for Mixed Integer Programming (MIP) problems.
 
 :download:`pdlp_warmstart_example.py <examples/pdlp_warmstart_example.py>`
 

--- a/docs/cuopt/source/cuopt-python/convex/examples/pdlp_warmstart_example.py
+++ b/docs/cuopt/source/cuopt-python/convex/examples/pdlp_warmstart_example.py
@@ -16,7 +16,7 @@ previous one.
 
 Note:
     Warmstart data is only available for Linear Programming (LP) problems,
-    not for Mixed Integer Linear Programming (MILP) problems.
+    not for Mixed Integer Programming (MIP) problems.
 
 Problem 1:
     Maximize: 2*x + y

--- a/docs/cuopt/source/cuopt-python/mip/examples/simple_milp_example.py
+++ b/docs/cuopt/source/cuopt-python/mip/examples/simple_milp_example.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Mixed Integer Linear Programming Example
+Mixed Integer Programming Example
 
 This example demonstrates how to:
 - Create a mixed integer programming problem

--- a/docs/cuopt/source/cuopt-python/mip/mip-examples.rst
+++ b/docs/cuopt/source/cuopt-python/mip/mip-examples.rst
@@ -6,10 +6,10 @@ This section contains examples of how to use the cuOpt MIP Python API.
 
 .. note::
 
-    The examples in this section are not exhaustive. They are provided to help you get started with the cuOpt mixed integer linear programming Python API. For more examples, please refer to the `cuopt-examples GitHub repository <https://github.com/NVIDIA/cuopt-examples>`_.
+    The examples in this section are not exhaustive. They are provided to help you get started with the cuOpt mixed integer programming Python API. For more examples, please refer to the `cuopt-examples GitHub repository <https://github.com/NVIDIA/cuopt-examples>`_.
 
 
-Mixed Integer Linear Programming Example
+Mixed Integer Programming Example
 ----------------------------------------
 
 :download:`simple_milp_example.py <examples/simple_milp_example.py>`

--- a/docs/cuopt/source/cuopt-python/quick-start.rst
+++ b/docs/cuopt/source/cuopt-python/quick-start.rst
@@ -2,7 +2,7 @@
 Quickstart Guide
 =================
 
-NVIDIA cuOpt provides a Python API for routing optimization and LP/QP/MILP that enables users to solve complex optimization problems efficiently.
+NVIDIA cuOpt provides a Python API for routing optimization and LP/QP/MIP that enables users to solve complex optimization problems efficiently.
 
 Installation
 ============

--- a/docs/cuopt/source/cuopt-server/examples/lp-examples.rst
+++ b/docs/cuopt/source/cuopt-server/examples/lp-examples.rst
@@ -10,7 +10,7 @@ The following example showcases how to use the ``CuOptServiceSelfHostClient`` to
    paths still use batch solve today; check response ``warnings`` or logs for the
    deprecation notice.
 
-The OpenAPI specification for the server is available in :doc:`open-api spec <../../open-api>`. The example data is structured as per the OpenAPI specification for the server, please refer :doc:`LPData under "POST /cuopt/request" <../../open-api>` under schema section. LP and MILP share same spec.
+The OpenAPI specification for the server is available in :doc:`open-api spec <../../open-api>`. The example data is structured as per the OpenAPI specification for the server, please refer :doc:`LPData under "POST /cuopt/request" <../../open-api>` under schema section. LP and MIP share same spec.
 
 If you want to run server locally, please run the following command in a terminal or tmux session so you can test examples in another terminal.
 
@@ -151,7 +151,7 @@ Batch mode response:
     }
 
 .. note::
-    Warm start is only applicable to LP and not for MILP.
+    Warm start is only applicable to LP and not for MIP.
 
 .. _warm-start:
 
@@ -319,7 +319,7 @@ The ``data`` argument to ``get_LP_solve`` may be a dictionary of the format show
 Aborting a Running Job in Thin Client
 -------------------------------------
 
-Please refer to the :ref:`aborting-thin-client` in the MILP Example for more details.
+Please refer to the :ref:`aborting-thin-client` in the MIP Example for more details.
 
 
 =================================================
@@ -407,7 +407,7 @@ Warm Start in CLI
 To use a previous solution as the initial/warm start solution for a new request ID, you are required to save the previous solution, which can be accomplished use option ``-k``. Use the previous reqId in the next request as follows:
 
 .. note::
-    Warm start is only applicable to LP and not for MILP.
+    Warm start is only applicable to LP and not for MIP.
 
 .. code-block:: shell
 
@@ -434,7 +434,7 @@ In the case of batch mode, you can send a bunch of ``mps`` files at once, and ac
    :doc:`../../convex-features`.
 
 .. note::
-   Batch mode is not available for MILP problems.
+   Batch mode is not available for MIP problems.
 
 A sample MPS file (:download:`sample.mps <lp/examples/sample.mps>`):
 
@@ -455,7 +455,7 @@ Run the example:
 Aborting a Running Job In CLI
 -----------------------------
 
-Please refer to the :ref:`aborting-cli` in the MILP Example for more details.
+Please refer to the :ref:`aborting-cli` in the MIP Example for more details.
 
 .. note::
    Please use solver settings while using .mps files.

--- a/docs/cuopt/source/cuopt-server/examples/lp/examples/batch_mode_example.sh
+++ b/docs/cuopt/source/cuopt-server/examples/lp/examples/batch_mode_example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # LP Batch Mode CLI Example
@@ -7,7 +7,7 @@
 # This example demonstrates how to solve multiple LP problems in batch mode
 # using MPS files with the cuopt_sh CLI tool.
 #
-# Note: Batch mode works only with MPS files in CLI and is not available for MILP.
+# Note: Batch mode works only with MPS files in CLI and is not available for MIP.
 #
 # Requirements:
 #   - cuOpt server running on localhost:5000
@@ -52,4 +52,4 @@ echo "=== Solving Multiple MPS Files in Batch Mode ==="
 cuopt_sh "$mps_file" "$mps_file" "$mps_file" -t LP -i $ip -p $port -ss '{"tolerances": {"optimality": 0.0001}, "time_limit": 5}'
 
 echo ""
-echo "Note: Batch mode is only available for LP with MPS files, not for MILP."
+echo "Note: Batch mode is only available for LP with MPS files, not for MIP."

--- a/docs/cuopt/source/cuopt-server/examples/lp/examples/warmstart_example.py
+++ b/docs/cuopt/source/cuopt-server/examples/lp/examples/warmstart_example.py
@@ -8,7 +8,7 @@ Warmstart allows reusing solution context from a previous solve to speed up
 solving of similar problems.
 
 Note:
-    Warmstart is only applicable to LP, not for MILP.
+    Warmstart is only applicable to LP, not for MIP.
 
 Important:
     To use warm start with PDLP, presolve must be explicitly disabled.

--- a/docs/cuopt/source/cuopt-server/examples/lp/examples/warmstart_example.sh
+++ b/docs/cuopt/source/cuopt-server/examples/lp/examples/warmstart_example.sh
@@ -7,7 +7,7 @@
 # This example demonstrates how to use a previous solution as warmstart
 # for a new LP request using the cuopt_sh CLI tool.
 #
-# Note: Warmstart is only applicable to LP, not for MILP.
+# Note: Warmstart is only applicable to LP, not for MIP.
 #
 # Requirements:
 #   - cuOpt server running on localhost:5000
@@ -77,4 +77,4 @@ cuopt_sh data.json -t LP -i $ip -p $port -wid $reqId
 rm -f data.json
 
 echo ""
-echo "Note: Warmstart is only supported for LP problems, not MILP."
+echo "Note: Warmstart is only supported for LP problems, not MIP."

--- a/docs/cuopt/source/cuopt-server/examples/milp-examples.rst
+++ b/docs/cuopt/source/cuopt-server/examples/milp-examples.rst
@@ -1,9 +1,9 @@
 ========================================
-MILP Python Examples
+MIP Python Examples
 ========================================
 
 The major difference between this example and the LP example is that some of the variables are integers, so ``variable_types`` need to be shared.
-The OpenAPI specification for the server is available in :doc:`open-api spec <../../open-api>`. The example data is structured as per the OpenAPI specification for the server, please refer :doc:`LPData data under "POST /cuopt/request" <../../open-api>` under schema section. LP and MILP share same spec.
+The OpenAPI specification for the server is available in :doc:`open-api spec <../../open-api>`. The example data is structured as per the OpenAPI specification for the server, please refer :doc:`LPData data under "POST /cuopt/request" <../../open-api>` under schema section. LP and MIP share same spec.
 
 Generic Example
 ---------------
@@ -64,7 +64,7 @@ Incumbent and Logging Callback
 The incumbent solution can be retrieved using a callback function as follows:
 
 .. note::
-    Incumbent solution callback is only applicable to MILP.
+    Incumbent solution callback is only applicable to MIP.
     The callback bound can be ``None`` when the solver has found an incumbent
     but no finite global bound is available yet.
 
@@ -136,7 +136,7 @@ Incumbent callback response:
 
 An example with DataModel is available in the `Examples Notebooks Repository <https://github.com/NVIDIA/cuopt-examples>`_.
 
-The ``data`` argument to ``get_LP_solve`` may be a dictionary of the format shown in :doc:`MILP Open-API spec <../../open-api>`. More details on the response can be found under responses schema in :doc:`"/cuopt/request" and "/cuopt/solution" API spec <../../open-api>`.
+The ``data`` argument to ``get_LP_solve`` may be a dictionary of the format shown in :doc:`MIP Open-API spec <../../open-api>`. More details on the response can be found under responses schema in :doc:`"/cuopt/request" and "/cuopt/solution" API spec <../../open-api>`.
 They can be of different format as well, please check the documentation.
 
 
@@ -152,10 +152,10 @@ Aborting a Running Job in Thin Client
    :linenos:
 
 ========================================
-MILP CLI Examples
+MIP CLI Examples
 ========================================
 
-Generic MILP Example
+Generic MIP Example
 ---------------------
 
 The only difference between this example and the prior LP example would be the variable types provided in data.
@@ -208,7 +208,7 @@ In case the user needs to update solver settings through CLI, the option ``-ss``
    cuopt_sh data.json -t LP -i $ip -p $port -ss '{"time_limit": 5}'
 
 .. note::
-   Batch mode is not supported for MILP.
+   Batch mode is not supported for MIP.
 
 .. _aborting-cli:
 

--- a/docs/cuopt/source/cuopt-server/examples/milp/examples/abort_job_example.py
+++ b/docs/cuopt/source/cuopt-server/examples/milp/examples/abort_job_example.py
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Aborting a Running MILP Job Example
+Aborting a Running MIP Job Example
 
 This example demonstrates how to abort a running or queued job on the cuOpt server.
 This is useful when:
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # Example usage - in practice, you would get the UUID from a previous job submission
     print("This is a template example.")
     print("To use this:")
-    print("1. Submit a MILP job and get its UUID")
+    print("1. Submit a MIP job and get its UUID")
     print("2. Replace '<UUID_THAT_WE_GOT>' in this file with that UUID")
     print("3. Run this script to abort the job")
 

--- a/docs/cuopt/source/cuopt-server/examples/milp/examples/abort_job_example.sh
+++ b/docs/cuopt/source/cuopt-server/examples/milp/examples/abort_job_example.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # TEST_SKIP: This is a template file requiring manual configuration
 #
-# Abort Running MILP Job CLI Example
+# Abort Running MIP Job CLI Example
 #
 # This example demonstrates how to abort a running or queued job
 # using the cuopt_sh CLI tool.
@@ -34,6 +34,6 @@ cuopt_sh -d -r -q $UUID -i $ip -p $port
 echo "Job abort request sent"
 echo ""
 echo "Note: This is a template. To use:"
-echo "1. Start a MILP job and note its UUID from the response"
+echo "1. Start a MIP job and note its UUID from the response"
 echo "2. Replace <UUID_THAT_WE_GOT> in this script with that UUID"
 echo "3. Run this script while the job is running or queued"

--- a/docs/cuopt/source/cuopt-server/examples/milp/examples/basic_milp_example.py
+++ b/docs/cuopt/source/cuopt-server/examples/milp/examples/basic_milp_example.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-Basic MILP Server Example
+Basic MIP Server Example
 
 This example demonstrates how to use the cuOpt Self-Hosted Service Client
-to solve MILP (Mixed Integer Linear Programming) problems via the cuOpt server.
+to solve MIP (Mixed Integer Programming) problems via the cuOpt server.
 
 The major difference between this example and the LP example is that some of
 the variables are integers, so 'variable_types' need to be specified.
@@ -66,8 +66,8 @@ def repoll(cuopt_service_client, solution, repoll_tries):
 
 
 def main():
-    """Run the basic MILP example."""
-    # Example data for MILP problem
+    """Run the basic MIP example."""
+    # Example data for MIP problem
     # The data is structured as per the OpenAPI specification for the server
     data = {
         "csr_constraint_matrix": {
@@ -96,7 +96,7 @@ def main():
         ip="localhost", port=5000, polling_timeout=25, timeout_exception=False
     )
 
-    print("=== Solving MILP Problem ===")
+    print("=== Solving MIP Problem ===")
     solution = cuopt_service_client.get_LP_solve(data, response_type="dict")
 
     # Number of repoll requests to be carried out for a successful response

--- a/docs/cuopt/source/cuopt-server/examples/milp/examples/basic_milp_example.sh
+++ b/docs/cuopt/source/cuopt-server/examples/milp/examples/basic_milp_example.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Basic MILP CLI Example
+# Basic MIP CLI Example
 #
 # This example demonstrates how to use the cuopt_sh CLI tool to solve
-# a simple MILP (Mixed Integer Linear Programming) problem.
+# a simple MIP (Mixed Integer Programming) problem.
 #
 # The main difference from LP is the variable_types field specifying
 # integer variables.
@@ -19,7 +19,7 @@
 export ip="localhost"
 export port=5000
 
-# Create MILP data file
+# Create MIP data file
 echo '{
     "csr_constraint_matrix": {
         "offsets": [0, 2, 4],
@@ -48,7 +48,7 @@ echo '{
  }' > data.json
 
 # Invoke the CLI
-# -t LP: Problem type (same for MILP)
+# -t LP: Problem type (same for MIP)
 # -i: IP address
 # -p: Port
 # -sl: Show logs

--- a/docs/cuopt/source/cuopt-server/examples/milp/examples/incumbent_callback_example.py
+++ b/docs/cuopt/source/cuopt-server/examples/milp/examples/incumbent_callback_example.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-MILP Incumbent and Logging Callback Example
+MIP Incumbent and Logging Callback Example
 
 This example demonstrates how to use callbacks with the cuOpt server:
 - Incumbent solution callback: Receives intermediate solutions as they're found
 - Logging callback: Receives solver log messages in real-time
 
 Note:
-    Incumbent solution callback is only applicable to MILP, not for LP.
+    Incumbent solution callback is only applicable to MIP, not for LP.
 
 Requirements:
     - cuOpt server running (default: localhost:5000)
@@ -78,7 +78,7 @@ def main():
         for i in log:
             print("server-log: ", i)
 
-    print("=== Solving MILP with Callbacks ===")
+    print("=== Solving MIP with Callbacks ===")
     print("\n--- Logging Output ---")
 
     solution = cuopt_service_client.get_LP_solve(

--- a/docs/cuopt/source/cuopt-server/examples/routing-examples.rst
+++ b/docs/cuopt/source/cuopt-server/examples/routing-examples.rst
@@ -277,7 +277,7 @@ Users can also upload a solution which might have been saved for later runs.
 Aborting a Running Job In CLI
 -----------------------------
 
-Please refer to the :ref:`aborting-cli` for more in MILP Example.
+Please refer to the :ref:`aborting-cli` for more in MIP Example.
 
 .. note::
    Please use solver settings while using .mps files.

--- a/docs/cuopt/source/cuopt-server/examples/routing-examples.rst
+++ b/docs/cuopt/source/cuopt-server/examples/routing-examples.rst
@@ -277,7 +277,7 @@ Users can also upload a solution which might have been saved for later runs.
 Aborting a Running Job In CLI
 -----------------------------
 
-Please refer to the :ref:`aborting-cli` for more in MIP Example.
+Please refer to the :ref:`aborting-cli` in the MIP examples for more details.
 
 .. note::
    Please use solver settings while using .mps files.

--- a/docs/cuopt/source/faq.rst
+++ b/docs/cuopt/source/faq.rst
@@ -433,7 +433,7 @@ Mixed Integer Programming FAQs
 
 .. dropdown:: What are the limitations of the MIP solver?
 
-    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MIP or LP, except the restrictions due to the number of bits in integer and the amount of memory in the CPU and GPU.
+    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MIP or LP, except the restrictions due to the number of bits in an integer and the amount of memory in the CPU and GPU.
 
     Depending on these factors, the problems that can be solved can vary, for example:
 

--- a/docs/cuopt/source/faq.rst
+++ b/docs/cuopt/source/faq.rst
@@ -401,7 +401,7 @@ Linear Programming FAQs
 
 .. dropdown:: What are the limitations of the LP solver?
 
-    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MILP or LP, except the restrictions due to the number of bits in an integer and the amount of memory in the CPU and GPU.
+    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MIP or LP, except the restrictions due to the number of bits in an integer and the amount of memory in the CPU and GPU.
 
     Depending on these factors, the problems that can be solved can vary, for example:
 
@@ -419,7 +419,7 @@ Linear Programming FAQs
     This is required because presolve transforms the problem, and the warm start solution from the original problem
     cannot be applied to the presolved problem.
 
-Mixed Integer Linear Programming FAQs
+Mixed Integer Programming FAQs
 --------------------------------------
 
 .. dropdown:: How do I run the MIP solver with cuOpt?
@@ -431,9 +431,9 @@ Mixed Integer Linear Programming FAQs
     heuristics. Proving feasible solutions optimal remains under active
     development.
 
-.. dropdown:: What are the limitations of the MILP solver?
+.. dropdown:: What are the limitations of the MIP solver?
 
-    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MILP or LP, except the restrictions due to the number of bits in integer and the amount of memory in the CPU and GPU.
+    #. There is no inherit limit imposed on the number of variables, number of constraints, or number of non-zeros you can have in a MIP or LP, except the restrictions due to the number of bits in integer and the amount of memory in the CPU and GPU.
 
     Depending on these factors, the problems that can be solved can vary, for example:
 

--- a/docs/cuopt/source/hidden/limitations.rst
+++ b/docs/cuopt/source/hidden/limitations.rst
@@ -32,7 +32,7 @@ Linear Programming
    - 10M rows/constraints 10M columns/variables and 2B non-zeros in the constraint matrix
    - 74.5M rows/constraints 74.5M columns/variables and 1.49B non-zeros in the constraint matrix
 
-Mixed Integer Linear Programming
+Mixed Integer Programming
 ================================
 
 -  Number of non-zeros/coefficient matrix size supported

--- a/docs/cuopt/source/milp-features.rst
+++ b/docs/cuopt/source/milp-features.rst
@@ -1,5 +1,5 @@
 ====================
-MILP Features
+MIP Features
 ====================
 
 Availability
@@ -10,9 +10,9 @@ currently excels at finding high-quality feasible solutions quickly with
 GPU-accelerated primal heuristics. Proving feasible solutions optimal remains
 under active development.
 
-The MILP solver can be accessed in the following ways:
+The MIP solver can be accessed in the following ways:
 
-- **Third-Party Modeling Languages**: cuOpt's LP and MILP solver can be called directly from the following third-party modeling languages. This allows you to leverage GPU acceleration while maintaining your existing optimization workflow in these modeling languages.
+- **Third-Party Modeling Languages**: cuOpt's LP and MIP solver can be called directly from the following third-party modeling languages. This allows you to leverage GPU acceleration while maintaining your existing optimization workflow in these modeling languages.
 
   Currently supported solvers:
    - AMPL
@@ -21,11 +21,11 @@ The MILP solver can be accessed in the following ways:
    - JuMP
    - Pyomo
 
-- **C API**: A native C API that provides direct low-level access to cuOpt's MILP solver, enabling integration into any application or system that can interface with C.
+- **C API**: A native C API that provides direct low-level access to cuOpt's MIP solver, enabling integration into any application or system that can interface with C.
 
-- **Python SDK**: A Python package that provides direct access to cuOpt's MILP capabilities through a simple, intuitive API. This allows for seamless integration into Python applications and workflows. For more information, see :doc:`cuopt-python/quick-start`.
+- **Python SDK**: A Python package that provides direct access to cuOpt's MIP capabilities through a simple, intuitive API. This allows for seamless integration into Python applications and workflows. For more information, see :doc:`cuopt-python/quick-start`.
 
-- **As a Self-Hosted Service**: cuOpt's MILP solver can be deployed in your own infrastructure, enabling you to maintain full control while integrating it into your existing systems.
+- **As a Self-Hosted Service**: cuOpt's MIP solver can be deployed in your own infrastructure, enabling you to maintain full control while integrating it into your existing systems.
 
 Each option provides the same mixed-integer optimization capabilities while offering flexibility in deployment and integration.
 
@@ -39,7 +39,7 @@ Constraints
 
 The constraint matrix is specified in `Compressed Sparse Row (CSR) format  <https://docs.nvidia.com/cuda/cusparse/#compressed-sparse-row-csr>`_.
 
-There are two ways to specify constraints in cuOpt MILP:
+There are two ways to specify constraints in cuOpt MIP:
 
 1. Using row_type and right-hand side:
 
@@ -67,7 +67,7 @@ When using the service, users can provide a callback to receive new integer feas
 Logging
 -------
 
-The CUOPT_LOG_FILE parameter can be set to write detailed solver logs for MILP problems. This parameter is available in all APIs that allow setting solver parameters except for the cuOpt service. For the service, see the logging callback below.
+The CUOPT_LOG_FILE parameter can be set to write detailed solver logs for MIP problems. This parameter is available in all APIs that allow setting solver parameters except for the cuOpt service. For the service, see the logging callback below.
 
 Logging Callback in the Service
 -------------------------------

--- a/docs/cuopt/source/mip-settings.rst
+++ b/docs/cuopt/source/mip-settings.rst
@@ -11,7 +11,7 @@ This page describes the parameter settings available for cuOpt's MIP solver. The
 Common Parameters
 -----------------
 
-We begin by describing parameters common to both the MILP and LP solvers.
+We begin by describing parameters common to both the MIP and LP solvers.
 
 
 Time Limit
@@ -75,7 +75,7 @@ Dual Postsolve
 ``CUOPT_DUAL_POSTSOLVE`` controls whether dual postsolve is enabled when using Papilo presolver for LP problems. Disabling dual postsolve can improve solve time at the expense of not having
 access to the dual solution. Enabled by default for LP when Papilo presolve is selected. This is not relevant for MIP problems.
 
-Mixed Integer Linear Programming
+Mixed Integer Programming
 ---------------------------------
 
 The cuOpt MIP solver is in **beta** and under active development. The solver
@@ -83,7 +83,7 @@ currently excels at finding high-quality feasible solutions quickly with
 GPU-accelerated primal heuristics. Proving feasible solutions optimal remains
 under active development.
 
-We now describe parameter settings for the MILP solver.
+We now describe parameter settings for the MIP solver.
 
 
 Heuristics Only
@@ -158,7 +158,7 @@ gap is infinity.
 Node Limit
 ^^^^^^^^^^
 
-``CUOPT_NODE_LIMIT`` controls the maximum number of branch-and-bound nodes the MILP solver will explore before stopping and returning the current best feasible solution (if any). If set along with the time limit, cuOpt stops at whichever limit is hit first.
+``CUOPT_NODE_LIMIT`` controls the maximum number of branch-and-bound nodes the MIP solver will explore before stopping and returning the current best feasible solution (if any). If set along with the time limit, cuOpt stops at whichever limit is hit first.
 
 .. note:: By default there is no node limit.
 

--- a/docs/cuopt/source/resources.rst
+++ b/docs/cuopt/source/resources.rst
@@ -13,7 +13,7 @@ cuOpt Examples and Tutorials Videos
 .. dropdown:: Tutorial List
 
     - `Quick Start to GPU-Accelerated Large-Scale Logistics and Supply Chain Optimization with NVIDIA cuOpt <https://www.youtube.com/watch?v=CVtqcUmW9nU>`_
-    - `Accelerated MILP for Supply Chain, Logistics & Planning Optimization — Quick Start with NVIDIA cuOpt <https://www.youtube.com/watch?v=jnDPQeUO0CM>`_
+    - `Accelerated MIP for Supply Chain, Logistics & Planning Optimization — Quick Start with NVIDIA cuOpt <https://www.youtube.com/watch?v=jnDPQeUO0CM>`_
     - `Solving Vehicle Routing Problems — Hands-On with Open Source NVIDIA cuOpt <https://www.youtube.com/watch?v=kSATyJrELUI>`_
 
 


### PR DESCRIPTION
We refer to both MILP and MIP in the documentation, so we decided to normalize around MIP everywhere.

Left a few references changed separately in #1653

