### PR TITLE
ci: stop nightly builds for release/26.08

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Trigger Nightly cuOpt Pipeline
@@ -23,7 +23,6 @@ jobs:
       matrix:
         cuopt_branch:
           - "main"
-          - "release/26.08"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Description

26.08 is released and no further 26.08 releases are planned, so the nightly pipeline no longer needs to build it.

Leaves `main`, which is 26.10 (`VERSION` = `26.10.00`).

`release/26.10` is not added here because it has not been cut yet — the workflow resolves each matrix entry through the branches API before triggering, so an entry for a branch that does not exist would fail every night:

```bash
export SHA=$(gh api -q '.commit.sha' "repos/nvidia/cuopt/branches/${CUOPT_BRANCH}")
```

It should be added once `release/26.10` exists.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] NA
- Documentation
   - [x] NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
