### PR TITLE
wheels: avoid vendoring libnvJitLink

### DIFF
--- a/ci/build_wheel_cuopt.sh
+++ b/ci/build_wheel_cuopt.sh
@@ -41,6 +41,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
   --exclude "libcuopt.so"
+  --exclude "libnvJitLink.so*"
   --exclude "librapids_logger.so"
   --exclude "librmm.so"
 )

--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -103,7 +103,7 @@ EXCLUDE_ARGS=(
   --exclude "libcusolver.so.*"
   --exclude "libcusparse.so.*"
   --exclude "libnccl.so.*"
-  --exclude "libnvJitLink*"
+  --exclude "libnvJitLink.so*"
   --exclude "librapids_logger.so"
   --exclude "librmm.so"
   # OpenSSL 3 is intentionally NOT bundled. Resolving libssl.so.3 / libcrypto.so.3

--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -76,7 +76,7 @@ select = [
 ]
 
 # PyPI hard limit is 1GiB, but try to keep this as small as possible
-max_allowed_size_compressed = '20Mi'
+max_allowed_size_compressed = '10Mi'
 
 [tool.pytest.ini_options]
 testpaths = ["cuopt/tests"]

--- a/python/cuopt/pyproject.toml
+++ b/python/cuopt/pyproject.toml
@@ -76,7 +76,7 @@ select = [
 ]
 
 # PyPI hard limit is 1GiB, but try to keep this as small as possible
-max_allowed_size_compressed = '55Mi'
+max_allowed_size_compressed = '20Mi'
 
 [tool.pytest.ini_options]
 testpaths = ["cuopt/tests"]


### PR DESCRIPTION
## Description

Noticed while reviewing #1731 and looking through logs... `cuopt-cu{12,13}` wheels are vendoring a copy of `libnvJitLink.so`.

```console
$ pydistcheck --inspect ./cuopt_*.whl
checking './cuopt_cu13-26.10.0a30.post260818050850-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl'
----- package inspection summary -----
file size
  * compressed size: 40.661M
  * uncompressed size: 99.188M
  * compression space saving: 59.0%
contents
  * directories: 25
  * files: 106 (10 compiled)
size by extension
  * .33 - 93.318M (94.1%)
  * .so - 5.188M (5.2%)
  * .py - 0.477M (0.5%)
  * .pyx - 0.136M (0.1%)
  * .pxd - 34.861K (0.0%)
  * no-extension - 23.259K (0.0%)
  * .md - 7.102K (0.0%)
  * .txt - 4.773K (0.0%)
  * .json - 1.647K (0.0%)
largest files
  * (93.318M) cuopt_cu13.libs/libnvJitLink-3ba1e744.so.13.3.33
  * (1.326M) cuopt/routing/vehicle_routing_wrapper.cpython-312-x86_64-linux-gnu.so
  * (1.167M) cuopt/routing/utils_wrapper.cpython-312-x86_64-linux-gnu.so
  * (1.092M) cuopt/distance_engine/waypoint_matrix_wrapper.cpython-312-x86_64-linux-gnu.so
  * (0.408M) cuopt/linear_programming/solver/solver_wrapper.cpython-312-x86_64-linux-gnu.so
```

That's unnecessary in 2 ways:

* `cuopt` doesn't directly use nvJitLink (`auditwheel` is probably picking that up as a transitive dependency coming from cusparse or similar)
* even if it did, it should get a copy from `nvidia-nvjitlink-cu{12,13}` wheels, not vendor one

This proposes removing that file from `cuopt` wheels and tightening the wheel-size limits to help prevent things like this from slipping through again.

## Issue

N/A

## Notes for Reviewers

### How I tested this

Check the `pydistcheck` output in CI logs from builds.

Saw wheel-testing CI pass.

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
- Documentation
   - [x] The documentation is up to date with these changes