### PR TITLE
docs: fix Vale heading case errors in gRPC async client docs

### DIFF
--- a/docs/cuopt/source/cuopt-grpc/index.rst
+++ b/docs/cuopt/source/cuopt-grpc/index.rst
@@ -36,7 +36,7 @@ This is **not** the HTTP/JSON :doc:`REST self-hosted server <../cuopt-server/ind
 (FastAPI). REST is for arbitrary HTTP clients; gRPC serves remote execution
 (client integrated into the solver APIs) and explicit gRPC clients.
 
-When to choose which path
+When to Choose Which Path
 =========================
 
 * **Remote execution** — drop-in remote solves with no code changes; same

--- a/docs/cuopt/source/cuopt-grpc/python-async-client-api.rst
+++ b/docs/cuopt/source/cuopt-grpc/python-async-client-api.rst
@@ -40,7 +40,7 @@ Exceptions
    :members:
    :show-inheritance:
 
-See also
+See Also
 =========
 
 * :doc:`python-async-client` — overview and when to use this client

--- a/docs/cuopt/source/cuopt-grpc/python-async-client.rst
+++ b/docs/cuopt/source/cuopt-grpc/python-async-client.rst
@@ -87,7 +87,7 @@ TLS / mTLS
 See :doc:`advanced` for server-side TLS and which environment variables apply
 to remote execution versus this gRPC client.
 
-Next steps
+Next Steps
 ==========
 
 * :doc:`python-async-client-examples` — log streaming and incumbent streaming


### PR DESCRIPTION
## Summary

Fixes three heading case errors flagged by the Vale prose linter (added in #1668) in docs that were merged in #1653 before Vale was introduced.

- `python-async-client-api.rst`: `See also` → `See Also`
- `index.rst`: `When to choose which path` → `When to Choose Which Path`
- `python-async-client.rst`: `Next steps` → `Next Steps`

These errors are currently blocking check-style on every open PR.

## Testing

Pre-commit passes on all three files.

## Docs

Heading text only — no content change.