### PR TITLE
Remove deprecated `solve-by-pdlp` attribute in Python API

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 ### Breaking Changes (26.08)
 
 - Routing `DataModel` now defers GPU device construction to solve time; applications that accessed device-side data between `DataModel` construction and the solve call must be updated
+- Removed the deprecated `get_solved_by_pdlp()` method from the Python LP solution object; use `get_solved_by()` instead
 
 ### Improvements (26.08)
 - Include Q matrix in Ruiz scaling to improve convergence

--- a/python/cuopt/cuopt/linear_programming/solution/solution.py
+++ b/python/cuopt/cuopt/linear_programming/solution/solution.py
@@ -306,19 +306,6 @@ class Solution:
         """
         return self.solve_time
 
-    def get_solved_by_pdlp(self):
-        from warnings import warn
-
-        warn(
-            "get_solved_by_pdlp() will be deprecated in 26.08. Use get_solved_by() instead. ",
-            DeprecationWarning,
-        )
-
-        """
-        Returns whether the problem was solved by PDLP or not.
-        """
-        return self.solved_by == SolverMethod.PDLP
-
     def get_solved_by(self):
         """
         Returns whether the LP was solved by Dual Simplex, PDLP or Barrier. See SolverMethod for all possible values.


### PR DESCRIPTION
Remove deprecated `solve-by-pdlp` attribute in Python API. It was deprecated since 26.02.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
