### PR TITLE
fix: build-images CI failures (deadsnakes PPA flakiness + nightly version mismatch)

### DIFF
--- a/.github/workflows/build_test_publish_images.yaml
+++ b/.github/workflows/build_test_publish_images.yaml
@@ -85,10 +85,7 @@ jobs:
         id: compute-cuopt-ver
         run: |
           source rapids-datetime-string
-          # Nightly wheels are published with a ".post<datetime>" suffix (see ci/build_wheel.sh)
-          # to ensure every nightly build produces a new package; match that here so the
-          # version pinned in the Dockerfile actually resolves on the package index.
-          # RAPIDS_VERSION_SUFFIX is ignored by rapids-generate-version for release builds.
+          # .post<datetime> makes every nightly version unique (see ci/build_wheel.sh); ignored on release builds.
           ver=$(RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" rapids-generate-version)
           # Remove starting 0s from version 25.08.0a18 -> 25.8.0a18
           CUOPT_VER=$(echo "$ver" | sed -E 's/\.0+([0-9])/\.\1/g')

--- a/.github/workflows/build_test_publish_images.yaml
+++ b/.github/workflows/build_test_publish_images.yaml
@@ -84,7 +84,12 @@ jobs:
       - name: Compute cuopt version
         id: compute-cuopt-ver
         run: |
-          ver=$(rapids-generate-version)
+          source rapids-datetime-string
+          # Nightly wheels are published with a ".post<datetime>" suffix (see ci/build_wheel.sh)
+          # to ensure every nightly build produces a new package; match that here so the
+          # version pinned in the Dockerfile actually resolves on the package index.
+          # RAPIDS_VERSION_SUFFIX is ignored by rapids-generate-version for release builds.
+          ver=$(RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" rapids-generate-version)
           # Remove starting 0s from version 25.08.0a18 -> 25.8.0a18
           CUOPT_VER=$(echo "$ver" | sed -E 's/\.0+([0-9])/\.\1/g')
           echo "CUOPT_VER=$CUOPT_VER" >> $GITHUB_OUTPUT

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -33,7 +33,12 @@ RUN apt-get update \
         gnupg2 \
         wget \
         unzip \
-    && add-apt-repository ppa:deadsnakes/ppa \
+    && ( for i in 1 2 3 4 5; do \
+            add-apt-repository -y ppa:deadsnakes/ppa && exit 0; \
+            echo "add-apt-repository failed (attempt ${i}/5), retrying in 10s..."; \
+            sleep 10; \
+         done; \
+         exit 1 ) \
     && apt-get install -y --no-install-recommends \
         python${PYTHON_SHORT_VER} \
         python${PYTHON_SHORT_VER}-dev \

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update \
         unzip \
     && ( for i in 1 2 3 4 5; do \
             add-apt-repository -y ppa:deadsnakes/ppa && exit 0; \
-            echo "add-apt-repository failed (attempt ${i}/5), retrying in 10s..."; \
-            sleep 10; \
+            echo "add-apt-repository failed (attempt ${i}/5), retrying in 5s..."; \
+            sleep 5; \
          done; \
          exit 1 ) \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Fixes two independent issues causing the `build-images` workflow to fail (e.g. https://github.com/NVIDIA/cuopt/actions/runs/32692816239):

- **`ci/docker/Dockerfile`**: `add-apt-repository ppa:deadsnakes/ppa` calls Launchpad's API to fetch the PPA's signing key, which is subject to transient failures (observed `HTTP 500 GPGKeyTemporarilyNotFoundError`). Wrapped it in a 5-attempt retry loop with backoff so a transient Launchpad hiccup doesn't fail the whole image build.
- **`.github/workflows/build_test_publish_images.yaml`**: `compute-cuopt-ver` computed `CUOPT_VER` with plain `rapids-generate-version`, but `ci/build_wheel.sh` has published nightly wheels with a `.post<datetime>` suffix since #1661 (`dbaf523f`). The two were out of sync, so nightly image builds pinned a version (e.g. `26.10.0a43`) that was never actually published — only `.post`-suffixed builds exist on the index — causing `pip install` to fail with "No matching distribution found". Now sets `RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}"` before calling `rapids-generate-version`, mirroring `ci/build_wheel.sh`. `RAPIDS_VERSION_SUFFIX` is a no-op on release builds (confirmed in `rapids-generate-version`'s source), so release tagging/versioning is unaffected.

## Test plan
- [ ] Trigger `build-images` workflow (nightly build) and confirm the `python-env` stage installs Python without hitting the deadsnakes PPA error
- [ ] Confirm `pip install cuopt-server-cu13==<CUOPT_VER>` resolves to a real published nightly wheel
- [ ] Confirm release-build version computation (`IMAGE_TAG_PREFIX`) is unchanged for tagged releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)