### PR TITLE
Reuse existing cuOptGetProblemIntAttribute to simplify code in c API

### DIFF
--- a/cpp/src/pdlp/cuopt_c.cpp
+++ b/cpp/src/pdlp/cuopt_c.cpp
@@ -736,61 +736,35 @@ cuopt_int_t cuOptGetNumConstraints(cuOptOptimizationProblem problem,
 
 cuopt_int_t cuOptGetNumVariables(cuOptOptimizationProblem problem, cuopt_int_t* num_variables_ptr)
 {
-  if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  if (num_variables_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  problem_and_stream_view_t* problem_and_stream_view =
-    static_cast<problem_and_stream_view_t*>(problem);
-  *num_variables_ptr = problem_and_stream_view->get_problem()->get_n_variables();
-  return CUOPT_SUCCESS;
+  return cuOptGetProblemIntAttribute(problem, CUOPT_ATTR_NUM_VARIABLES, num_variables_ptr);
 }
 
 cuopt_int_t cuOptGetObjectiveSense(cuOptOptimizationProblem problem,
                                    cuopt_int_t* objective_sense_ptr)
 {
-  if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  if (objective_sense_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  problem_and_stream_view_t* problem_and_stream_view =
-    static_cast<problem_and_stream_view_t*>(problem);
-  *objective_sense_ptr =
-    problem_and_stream_view->get_problem()->get_sense() ? CUOPT_MAXIMIZE : CUOPT_MINIMIZE;
-  return CUOPT_SUCCESS;
+  return cuOptGetProblemIntAttribute(problem, CUOPT_ATTR_OBJECTIVE_SENSE, objective_sense_ptr);
 }
 
 cuopt_int_t cuOptGetObjectiveOffset(cuOptOptimizationProblem problem,
                                     cuopt_float_t* objective_offset_ptr)
 {
-  if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  if (objective_offset_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  problem_and_stream_view_t* problem_and_stream_view =
-    static_cast<problem_and_stream_view_t*>(problem);
-  *objective_offset_ptr = problem_and_stream_view->get_problem()->get_objective_offset();
-  return CUOPT_SUCCESS;
+  return cuOptGetProblemFloatAttribute(problem, CUOPT_ATTR_OBJECTIVE_OFFSET, objective_offset_ptr);
 }
 
 cuopt_int_t cuOptGetObjectiveCoefficients(cuOptOptimizationProblem problem,
                                           cuopt_float_t* objective_coefficients_ptr)
 {
-  if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  if (objective_coefficients_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  problem_and_stream_view_t* problem_and_stream_view =
-    static_cast<problem_and_stream_view_t*>(problem);
-
-  cuopt_int_t size = problem_and_stream_view->get_problem()->get_n_variables();
-  problem_and_stream_view->get_problem()->copy_objective_coefficients_to_host(
-    objective_coefficients_ptr, size);
-
-  return CUOPT_SUCCESS;
+  cuopt_int_t size   = 0;
+  cuopt_int_t status = cuOptGetProblemIntAttribute(problem, CUOPT_ATTR_NUM_VARIABLES, &size);
+  if (status != CUOPT_SUCCESS) { return status; }
+  return cuOptGetProblemFloatArrayAttribute(
+    problem, CUOPT_ARRAY_ATTR_OBJECTIVE_COEFFICIENTS, objective_coefficients_ptr, size);
 }
 
 cuopt_int_t cuOptGetNumNonZeros(cuOptOptimizationProblem problem,
                                 cuopt_int_t* num_non_zero_elements_ptr)
 {
-  if (problem == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  if (num_non_zero_elements_ptr == nullptr) { return CUOPT_INVALID_ARGUMENT; }
-  problem_and_stream_view_t* problem_and_stream_view =
-    static_cast<problem_and_stream_view_t*>(problem);
-  *num_non_zero_elements_ptr = problem_and_stream_view->get_problem()->get_nnz();
-  return CUOPT_SUCCESS;
+  return cuOptGetProblemIntAttribute(problem, CUOPT_ATTR_NUM_NONZEROS, num_non_zero_elements_ptr);
 }
 
 cuopt_int_t cuOptGetConstraintMatrix(cuOptOptimizationProblem problem,


### PR DESCRIPTION
<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description

Several standalone C API getters (`cuOptGetNumVariables`,
`cuOptGetObjectiveSense`, `cuOptGetObjectiveOffset`,
`cuOptGetObjectiveCoefficients`, `cuOptGetNumNonZeros`) duplicated logic
that already exists in `cuOptGetProblemIntAttribute` /
`cuOptGetProblemFloatAttribute` / `cuOptGetProblemFloatArrayAttribute` —
same null checks, same single-field access, maintained in two places.

Rewrote each as a thin wrapper delegating to the corresponding attribute
call, so there's a single source of truth per attribute and the
implementations can't drift apart. Behavior is unchanged: the delegated-to
functions already perform the same null/argument validation, so error
codes and return values are identical to before.

`cuOptGetNumConstraints` had the same duplication and was already cleaned
up the same way in #1761, along with other bug fixs.

## Issue

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [x] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [x] NA
