### PR TITLE
fix: add statuses: read permission to request-nvskills-ci workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

The called workflow `NVIDIA/skills/.github/workflows/team-request.yml@main` requests `statuses: read`, but the job's `permissions` block did not grant it, causing the workflow validation error:

> Error calling workflow ... The nested job 'require-nvskills-ci' is requesting 'statuses: read', but is only allowed 'statuses: none'.

Adds `statuses: read` to the `request` job permissions.

## Testing

Workflow file passes `yamllint` and `zizmor` pre-commit hooks.

## Docs

No doc changes needed.