### PR TITLE
Fix cuopt_assert macro argument expansion

### DIFF
--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
@@ -437,7 +437,7 @@ DI bool check_feasibility(const typename fj_t<i_t, f_t>::climber_data_t::view_t&
       fj_kahan_babushka_neumaier_sum<i_t, f_t>(delta_it + offset_begin, delta_it + offset_end);
     cuopt_assert(fj.cstr_satisfied(cIdx, lhs), "constraint violated");
   }
-  cuopt_func_call((check_variable_feasibility<i_t, f_t>(fj, check_integer)));
+  cuopt_func_call(check_variable_feasibility<i_t, f_t>(fj, check_integer));
 
   return true;
 }
@@ -488,7 +488,7 @@ DI bool save_best_solution(typename fj_t<i_t, f_t>::climber_data_t::view_t& fj)
 
       if (*fj.best_excess == 0) { *fj.saved_solution_objective = *fj.incumbent_objective; }
     }
-    cuopt_func_call((check_variable_feasibility<i_t, f_t>(fj, false)));
+    cuopt_func_call(check_variable_feasibility<i_t, f_t>(fj, false));
     for (i_t i = threadIdx.x; i < fj.pb.n_variables; i += blockDim.x) {
       fj.best_assignment[i] = fj.incumbent_assignment[i];
     }
@@ -499,7 +499,7 @@ DI bool save_best_solution(typename fj_t<i_t, f_t>::climber_data_t::view_t& fj)
       *fj.weighted_violation_score <= *fj.max_cstr_weight * fj.pb.tolerances.absolute_tolerance,
       "Violated constraint and score mismatch");
     bool check_integer = fj.settings->mode != fj_mode_t::ROUNDING;
-    cuopt_func_call((check_feasibility<i_t, f_t>(fj, check_integer)));
+    cuopt_func_call(check_feasibility<i_t, f_t>(fj, check_integer));
   }
   // return whether it is an improving local minimum
   return improving;

--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -1012,7 +1012,7 @@ static void apply_move(fj_cpu_climber_t<i_t, f_t>& fj_cpu,
   delta   = new_val - old_val;
   cuopt_assert(isfinite(new_val), "assignment is not finite");
   cuopt_assert(isfinite(delta), "applied delta is not finite");
-  cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val)),
+  cuopt_assert(check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val),
                "assignment not within bounds");
 
   // Update the LHSs of all involved constraints.
@@ -1217,7 +1217,7 @@ static thrust::tuple<fj_move_t, fj_staged_score_t> find_mtm_move(
         }
       }
       if (!isfinite(new_val)) continue;
-      cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val)),
+      cuopt_assert(check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val),
                    "new_val is not within bounds");
       delta = new_val - val;
       // more permissive tabu in the case of local minima
@@ -1264,7 +1264,7 @@ static thrust::tuple<fj_move_t, fj_staged_score_t> find_mtm_move(
 
       auto [score, infeasibility] = compute_score<i_t, f_t>(fj_cpu, var_idx, delta);
 
-      cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val)), "");
+      cuopt_assert(check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, new_val), "");
       cuopt_assert(isfinite(delta), "");
 
       if (fj_cpu.view.move_numerically_stable(
@@ -1493,7 +1493,7 @@ static void perturb(fj_cpu_climber_t<i_t, f_t>& fj_cpu)
       val = std::min(std::max(val, lb), ub);
     }
 
-    cuopt_assert((check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, val)),
+    cuopt_assert(check_variable_within_bounds<i_t, f_t>(fj_cpu, var_idx, val),
                  "value is out of bounds");
     fj_cpu.h_assignment[var_idx] = val;
   }

--- a/cpp/src/routing/util_kernels/runtime_checks.cu
+++ b/cpp/src/routing/util_kernels/runtime_checks.cu
@@ -59,15 +59,14 @@ __global__ void feasibility_check(typename solution_t<i_t, f_t, REQUEST>::view_t
         node, route.get_node(i + 1), route.vehicle_info(), d_default_weights, 0.001);
       if (!res) {
         *solution.sol_found = 0;
-        cuopt_assert(true,
-                     printf("Failed node:%d f_excess:%f b_excess:%f route:%d, vehicle:%d "
-                            "n_nodes:%d\n",
-                            node.request.info.node(),
-                            node.time_dim.excess_forward,
-                            node.time_dim.excess_backward,
-                            route_id,
-                            vehicle_id,
-                            n_nodes));
+        cuopt_func_call(printf("Failed node:%d f_excess:%f b_excess:%f route:%d, vehicle:%d "
+                               "n_nodes:%d\n",
+                               node.request.info.node(),
+                               node.time_dim.excess_forward,
+                               node.time_dim.excess_backward,
+                               route_id,
+                               vehicle_id,
+                               n_nodes));
         cuopt_assert(false, "Node should be feasible combine");
         return;
       }

--- a/cpp/src/routing/util_kernels/runtime_checks.cu
+++ b/cpp/src/routing/util_kernels/runtime_checks.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -59,14 +59,15 @@ __global__ void feasibility_check(typename solution_t<i_t, f_t, REQUEST>::view_t
         node, route.get_node(i + 1), route.vehicle_info(), d_default_weights, 0.001);
       if (!res) {
         *solution.sol_found = 0;
-        cuopt_func_call(printf("Failed node:%d f_excess:%f b_excess:%f route:%d, vehicle:%d "
-                               "n_nodes:%d\n",
-                               node.request.info.node(),
-                               node.time_dim.excess_forward,
-                               node.time_dim.excess_backward,
-                               route_id,
-                               vehicle_id,
-                               n_nodes));
+        cuopt_func_call(
+          printf("Failed node:%d f_excess:%f b_excess:%f route:%d, vehicle:%d "
+                 "n_nodes:%d\n",
+                 node.request.info.node(),
+                 node.time_dim.excess_forward,
+                 node.time_dim.excess_backward,
+                 route_id,
+                 vehicle_id,
+                 n_nodes));
         cuopt_assert(false, "Node should be feasible combine");
         return;
       }

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -14,17 +14,24 @@
 // 3) heavy
 #ifdef ASSERT_MODE
 #include <cassert>
-#define cuopt_assert(val, msg) assert(val&& msg)
-#define cuopt_func_call(func)  func;
-#else
-#define cuopt_assert(val, msg)
-#define cuopt_func_call(func) ;
-#endif
+#include <cstddef>
 
-#ifdef BENCHMARK
-#define benchmark_call(func) func;
+namespace cuopt::detail {
+// handle the argument processing through the C++ parser instead of the preprocessor
+// since it chokes on colons in template arguments (e.g. cuopt_assert(std::is_same_v<T, int>, "message"))
+// constexpr because otherwise __host__ __device__ is required and it would break pure host builds
+template <typename T, size_t N>
+constexpr bool assert_msg(T&& cond, const char (&)[N])
+{
+  return (bool)cond;
+}
+}  // namespace cuopt::detail
+
+#define cuopt_assert(...)     assert(::cuopt::detail::assert_msg(__VA_ARGS__))
+#define cuopt_func_call(func) func;
 #else
-#define benchmark_call(func) ;
+#define cuopt_assert(...)
+#define cuopt_func_call(func) ;
 #endif
 
 // For CUDA Driver API

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -28,17 +28,17 @@ constexpr bool assert_msg(T&& cond, const char (&)[N])
 }
 }  // namespace cuopt::detail
 
-#define cuopt_assert(...)     assert(::cuopt::detail::assert_msg(__VA_ARGS__))
+#define cuopt_assert(...)    assert(::cuopt::detail::assert_msg(__VA_ARGS__))
 #define cuopt_func_call(...) __VA_ARGS__;
 #else
 #define cuopt_assert(...)
-#define cuopt_func_call(func) ;
+#define cuopt_func_call(...) ;
 #endif
 
 #ifdef BENCHMARK
 #define benchmark_call(...) __VA_ARGS__;
 #else
-#define benchmark_call(func) ;
+#define benchmark_call(...) ;
 #endif
 
 // For CUDA Driver API

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -18,9 +18,9 @@
 
 namespace cuopt::detail {
 // handle the argument processing through the C++ parser instead of the preprocessor
-// since it chokes on colons in template arguments (e.g. cuopt_assert(std::is_same_v<T, int>,
-// "message")) constexpr because otherwise __host__ __device__ is required and it would break pure
-// host builds
+// since it chokes on colons in template arguments.
+// (e.g. cuopt_assert(std::is_same_v<T, int>, "message")).
+// constexpr because otherwise __host__ __device__ is required and it would break pure host builds
 template <typename T, size_t N>
 constexpr bool assert_msg(T&& cond, const char (&)[N])
 {

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -18,8 +18,9 @@
 
 namespace cuopt::detail {
 // handle the argument processing through the C++ parser instead of the preprocessor
-// since it chokes on colons in template arguments (e.g. cuopt_assert(std::is_same_v<T, int>, "message"))
-// constexpr because otherwise __host__ __device__ is required and it would break pure host builds
+// since it chokes on colons in template arguments (e.g. cuopt_assert(std::is_same_v<T, int>,
+// "message")) constexpr because otherwise __host__ __device__ is required and it would break pure
+// host builds
 template <typename T, size_t N>
 constexpr bool assert_msg(T&& cond, const char (&)[N])
 {

--- a/cpp/src/utilities/macros.cuh
+++ b/cpp/src/utilities/macros.cuh
@@ -29,10 +29,16 @@ constexpr bool assert_msg(T&& cond, const char (&)[N])
 }  // namespace cuopt::detail
 
 #define cuopt_assert(...)     assert(::cuopt::detail::assert_msg(__VA_ARGS__))
-#define cuopt_func_call(func) func;
+#define cuopt_func_call(...) __VA_ARGS__;
 #else
 #define cuopt_assert(...)
 #define cuopt_func_call(func) ;
+#endif
+
+#ifdef BENCHMARK
+#define benchmark_call(...) __VA_ARGS__;
+#else
+#define benchmark_call(func) ;
 #endif
 
 // For CUDA Driver API


### PR DESCRIPTION
Previously, cuopt_assert was defined as `#define cuopt_assert(val, msg) assert(val&& msg)`, which could cause operator precedence issues by expanding patterns such as this one into:
```
cuopt_assert(x = pointer(), "x should not be nullptr");
// expanded into
assert(x = (pointer() && "a OR b should be true"));
```

This has been fixed by passing the cuopt_assert args to a C++ function to circumvent macro gotchas altogether.
As a side effect, constructs like
```
cuopt_assert(std::is_same_v<T, int>, "msg");
```
are now valid.
They were previously rejected because the C preprocessor doesn't recognize colons in template parameter lists.

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
