### PR TITLE
Remove unused docs and notebook dependencies

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -57,7 +57,6 @@ dependencies:
 - pre-commit
 - psutil>=6.0.0
 - pylibraft==26.10.*,>=0.0.0a0
-- pyrsistent
 - pytest-cov
 - pytest-rerunfailures
 - pytest-xdist
@@ -76,9 +75,6 @@ dependencies:
 - sphinx-copybutton
 - sphinx-design
 - sphinx-markdown-tables
-- sphinx_rtd_theme
-- sphinxcontrib-openapi
-- sphinxcontrib-websupport
 - sysroot_linux-aarch64==2.28
 - tbb-devel
 - uvicorn==0.34.*
@@ -87,5 +83,4 @@ dependencies:
 - pip:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
-  - veroviz
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -57,7 +57,6 @@ dependencies:
 - pre-commit
 - psutil>=6.0.0
 - pylibraft==26.10.*,>=0.0.0a0
-- pyrsistent
 - pytest-cov
 - pytest-rerunfailures
 - pytest-xdist
@@ -76,9 +75,6 @@ dependencies:
 - sphinx-copybutton
 - sphinx-design
 - sphinx-markdown-tables
-- sphinx_rtd_theme
-- sphinxcontrib-openapi
-- sphinxcontrib-websupport
 - sysroot_linux-64==2.28
 - tbb-devel
 - uvicorn==0.34.*
@@ -87,5 +83,4 @@ dependencies:
 - pip:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
-  - veroviz
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -57,7 +57,6 @@ dependencies:
 - pre-commit
 - psutil>=6.0.0
 - pylibraft==26.10.*,>=0.0.0a0
-- pyrsistent
 - pytest-cov
 - pytest-rerunfailures
 - pytest-xdist
@@ -76,9 +75,6 @@ dependencies:
 - sphinx-copybutton
 - sphinx-design
 - sphinx-markdown-tables
-- sphinx_rtd_theme
-- sphinxcontrib-openapi
-- sphinxcontrib-websupport
 - sysroot_linux-aarch64==2.28
 - tbb-devel
 - uvicorn==0.34.*
@@ -87,5 +83,4 @@ dependencies:
 - pip:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
-  - veroviz
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -57,7 +57,6 @@ dependencies:
 - pre-commit
 - psutil>=6.0.0
 - pylibraft==26.10.*,>=0.0.0a0
-- pyrsistent
 - pytest-cov
 - pytest-rerunfailures
 - pytest-xdist
@@ -76,9 +75,6 @@ dependencies:
 - sphinx-copybutton
 - sphinx-design
 - sphinx-markdown-tables
-- sphinx_rtd_theme
-- sphinxcontrib-openapi
-- sphinxcontrib-websupport
 - sysroot_linux-64==2.28
 - tbb-devel
 - uvicorn==0.34.*
@@ -87,5 +83,4 @@ dependencies:
 - pip:
   - nvidia-sphinx-theme
   - swagger-plugin-for-sphinx
-  - veroviz
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -803,14 +803,10 @@ dependencies:
           - *msgpack_numpy
           - myst-parser
           - numpydoc
-          - pyrsistent
           - breathe
           - sphinx
           - sphinx-copybutton
           - sphinx-markdown-tables
-          - sphinx_rtd_theme
-          - sphinxcontrib-openapi
-          - sphinxcontrib-websupport
           - sphinx-design
           - pip:
               - swagger-plugin-for-sphinx
@@ -828,12 +824,9 @@ dependencies:
           - *msgpack_numpy
           - *msgpack_python
           - *numpy
-          - pip:
-              - &veroviz veroviz
       - output_types: [requirements]
         packages:
           - *numpy
-          - *veroviz
   py_version:
     specific:
       - output_types: conda


### PR DESCRIPTION
## Summary
Removes unused documentation and notebook dependencies: `sphinx_rtd_theme`, `sphinxcontrib-openapi`, `sphinxcontrib-websupport`, `pyrsistent`, and `veroviz`. None are referenced anywhere in the repo.

## Test plan
- [x] CI passes