### PR TITLE
TESTING (do not merge): identify the hanging pytest in CI

### DIFF
--- a/ci/run_cuopt_pytests.sh
+++ b/ci/run_cuopt_pytests.sh
@@ -33,12 +33,23 @@ done
 export PYTHONPATH="${SCRIPT_DIR}/utils:${PYTHONPATH:-}"
 
 rc=0
+# A test that never returns takes the whole step down when the outer 'timeout'
+# fires, and pytest is killed before it can say which test was running. -v names
+# each test as it is dispatched, and faulthandler_timeout dumps the stack of any
+# test still running after FAULTHANDLER_TIMEOUT seconds, so a stuck test
+# identifies itself while the step is still alive. Neither kills the test; they
+# only make it visible.
+FAULTHANDLER_TIMEOUT=${FAULTHANDLER_TIMEOUT:-600}
+PYTEST_DIAG_ARGS=(-v -o "faulthandler_timeout=${FAULTHANDLER_TIMEOUT}" --durations=25)
+
 if [ "${IS_NIGHTLY}" = "nightly" ]; then
-    pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml "$@" tests || rc=$?
+    pytest -s --cache-clear --reruns 2 --reruns-delay 5 -p cuopt_rerun_xml \
+        "${PYTEST_DIAG_ARGS[@]}" "$@" tests || rc=$?
 else
     # loadgroup keeps xdist_group (grpc server) tests on one worker;
     # max-worker-restart=0 stops a crashed worker from respawning.
-    pytest -s --cache-clear -n 4 --dist loadgroup --max-worker-restart=0 "$@" tests || rc=$?
+    pytest -s --cache-clear -n 4 --dist loadgroup --max-worker-restart=0 \
+        "${PYTEST_DIAG_ARGS[@]}" "$@" tests || rc=$?
 fi
 
 # If not a crash, exit normally


### PR DESCRIPTION
## Description

**Testing / diagnosis only — do not merge.**

Opened to get CI to tell us which tests are hanging in the `pytest cuopt` step. Not a fix.

The step has been hitting its time limit on `13.3.0 amd64` with **140 of 142** tests complete — two tests start and never finish. When the outer `timeout` fires, pytest is killed before it can report, and the conda path runs without `-v`, so the output is bare progress dots and the responsible tests cannot be identified. Raising the limit does not help: 30m and 45m both end at 140/142.

Adds three diagnostics to the shared runner so both the conda and wheel paths get them:

- `-v` names each test as it is dispatched.
- `faulthandler_timeout` dumps the stack of any test still running after `FAULTHANDLER_TIMEOUT` seconds (default 600), so a stuck test identifies itself while the step is still alive.
- `--durations=25` surfaces tests approaching the limit.

None of these kill a test; they only make it visible.

Verified locally against a deliberately hanging test under xdist:

```
tests/test_hang_demo.py::test_hangs
Timeout (0:00:08)!
  File ".../tests/test_hang_demo.py", line 9 in test_hangs
```

The hang is not specific to any one PR — it reproduces on a branch that changes only `ci/*.sh`.

Once CI names the offending tests here, the real fix belongs in a separate PR against those tests.
