### PR TITLE
Early plunge stop

### DIFF
--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -4819,7 +4819,7 @@ void branch_and_bound_t<i_t, f_t>::deterministic_sort_replay_events(
   deterministic_merge_pseudo_cost_updates(*deterministic_workers_);
 
   for (const auto& worker : *deterministic_workers_) {
-    fetch_min(lower_bound_numerical_, worker.local_lower_bound_ceiling);
+    lower_bound_numerical_.fetch_min(worker.local_lower_bound_ceiling);
   }
 }
 

--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -1124,7 +1124,7 @@ struct nondeterministic_policy_t : tree_update_policy_t<i_t, f_t> {
   void on_numerical_issue(mip_node_t<i_t, f_t>* node) override
   {
     if (worker->search_strategy == search_strategy_t::BEST_FIRST) {
-      fetch_min(bnb.lower_bound_numerical_, node->lower_bound);
+      bnb.lower_bound_numerical_.fetch_min(node->lower_bound);
       log.printf("LP returned numerical issue on node %d. Best bound set to %+10.6e.\n",
                  node->node_id,
                  compute_user_objective(bnb.original_lp_, bnb.lower_bound_numerical_.load()));
@@ -1722,7 +1722,7 @@ void branch_and_bound_t<i_t, f_t>::plunge_with(bfs_worker_t<i_t, f_t>* worker,
     // relaxation
     // - The lower bound of the parent is lower or equal to its children
     worker->lower_bound = node_ptr->lower_bound;
-    fetch_max(exploration_stats_.max_node_depth, node_ptr->depth);
+    exploration_stats_.max_node_depth.fetch_max(node_ptr->depth);
 
     if (node_ptr->lower_bound > upper_bound_.load()) {
       search_tree_.graphviz_node(settings_.log, node_ptr, "cutoff", node_ptr->lower_bound);
@@ -1781,6 +1781,7 @@ void branch_and_bound_t<i_t, f_t>::plunge_with(bfs_worker_t<i_t, f_t>* worker,
       if (node_ptr->lower_bound >= max_bound ||
           plunge_depth >= settings_.bnb_max_plunge_depth * max_node_depth) {
         stack.push_front(node_ptr);
+        --exploration_stats_.nodes_being_solved;
         break;
       }
     }
@@ -3470,6 +3471,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
   root_lp_current_lower_bound_        = -inf;
   exploration_stats_.nodes_unexplored = 0;
   exploration_stats_.nodes_explored   = 0;
+  exploration_stats_.max_node_depth   = 0;
   original_lp_.A.to_compressed_row(Arow_);
 
   settings_.log.debug("Reduced cost strengthening enabled: %d\n",
@@ -3900,6 +3902,7 @@ mip_status_t branch_and_bound_t<i_t, f_t>::solve(mip_solution_t<i_t, f_t>& solut
 
   exploration_stats_.nodes_explored       = 0;
   exploration_stats_.nodes_unexplored     = 2;
+  exploration_stats_.max_node_depth       = 0;
   exploration_stats_.nodes_since_last_log = 0;
   exploration_stats_.last_log             = tic();
   min_node_queue_size_                    = 20;

--- a/cpp/src/branch_and_bound/branch_and_bound.cpp
+++ b/cpp/src/branch_and_bound/branch_and_bound.cpp
@@ -1722,6 +1722,7 @@ void branch_and_bound_t<i_t, f_t>::plunge_with(bfs_worker_t<i_t, f_t>* worker,
     // relaxation
     // - The lower bound of the parent is lower or equal to its children
     worker->lower_bound = node_ptr->lower_bound;
+    fetch_max(exploration_stats_.max_node_depth, node_ptr->depth);
 
     if (node_ptr->lower_bound > upper_bound_.load()) {
       search_tree_.graphviz_node(settings_.log, node_ptr, "cutoff", node_ptr->lower_bound);
@@ -1770,6 +1771,18 @@ void branch_and_bound_t<i_t, f_t>::plunge_with(bfs_worker_t<i_t, f_t>* worker,
       stack.push_front(node_ptr);
       --exploration_stats_.nodes_being_solved;
       break;
+    }
+
+    i_t max_node_depth = exploration_stats_.max_node_depth;
+    i_t plunge_depth   = node_ptr->depth - start_node->depth;
+
+    if (plunge_depth >= settings_.bnb_min_plunge_depth * max_node_depth) {
+      f_t max_bound = lower_bound + settings_.bnb_plunge_gap_factor * (upper_bound - lower_bound);
+      if (node_ptr->lower_bound >= max_bound ||
+          plunge_depth >= settings_.bnb_max_plunge_depth * max_node_depth) {
+        stack.push_front(node_ptr);
+        break;
+      }
     }
 
     decompress_vstatus(

--- a/cpp/src/branch_and_bound/worker.hpp
+++ b/cpp/src/branch_and_bound/worker.hpp
@@ -30,6 +30,7 @@ struct branch_and_bound_stats_t {
   omp_atomic_t<int64_t> nodes_unexplored = 0;
   // Tracks the number of nodes being solved by the workers at a given time
   omp_atomic_t<i_t> nodes_being_solved = 0;
+  omp_atomic_t<i_t> max_node_depth     = 0;
 
   omp_atomic_t<int64_t> total_simplex_iters = 0;
   omp_atomic_t<i_t> nodes_since_last_log    = 0;

--- a/cpp/src/dual_simplex/simplex_solver_settings.hpp
+++ b/cpp/src/dual_simplex/simplex_solver_settings.hpp
@@ -108,6 +108,9 @@ struct simplex_solver_settings_t {
       bnb_steal_chance(-1),
       bnb_nodes_per_steal(-1),
       bnb_max_steal_attempts(-1),
+      bnb_plunge_gap_factor(0.25),
+      bnb_min_plunge_depth(0.1),
+      bnb_max_plunge_depth(0.5),
       reliability_branching(-1),
       inside_mip(0),
       inside_submip(0),
@@ -222,6 +225,9 @@ struct simplex_solver_settings_t {
   f_t bnb_steal_chance;
   i_t bnb_nodes_per_steal;
   i_t bnb_max_steal_attempts;
+  f_t bnb_plunge_gap_factor;
+  f_t bnb_min_plunge_depth;
+  f_t bnb_max_plunge_depth;
 
   // Settings for the reliability branching.
   // - -1: automatic

--- a/cpp/src/utilities/omp_helpers.hpp
+++ b/cpp/src/utilities/omp_helpers.hpp
@@ -219,6 +219,7 @@ class omp_atomic_t {
 
   friend double fetch_min(omp_atomic_t<double>& atomic_var, double other);
   friend double fetch_max(omp_atomic_t<double>& atomic_var, double other);
+  friend double fetch_max(omp_atomic_t<int>& atomic_var, int other);
 };
 
 // Free non-template functions are necessary because of a clang 20 bug
@@ -236,6 +237,17 @@ inline double fetch_min(omp_atomic_t<double>& atomic_var, double other)
 }
 
 inline double fetch_max(omp_atomic_t<double>& atomic_var, double other)
+{
+  double old;
+#pragma omp atomic compare capture
+  {
+    old = atomic_var.val;
+    if (other > atomic_var.val) { atomic_var.val = other; }
+  }
+  return old;
+}
+
+inline double fetch_max(omp_atomic_t<int>& atomic_var, int other)
 {
   double old;
 #pragma omp atomic compare capture

--- a/cpp/src/utilities/omp_helpers.hpp
+++ b/cpp/src/utilities/omp_helpers.hpp
@@ -214,50 +214,31 @@ class omp_atomic_t {
   T& underlying() { return val; }
   T underlying() const { return val; }
 
+  T fetch_min(T other)
+  {
+    T old;
+#pragma omp atomic compare capture
+    {
+      old = val;
+      if (other < val) { val = other; }
+    }
+    return old;
+  }
+
+  T fetch_max(T other)
+  {
+    T old;
+#pragma omp atomic compare capture
+    {
+      old = val;
+      if (other > val) { val = other; }
+    }
+    return old;
+  }
+
  private:
   T val;
-
-  friend double fetch_min(omp_atomic_t<double>& atomic_var, double other);
-  friend double fetch_max(omp_atomic_t<double>& atomic_var, double other);
-  friend double fetch_max(omp_atomic_t<int>& atomic_var, int other);
 };
-
-// Free non-template functions are necessary because of a clang 20 bug
-// when omp atomic compare is used within a templated context.
-// see https://github.com/llvm/llvm-project/issues/127466
-inline double fetch_min(omp_atomic_t<double>& atomic_var, double other)
-{
-  double old;
-#pragma omp atomic compare capture
-  {
-    old = atomic_var.val;
-    if (other < atomic_var.val) { atomic_var.val = other; }
-  }
-  return old;
-}
-
-inline double fetch_max(omp_atomic_t<double>& atomic_var, double other)
-{
-  double old;
-#pragma omp atomic compare capture
-  {
-    old = atomic_var.val;
-    if (other > atomic_var.val) { atomic_var.val = other; }
-  }
-  return old;
-}
-
-inline double fetch_max(omp_atomic_t<int>& atomic_var, int other)
-{
-  double old;
-#pragma omp atomic compare capture
-  {
-    old = atomic_var.val;
-    if (other > atomic_var.val) { atomic_var.val = other; }
-  }
-  return old;
-}
-
 }  // namespace cuopt
 
 #endif


### PR DESCRIPTION
In the current implementation, we let the plunge naturally end (i.e., when it reaches the bottom of the tree and there is no sibling node to backtrack). This PR mirrors SCIP to terminate the plunge early when it exceeded a certain depth or when the local gap becomes too deteriorated, which allows the solver to prioritize exploring more promising parts of the tree first.

Benchmark results:
8x H200, 2x Intel 8480+ 56C/112T, 10min

```
================================================================================
 main-2026-08-26-1 (1) vs plunge-early-stop-1 (2)
================================================================================

------------------------------------------------------------------------------------------------------------------------------
|                                        |       Run 1        |       Run 2        |     Abs. Diff.     |   Rel. Diff. (%)   |
------------------------------------------------------------------------------------------------------------------------------
| Imported                                                 239                  239                   +0                 --- |
| Feasible                                                 225                  227                   +2                 --- |
| Optimal                                                   79                   79                   +0                 --- |
| Solutions with <0.1% primal gap                          131                  131                   +0                 --- |
| Nodes explored (mean)                              2.286e+06            2.191e+06           -9.488e+04               -4.15 |
| Nodes explored (shifted geomean)                        1799                 1698               -101.5               -5.64 |
| Relative MIP gap (mean)                               0.3591               0.3028             -0.05634               -15.7 |
| Relative MIP gap (shifted geomean)                    0.1073               0.1067           -0.0006535              -0.609 |
| Solve time (mean)                                      446.6                447.3              +0.6889              +0.154 |
| Solve time (shifted geomean)                           255.6                260.1               +4.521               +1.77 |
| Primal gap (mean)                                      10.73                10.12              -0.6136               -5.72 |
| Primal gap (shifted geomean)                          0.5081               0.4896             -0.01847               -3.64 |
| Primal integral (mean)                                 22.83                21.65               -1.177               -5.15 |
| Primal integral (shifted geomean)                      2.791                2.831             +0.03911                +1.4 |
------------------------------------------------------------------------------------------------------------------------------


----------------------------------------------------------------------
|             Name             |     status 1     |     status 2     |
----------------------------------------------------------------------
| cbs-cta                                 optimal           feasible |
| drayage-25-23                           optimal           feasible |
| map10                                  feasible            optimal |
| neos-3216931-puriri                     timeout           feasible |
| ns1208400                               optimal           feasible |
| ns1830653                              feasible            optimal |
| ns1952667                               timeout            optimal |
| physiciansched6-2                      feasible            optimal |
| supportcase33                           optimal           feasible |
----------------------------------------------------------------------

================================================================================
 main-2026-08-26-2 (1) vs plunge-dynamic-stop-2 (2)
================================================================================
------------------------------------------------------------------------------------------------------------------------------
|                                        |       Run 1        |       Run 2        |     Abs. Diff.     |   Rel. Diff. (%)   |
------------------------------------------------------------------------------------------------------------------------------
| Imported                                                 239                  239                   +0                 --- |
| Feasible                                                 226                  227                   +1                 --- |
| Optimal                                                   79                   79                   +0                 --- |
| Solutions with <0.1% primal gap                          128                  129                   +1                 --- |
| Nodes explored (mean)                              2.339e+06            2.137e+06           -2.024e+05               -8.65 |
| Nodes explored (shifted geomean)                        1702                 1547               -154.7               -9.09 |
| Relative MIP gap (mean)                               0.3146               0.2915             -0.02306               -7.33 |
| Relative MIP gap (shifted geomean)                    0.1036               0.1052            +0.001552                +1.5 |
| Solve time (mean)                                      445.8                447.4                +1.59              +0.357 |
| Solve time (shifted geomean)                             249                257.9               +8.883               +3.57 |
| Primal gap (mean)                                      10.29                10.11              -0.1841               -1.79 |
| Primal gap (shifted geomean)                          0.5164                0.519             +0.00267              +0.517 |
| Primal integral (mean)                                 21.85                22.34              +0.4894               +2.24 |
| Primal integral (shifted geomean)                       2.83                2.871             +0.04095               +1.45 |
------------------------------------------------------------------------------------------------------------------------------


----------------------------------------------------------------------
|             Name             |     status 1     |     status 2     |
----------------------------------------------------------------------
| cbs-cta                                 optimal           feasible |
| map10                                   optimal           feasible |
| mzzv42z                                feasible            optimal |
| neos-2746589-doon                      feasible            optimal |
| ns1952667                               timeout            optimal |
| radiationm40-10-02                     feasible            optimal |
| supportcase33                           optimal           feasible |
| supportcase6                            optimal           feasible |
----------------------------------------------------------------------
```
Overall, this decreases the relative MIP Gap by roughly `~10 to 15%` and increase the number of feasible solutions by `1`.


Note that `reblock115` was excluded due to crashes on the main branch. 


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
