### PR TITLE
ci: report step timeouts explicitly, and skip the test that was hitting them

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -53,12 +53,16 @@ FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/crash_helpers.sh"
+
+
 # Run gtests from libcuopt-tests package
 # XML output and retry logic handled by run_ctests.sh
 export RAPIDS_TESTS_DIR
 
 rapids-logger "Run gtests"
-timeout 60m ./ci/run_ctests.sh || FAILED_STEPS+=("gtests (run_ctests.sh)")
+run_step_with_timeout "gtests (run_ctests.sh)" 60m "" ./ci/run_ctests.sh
 
 rapids-logger "Generate nightly test report"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -47,28 +47,34 @@ FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/crash_helpers.sh"
+
 rapids-logger "Test cuopt_cli"
-timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh || FAILED_STEPS+=("cuopt_cli")
+run_step_with_timeout "cuopt_cli" 10m "" \
+  bash ./python/libcuopt/libcuopt/tests/test_cli.sh
 
 rapids-logger "pytest cuopt"
-timeout 30m ./ci/run_cuopt_pytests.sh \
+run_step_with_timeout "pytest cuopt" 45m "${RAPIDS_TESTS_DIR}/junit-cuopt.xml" \
+  ./ci/run_cuopt_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuopt.xml" \
   --cov-config=.coveragerc \
   --cov=cuopt \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuopt-coverage.xml" \
   --cov-report=term \
-  --ignore=raft || FAILED_STEPS+=("pytest cuopt")
+  --ignore=raft
 
 rapids-logger "pytest cuopt-server"
-timeout 20m ./ci/run_cuopt_server_pytests.sh \
+run_step_with_timeout "pytest cuopt-server" 20m "${RAPIDS_TESTS_DIR}/junit-cuopt-server.xml" \
+  ./ci/run_cuopt_server_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cuopt-server.xml" \
   --cov-config=.coveragerc \
   --cov=cuopt_server \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cuopt-server-coverage.xml" \
-  --cov-report=term || FAILED_STEPS+=("pytest cuopt-server")
+  --cov-report=term
 
 rapids-logger "Test skills/ assets (Python, C, CLI)"
-timeout 10m ./ci/test_skills_assets.sh || FAILED_STEPS+=("skills assets")
+run_step_with_timeout "skills assets" 10m "" ./ci/test_skills_assets.sh
 
 rapids-logger "Generate nightly test report"
 source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/nightly_report_helper.sh"

--- a/ci/test_wheel_cuopt.sh
+++ b/ci/test_wheel_cuopt.sh
@@ -70,13 +70,19 @@ FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/crash_helpers.sh"
+
+
 # Run CLI tests
-timeout 10m bash ./python/libcuopt/libcuopt/tests/test_cli.sh || FAILED_STEPS+=("cuopt_cli")
+run_step_with_timeout "cuopt_cli" 10m "" \
+  bash ./python/libcuopt/libcuopt/tests/test_cli.sh
 
 # Run Python tests
-timeout 30m ./ci/run_cuopt_pytests.sh \
+run_step_with_timeout "pytest cuopt (wheel)" 45m "${RAPIDS_TESTS_DIR}/junit-wheel-cuopt.xml" \
+  ./ci/run_cuopt_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-wheel-cuopt.xml" \
-  --verbose --capture=no || FAILED_STEPS+=("pytest cuopt (wheel)")
+  --verbose --capture=no
 
 # run thirdparty integration tests for only nightly builds
 if [[ "${RAPIDS_BUILD_TYPE}" == "nightly" ]]; then

--- a/ci/test_wheel_cuopt_server.sh
+++ b/ci/test_wheel_cuopt_server.sh
@@ -46,9 +46,14 @@ FAILED_STEPS=()
 trap "EXITCODE=1" ERR
 set +e
 
-timeout 30m ./ci/run_cuopt_server_pytests.sh \
+# shellcheck source=ci/utils/crash_helpers.sh
+source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils/crash_helpers.sh"
+
+run_step_with_timeout "pytest cuopt-server (wheel)" 30m \
+  "${RAPIDS_TESTS_DIR}/junit-wheel-cuopt-server.xml" \
+  ./ci/run_cuopt_server_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-wheel-cuopt-server.xml" \
-  --verbose --capture=no || FAILED_STEPS+=("pytest cuopt-server (wheel)")
+  --verbose --capture=no
 
 # Run documentation tests
 ./ci/test_doc_examples.sh || FAILED_STEPS+=("doc examples")

--- a/ci/utils/crash_helpers.sh
+++ b/ci/utils/crash_helpers.sh
@@ -92,6 +92,72 @@ write_pytest_crash_marker() {
         "pytest process terminated by ${sig} mid-run. The JUnit XML was not finalized; the test that triggered the crash is unknown — inspect the run log for the last test invoked."
 }
 
+# Synthesize a JUnit XML record for a step killed by the 'timeout' command.
+# nightly_report.py classifies purely from XML, so without this a step that
+# hits its time limit is invisible in the report -- it looks like nothing ran.
+#
+# Usage: write_pytest_timeout_marker <junitxml_path> <suite_name> <limit>
+write_pytest_timeout_marker() {
+    local junitxml_path="$1"
+    local suite_name="$2"
+    local limit="$3"
+
+    if [ -z "${junitxml_path}" ]; then
+        return
+    fi
+
+    local timeout_xml="${junitxml_path%.xml}-timeout.xml"
+    write_crash_xml "${timeout_xml}" "${suite_name}" "STEP_TIMEOUT" \
+        "${suite_name} did not finish within its ${limit} time limit and was killed" \
+        "The step was killed by the 'timeout' command after ${limit}. It was terminated before it could report, so the JUnit XML was never finalized. Either the time limit is too low for this suite, or a test is taking longer than expected -- raise the limit for this step in the CI script, or investigate the slow test. The pytest progress output in the run log shows which tests had not produced a result."
+}
+
+# Run a step under a time limit, reporting a timeout kill distinctly from an
+# ordinary failure. Appends to the caller's FAILED_STEPS array.
+#
+# Plain 'timeout Nm cmd || FAILED_STEPS+=(label)' discards the exit code, so a
+# step that burns the full limit is reported identically to a test failure and
+# emits no XML. That is silent enough that the only evidence is the gap between
+# step timestamps.
+#
+# Usage: run_step_with_timeout <label> <limit> <junitxml_or_empty> <cmd> [args...]
+run_step_with_timeout() {
+    local label="$1"
+    local limit="$2"
+    local junitxml="$3"
+    shift 3
+
+    local rc=0
+    timeout "${limit}" "$@" || rc=$?
+
+    if [ "${rc}" -eq 0 ]; then
+        return 0
+    fi
+
+    if [ "${rc}" -eq 124 ]; then
+        echo ""
+        echo "=================================================================="
+        echo "TIMEOUT: '${label}' did not finish within its ${limit} time limit"
+        echo "         and was killed."
+        echo ""
+        echo "  It was terminated before it could report, so no result"
+        echo "  summary was written. Either the time limit is too low for"
+        echo "  this suite, or a test is taking longer than expected."
+        echo ""
+        echo "  Raise the limit for this step in the CI script, or"
+        echo "  investigate the slow test. The progress output above shows"
+        echo "  which tests had not produced a result."
+        echo "=================================================================="
+        echo ""
+        FAILED_STEPS+=("${label} (TIMEOUT after ${limit})")
+        write_pytest_timeout_marker "${junitxml}" "${label}" "${limit}"
+    else
+        FAILED_STEPS+=("${label}")
+    fi
+
+    return "${rc}"
+}
+
 # Isolate crashing pytest tests by retrying individually.
 # Called after pytest exits with a signal (exit code > 128) on nightly builds.
 #

--- a/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
+++ b/python/cuopt/cuopt/tests/linear_programming/test_lp_solver.py
@@ -576,6 +576,11 @@ def test_parse_var_names():
         )
 
 
+@pytest.mark.skip(
+    reason="Intermittently hangs inside LP BatchSolve on CUDA 13.3, see "
+    "https://github.com/NVIDIA/cuopt/issues/1781. The test never returns, so "
+    "the step's outer timeout kills the whole run; xfail cannot catch it."
+)
 def test_parser_and_batch_solver():
     data_model_list = []
     file_path = (


### PR DESCRIPTION
## Description

Two related CI fixes.

**Report step timeouts.** A step killed by `timeout` was reported identically to a test failure, with no indication a time limit was hit. `timeout 30m cmd || FAILED_STEPS+=(label)` discards the exit code, and the kill also stops the runner script from reporting, so no JUnit XML is finalized and `nightly_report.py` — which classifies purely from XML — sees nothing. The only evidence was the gap between step timestamps.

Adds `run_step_with_timeout()`, which captures the exit code and on `124` reports that the step did not finish within its limit, labels it `(TIMEOUT after <limit>)`, and writes a `STEP_TIMEOUT` JUnit marker. The message points at the two actionable outcomes: raise the limit, or investigate the slow test. Non-timeout failures keep their previous behaviour. All eight `timeout` call sites across the four test scripts use it.

Also raises the `pytest cuopt` limit from 30m to 45m for the conda and wheel paths. Other steps keep their existing limits.

**Skip the test that was consuming the limit.** `test_lp_solver.py::test_parser_and_batch_solver` intermittently hangs inside LP `BatchSolve` on CUDA 13.3 and never returns, so the outer timeout kills the whole pytest run and every other test in it. Seen on amd64 rtxpro6000 (3 of 4 runs) and arm64 l4; not seen on 13.0.3 or 12.x. It is not caused by any one PR — it reproduces on a branch that changes only `ci/*.sh`.

`xfail` does not work: the test never returns, so pytest cannot observe a failure. Skipping is the only way to keep the rest of the suite running.

Tracked in #1781, which carries the faulthandler stack that identified it and what has been ruled out.

Note the 45m bump does not fix the hang — 30m and 45m both end at 140/142 tests. It is there so genuinely slow runs under contention have headroom, not to accommodate the hang.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
- Documentation
   - [x] NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
