### PR TITLE
Add iterative refinement to the GPU ADAT solve path

### DIFF
--- a/benchmarks/linear_programming/run_mps_files.sh
+++ b/benchmarks/linear_programming/run_mps_files.sh
@@ -360,7 +360,7 @@ else
         mapfile -t mps_files < <(find "$MPS_DIR" -type f \( -name "*.mps" -o -name "*.MPS" -o -name "*.SIF" \) | sort)
     else
         # Gather .mps/.MPS and .SIF files in the directory
-        mapfile -t mps_files < <(ls "$MPS_DIR"/*.mps "$MPS_DIR"/*.MPS "$MPS_DIR"/*.SIF 2>/dev/null)
+        mapfile -t mps_files < <(ls "$MPS_DIR"/*.mps "$MPS_DIR"/*.MPS "$MPS_DIR"/*.SIF "$MPS_DIR"/*.mps.gz 2>/dev/null)
     fi
 
     echo "Found ${#mps_files[@]} .mps and .SIF files in $MPS_DIR"

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -1715,6 +1715,26 @@ class iteration_data_t {
     cusparse_view.spmv(alpha, cusparse_u, beta, cusparse_v);
   }
 
+  // v = alpha * A * Dinv * A^T * y + beta * v. Simple interface (plain device vectors,
+  // no pre-built cusparse descriptors) so it can be used as the `a_multiply` callback of
+  // the generic iterative-refinement operator for the ADAT (non-augmented) solve path.
+  void gpu_adat_multiply_simple(f_t alpha,
+                                const rmm::device_uvector<f_t>& y,
+                                f_t beta,
+                                rmm::device_uvector<f_t>& v)
+  {
+    const i_t n = A.n;
+    rmm::device_uvector<f_t> u(n, stream_view_);
+    cusparse_view_.transpose_spmv(1.0, y, 0.0, u);
+    cub::DeviceTransform::Transform(cuda::std::make_tuple(u.data(), d_inv_diag.data()),
+                                    u.data(),
+                                    u.size(),
+                                    cuda::std::multiplies<>{},
+                                    stream_view_.value());
+    RAFT_CHECK_CUDA(stream_view_);
+    cusparse_view_.spmv(alpha, u, beta, v);
+  }
+
   // v = alpha * A * Dinv * A^T * y + beta * v
   void adat_multiply(f_t alpha,
                      const dense_vector_t<i_t, f_t>& y,
@@ -2946,6 +2966,37 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       if (solve_status < 0) {
         settings.log.printf("Linear solve failed\n");
         return -1;
+      }
+
+      // Iterative refinement on the ADAT (Schur-complement) system using GMRES.
+      // The direct Cholesky solve can degrade in accuracy on ill-conditioned D near
+      // convergence, as the diagonal D can span many orders of magnitude with small
+      // barrier parameter. In this case, we launch a GMRES-based iterative refinement
+      // loop for added robustness in the Schur-complement (ADAT) approach.
+      // GMRES can handle large, potentially ill-conditioned systems better than simple Richardson
+      // or classical iterative refinement, at the potential cost of higher computational work and
+      // memory. This is only used on the pure Schur-complement (n_dense_columns == 0).
+      if (settings.barrier_iterative_refinement && data.n_dense_columns == 0) {
+        struct adat_op_t {
+          adat_op_t(iteration_data_t<i_t, f_t>& data) : data_(data) {}
+          iteration_data_t<i_t, f_t>& data_;
+          void a_multiply(f_t alpha,
+                          const rmm::device_uvector<f_t>& x,
+                          f_t beta,
+                          rmm::device_uvector<f_t>& y) const
+          {
+            data_.gpu_adat_multiply_simple(alpha, x, beta, y);
+          }
+          void solve(rmm::device_uvector<f_t>& b, rmm::device_uvector<f_t>& x) const
+          {
+            data_.gpu_solve_adat(b, x);
+          }
+        } adat_op(data);
+        const f_t adat_solve_err =
+          iterative_refinement<i_t, f_t, adat_op_t>(adat_op, data.d_h_, data.d_dy_);
+        if (adat_solve_err > 1e-1) {
+          settings.log.printf("||ADAT*dy - h|| %e after IR\n", adat_solve_err);
+        }
       }
     }  // Close NVTX range
 


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

Adds iterative refinement to the GPU ADAT (Schur-complement) solve path in the barrier solver

**Changes:**
- Implement a simple ADAT matvec (gpu_adat_multiply_simple) that does not rely on pre-allocated cuSPARSE descriptors
- Apply GMRES-based iterative refinement after the ADAT Cholesky solve (Hiverge proposed Richardson-style; GMRES chosen based on our experiments for better robustness)
- Improves accuracy when the diagonal scaling D becomes ill-conditioned near convergence
- Previously only the augmented-KKT path had iterative refinement; the ADAT path had none

**Motivation:**
As the barrier parameter shrinks, D spans huge magnitude ranges and the direct Cholesky solve alone can degrade. Refining the ADAT solution improves robustness on ill-conditioned LP/QP instances without affecting the SOCP path (which does not use the Schur-complement formulation).

**Benchmarks:**
- **LP Barrier (10 min)**: Optimal 32 → 34, suboptimal 3 → 4, unsolved 14 → 11. 9% geometric mean speedup.
- **QP (Maros):** All 136 problems solved (131 optimal, 5 suboptimal); previously 130 optimal, 2 suboptimal, 4 failures.  27% geometric mean speedup.
- **QCQP:** bdry3 goes from suboptimal → optimal. No performance change.
- **SOCP:** Slight differences possibly from code perturbation; this change is inactive for SOCP (Schur-complement path only).

**Acknowledgment:** This improvement was proposed by the [Hiverge](https://www.hiverge.ai/) AI discovery engine with experiments by [@kerry-hiverge](https://github.com/kerry-hiverge).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
