### PR TITLE
Fix dual residual computation in final solution output

### DIFF
--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -1374,6 +1374,7 @@ class iteration_data_t {
     dense_vector_t<i_t, f_t> dual_res = z_tilde;
     dual_res.axpy(-1.0, lp.objective, 1.0);
     cusparse_view.transpose_spmv(1.0, solution.y, 1.0, dual_res);
+    if (Q.n > 0) { matrix_vector_multiply(Q, -1.0, x, 1.0, dual_res); }
     f_t dual_residual_norm = vector_norm_inf<i_t, f_t>(dual_res, stream_view_);
 #ifdef PRINT_INFO
     settings_.log.printf("Solution Dual residual: %e\n", dual_residual_norm);

--- a/cpp/tests/qp/unit_tests/lp_parser_solve_test.cu
+++ b/cpp/tests/qp/unit_tests/lp_parser_solve_test.cu
@@ -206,16 +206,11 @@ End
                           {4.0, 2.0});
 }
 
-// Regression test for issue #1598: l2_dual_residual dropped the Q*x term,
-// so an optimal QP solution reported a large spurious dual residual instead
-// of a value near zero. Reuses the qp_diagonal_only problem above.
-//
-// Minimize x1^2 + 4 x2^2 - 8 x1 - 16 x2 s.t. x1 + x2 >= 5, 0 <= x1, x2 <= 10.
-// Optimum (4, 2), obj = -32.
+// Dual residual check for QP.
 TEST(lp_parser_solve, qp_diagonal_only_dual_residual)
 {
   raft::handle_t handle;
-  auto problem = io::read_lp_from_string<int, double>(R"LP(
+  auto problem  = io::read_lp_from_string<int, double>(R"LP(
 Minimize
   obj: -8 x1 - 16 x2 + [ 2 x1 ^ 2 + 8 x2 ^ 2 ] / 2
 Subject To

--- a/cpp/tests/qp/unit_tests/lp_parser_solve_test.cu
+++ b/cpp/tests/qp/unit_tests/lp_parser_solve_test.cu
@@ -206,4 +206,31 @@ End
                           {4.0, 2.0});
 }
 
+// Regression test for issue #1598: l2_dual_residual dropped the Q*x term,
+// so an optimal QP solution reported a large spurious dual residual instead
+// of a value near zero. Reuses the qp_diagonal_only problem above.
+//
+// Minimize x1^2 + 4 x2^2 - 8 x1 - 16 x2 s.t. x1 + x2 >= 5, 0 <= x1, x2 <= 10.
+// Optimum (4, 2), obj = -32.
+TEST(lp_parser_solve, qp_diagonal_only_dual_residual)
+{
+  raft::handle_t handle;
+  auto problem = io::read_lp_from_string<int, double>(R"LP(
+Minimize
+  obj: -8 x1 - 16 x2 + [ 2 x1 ^ 2 + 8 x2 ^ 2 ] / 2
+Subject To
+  c1: x1 + x2 >= 5
+Bounds
+  0 <= x1 <= 10
+  0 <= x2 <= 10
+End
+)LP");
+  auto settings = pdlp_solver_settings_t<int, double>();
+  auto solution = solve_lp(&handle, problem, settings);
+
+  ASSERT_EQ(solution.get_termination_status(), pdlp_termination_status_t::Optimal);
+  EXPECT_NEAR(solution.get_objective_value(), -32.0, 1e-4);
+  EXPECT_NEAR(solution.get_additional_termination_information().l2_dual_residual, 0.0, 1e-4);
+}
+
 }  // namespace cuopt::mathematical_optimization


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
`get_lp_stats()` reported a spurious, large `l2_dual_residual` for QPs and SOCPs solved via the barrier path, even at a fully optimal solution. The final-solution dual residual computed in `iteration_data_t::to_solution()` (`cpp/src/barrier/barrier.cu`) omitted the `Q*x` quadratic term, computing only `‖Aᵀy + z − c‖` instead of `‖Aᵀy + z − c − Qx‖`.

Adds the missing `Q*x` term to the reported dual residual, mirroring the existing correct pattern used internally.

Also adds a regression test (`qp_diagonal_only_dual_residual`) that reuses the diagonal-Hessian QP problem from the linked issue and asserts `l2_dual_residual` is near zero at the known optimum.

## Issue
Closes #1598
