### PR TITLE
Update cpp/benchmarks codeowners to cuopt-solver-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 *                  @nvidia/cuopt-infra-codeowners
 
 #cpp code owners
-cpp/               @nvidia/cuopt-engine-codeowners
-benchmarks/        @nvidia/cuopt-engine-codeowners
+cpp/               @nvidia/cuopt-solver-codeowners
+benchmarks/        @nvidia/cuopt-solver-codeowners
 
 #python code owners
 python/            @nvidia/cuopt-infra-codeowners


### PR DESCRIPTION
## Description

Renames the owning team for `cpp/` and `benchmarks/` in `.github/CODEOWNERS` from `@nvidia/cuopt-engine-codeowners` to `@nvidia/cuopt-solver-codeowners`.

These were the only two references to the old team name in the repo. No other ownership rules change.

## Issue

NA

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] NA
- Documentation
   - [x] NA
