### PR TITLE
Fix crash when symmetry generators are pruned

### DIFF
--- a/cpp/src/branch_and_bound/symmetry.hpp
+++ b/cpp/src/branch_and_bound/symmetry.hpp
@@ -319,7 +319,7 @@ class orbital_fixing_t {
       node = node->parent;
     }
 
-    surviving_generators_.resize(max_generators_);
+    surviving_generators_.resize(symmetry->num_generators);
     std::iota(surviving_generators_.begin(), surviving_generators_.end(), 0);
 
     // Seed cumulative fixings from the parent's stored orbital fixings.


### PR DESCRIPTION
If the symmetry generators are pruned from one restart to the next, `surviving_generators_` will store the incorrect set of indexes and cause a `out-of-bound` memory access.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
