### PR TITLE
Add missing TransactionGuard in the SLDA presolver

### DIFF
--- a/cpp/src/mip_heuristics/presolve/single_lock_dual_aggregation.cpp
+++ b/cpp/src/mip_heuristics/presolve/single_lock_dual_aggregation.cpp
@@ -325,11 +325,9 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
   // Return the best master from the top-2 tracker, skipping excluded columns.
   auto pick_master = [&used_in_substitution](const top2_t<f_t>& t,
                                              int exclude) -> std::pair<int, f_t> {
-    if (t.top1.first >= 0 && t.top1.first != exclude &&
-        !used_in_substitution[t.top1.first])
+    if (t.top1.first >= 0 && t.top1.first != exclude && !used_in_substitution[t.top1.first])
       return t.top1;
-    if (t.top2.first >= 0 && t.top2.first != exclude &&
-        !used_in_substitution[t.top2.first])
+    if (t.top2.first >= 0 && t.top2.first != exclude && !used_in_substitution[t.top2.first])
       return t.top2;
     return {-1, f_t{0}};
   };
@@ -413,7 +411,8 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
     for (int j = 0; j < length; ++j)
       reductions.lockColBounds(cols[j]);
 
-    // PaPILO encodes a replacement as REPLACE(source, factor) followed by a NONE(master, offset) payload.
+    // PaPILO encodes a replacement as REPLACE(source, factor) followed by a NONE(master, offset)
+    // payload.
     if (is_anti) {
       // x = 1 - y
       reductions.add_reduction(papilo::ColReduction::REPLACE, cand, f_t{-1});

--- a/cpp/src/mip_heuristics/presolve/single_lock_dual_aggregation.cpp
+++ b/cpp/src/mip_heuristics/presolve/single_lock_dual_aggregation.cpp
@@ -241,7 +241,7 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
                               typename std::vector<candidate_t>::iterator cand_end,
                               int row,
                               std::vector<f_t>& dense_row_coefs,
-                              std::vector<uint8_t>& substituted)
+                              std::vector<uint8_t>& used_in_substitution)
 {
   const auto& constraint_matrix = problem.getConstraintMatrix();
   const auto& lhs_values        = constraint_matrix.getLeftHandSides();
@@ -323,9 +323,14 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
   };
 
   // Return the best master from the top-2 tracker, skipping excluded columns.
-  auto pick_master = [&substituted](const top2_t<f_t>& t, int exclude) -> std::pair<int, f_t> {
-    if (t.top1.first >= 0 && t.top1.first != exclude && !substituted[t.top1.first]) return t.top1;
-    if (t.top2.first >= 0 && t.top2.first != exclude && !substituted[t.top2.first]) return t.top2;
+  auto pick_master = [&used_in_substitution](const top2_t<f_t>& t,
+                                             int exclude) -> std::pair<int, f_t> {
+    if (t.top1.first >= 0 && t.top1.first != exclude &&
+        !used_in_substitution[t.top1.first])
+      return t.top1;
+    if (t.top2.first >= 0 && t.top2.first != exclude &&
+        !used_in_substitution[t.top2.first])
+      return t.top2;
     return {-1, f_t{0}};
   };
 
@@ -333,7 +338,7 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
 
   for (auto ci = cand_begin; ci != cand_end; ++ci) {
     auto [cand, locking_row, dir] = *ci;
-    if (substituted[cand]) continue;
+    if (used_in_substitution[cand]) continue;
 
     bool is_upward = (dir == UP);
     f_t cand_coeff = dense_row_coefs[cand];
@@ -368,7 +373,7 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
 
     cuopt_assert(master_col >= 0, "");
     cuopt_assert(master_col != cand, "");
-    cuopt_assert(!substituted[master_col], "");
+    cuopt_assert(!used_in_substitution[master_col], "");
 
     // The probe proves a one-directional implication (e.g. y=0 => x=0).
     // The substitution x=y also asserts the reverse (y=1 => x=1), which is
@@ -398,11 +403,26 @@ int try_substitutions_for_row(const papilo::Problem<f_t>& problem,
 
     if (!substitution_numerically_stable(constraint_matrix, cand)) continue;
 
-    substituted[cand] = true;
-    if (is_anti)
-      reductions.replaceCol(cand, master_col, f_t{-1}, f_t{1});  // x = 1 - y
-    else
-      reductions.replaceCol(cand, master_col, f_t{1}, f_t{0});  // x = y
+    used_in_substitution[cand]       = true;
+    used_in_substitution[master_col] = true;
+
+    papilo::TransactionGuard<f_t> guard{reductions};
+    reductions.lockCol(cand);
+    reductions.lockCol(master_col);
+    reductions.lockRow(row);
+    for (int j = 0; j < length; ++j)
+      reductions.lockColBounds(cols[j]);
+
+    // PaPILO encodes a replacement as REPLACE(source, factor) followed by a NONE(master, offset) payload.
+    if (is_anti) {
+      // x = 1 - y
+      reductions.add_reduction(papilo::ColReduction::REPLACE, cand, f_t{-1});
+      reductions.add_reduction(papilo::ColReduction::NONE, master_col, f_t{1});
+    } else {
+      // x = y
+      reductions.add_reduction(papilo::ColReduction::REPLACE, cand, f_t{1});
+      reductions.add_reduction(papilo::ColReduction::NONE, master_col, f_t{0});
+    }
     ++n_substitutions;
   }
 
@@ -450,7 +470,7 @@ papilo::PresolveStatus SingleLockDualAggregation<f_t>::execute(
 
   int n_substitutions = 0;
   std::vector<f_t> dense_row_coefs(ncols, f_t{0});
-  std::vector<uint8_t> substituted(ncols, 0);
+  std::vector<uint8_t> used_in_substitution(ncols, 0);
 
   auto cand_it = candidates.begin();
   while (cand_it != candidates.end()) {
@@ -467,7 +487,7 @@ papilo::PresolveStatus SingleLockDualAggregation<f_t>::execute(
       cand_it, candidates.end(), [r](const candidate_t& c) { return c.locking_row != r; });
 
     n_substitutions += try_substitutions_for_row(
-      problem, num, reductions, cand_it, row_end, r, dense_row_coefs, substituted);
+      problem, num, reductions, cand_it, row_end, r, dense_row_coefs, used_in_substitution);
 
     cand_it = row_end;
   }

--- a/cpp/tests/mip/single_lock_dual_aggregation_test.cpp
+++ b/cpp/tests/mip/single_lock_dual_aggregation_test.cpp
@@ -78,8 +78,10 @@ struct papilo_harness_t {
     return false;
   }
 
-  bool replacement_locks_dependencies(
-    int col1, int col2, int row, const std::unordered_set<int>& bound_cols) const
+  bool replacement_locks_dependencies(int col1,
+                                      int col2,
+                                      int row,
+                                      const std::unordered_set<int>& bound_cols) const
   {
     const auto& txns = reductions.getTransactions();
     const auto& reds = reductions.getReductions();
@@ -448,11 +450,7 @@ TEST(SingleLockDualAggregation, PreventsSubstitutionChains)
 {
   auto problem = build_problem(2,
                                3,
-                               {{0, 0, 3.0},
-                                {0, 1, -3.0},
-                                {1, 0, -4.0},
-                                {1, 1, 4.0},
-                                {1, 2, -5.0}},
+                               {{0, 0, 3.0}, {0, 1, -3.0}, {1, 0, -4.0}, {1, 1, 4.0}, {1, 2, -5.0}},
                                {-1.0, -1.0, 0.0},
                                {0.0, 0.0, 0.0},
                                {1.0, 1.0, 1.0},
@@ -497,7 +495,7 @@ Binaries
   z
 End
 )LP",
-                            {"single_lock_dual_aggregation"});
+                             {"single_lock_dual_aggregation"});
 
   EXPECT_TRUE(result.status == third_party_presolve_status_t::REDUCED ||
               result.status == third_party_presolve_status_t::OPTIMAL);

--- a/cpp/tests/mip/single_lock_dual_aggregation_test.cpp
+++ b/cpp/tests/mip/single_lock_dual_aggregation_test.cpp
@@ -66,13 +66,48 @@ struct papilo_harness_t {
     const auto& txns = reductions.getTransactions();
     const auto& reds = reductions.getReductions();
     for (const auto& t : txns) {
-      if (t.end - t.start != 2) continue;
-      const auto& r0 = reds[t.start];
-      const auto& r1 = reds[t.start + 1];
+      const int payload_start = t.start + t.nlocks;
+      if (t.end - payload_start != 2) continue;
+      const auto& r0 = reds[payload_start];
+      const auto& r1 = reds[payload_start + 1];
       if (r0.row == papilo::ColReduction::REPLACE && r0.col == col1 &&
           std::abs(r0.newval - factor) < 1e-9 && r1.col == col2 &&
           std::abs(r1.newval - offset) < 1e-9)
         return true;
+    }
+    return false;
+  }
+
+  bool replacement_locks_dependencies(
+    int col1, int col2, int row, const std::unordered_set<int>& bound_cols) const
+  {
+    const auto& txns = reductions.getTransactions();
+    const auto& reds = reductions.getReductions();
+    for (const auto& t : txns) {
+      const int payload_start = t.start + t.nlocks;
+      if (t.end - payload_start != 2) continue;
+      const auto& replacement = reds[payload_start];
+      const auto& master      = reds[payload_start + 1];
+      if (replacement.row != papilo::ColReduction::REPLACE || replacement.col != col1 ||
+          master.col != col2)
+        continue;
+
+      bool col1_locked = false;
+      bool col2_locked = false;
+      bool row_locked  = false;
+      std::unordered_set<int> locked_bound_cols;
+      for (int i = t.start; i < payload_start; ++i) {
+        const auto& lock = reds[i];
+        if (lock.row == papilo::ColReduction::LOCKED) {
+          col1_locked |= lock.col == col1;
+          col2_locked |= lock.col == col2;
+        } else if (lock.row == papilo::ColReduction::BOUNDS_LOCKED) {
+          locked_bound_cols.insert(lock.col);
+        } else if (lock.row == row && lock.col == papilo::RowReduction::LOCKED) {
+          row_locked = true;
+        }
+      }
+      return col1_locked && col2_locked && row_locked && locked_bound_cols == bound_cols;
     }
     return false;
   }
@@ -141,6 +176,7 @@ TEST(SingleLockDualAggregation, DirectSubstitution)
 
   EXPECT_EQ(status, papilo::PresolveStatus::kReduced);
   EXPECT_TRUE(h.has_replace(0, 1, 1.0, 0.0));  // x = y
+  EXPECT_TRUE(h.replacement_locks_dependencies(0, 1, 0, {0, 1}));
 }
 
 // Direct master has no negative binary coeff, so direct probe fails.
@@ -408,6 +444,33 @@ TEST(SingleLockDualAggregation, ZeroObjectiveNeedsFullDualreds)
   }
 }
 
+TEST(SingleLockDualAggregation, PreventsSubstitutionChains)
+{
+  auto problem = build_problem(2,
+                               3,
+                               {{0, 0, 3.0},
+                                {0, 1, -3.0},
+                                {1, 0, -4.0},
+                                {1, 1, 4.0},
+                                {1, 2, -5.0}},
+                               {-1.0, -1.0, 0.0},
+                               {0.0, 0.0, 0.0},
+                               {1.0, 1.0, 1.0},
+                               {true, true, true},
+                               {0.0, 0.0},
+                               {1.0, -1.0},
+                               {true, true},
+                               {false, false});
+
+  SingleLockDualAggregation<double> presolver;
+  papilo_harness_t h;
+  auto status = h.run(problem, presolver);
+
+  EXPECT_EQ(status, papilo::PresolveStatus::kReduced);
+  EXPECT_TRUE(h.has_replace(0, 1, 1.0, 0.0));
+  EXPECT_FALSE(h.has_replace(1, 2, 1.0, 0.0));
+}
+
 third_party_presolve_device_result_t<int, double> static run_presolve(
   std::string_view lp_text, std::unordered_set<std::string> allowlist)
 {
@@ -418,6 +481,26 @@ third_party_presolve_device_result_t<int, double> static run_presolve(
   presolver->set_reduction_allowlist(std::move(allowlist));
   return presolver->apply_presolve_from_op_problem(
     op_problem, problem_category_t::MIP, presolver_t::Papilo, false, 1e-6, 1e-12, 20, 1);
+}
+
+TEST(SingleLockDualAggregation, AppliesOnlyDisjointSubstitutions)
+{
+  auto result = run_presolve(R"LP(
+Minimize
+  obj: - x - y
+Subject To
+  r0: 3 x - 3 y <= 1
+  r1: -4 x + 4 y - 5 z <= -1
+Binaries
+  x
+  y
+  z
+End
+)LP",
+                            {"single_lock_dual_aggregation"});
+
+  EXPECT_TRUE(result.status == third_party_presolve_status_t::REDUCED ||
+              result.status == third_party_presolve_status_t::OPTIMAL);
 }
 
 }  // namespace cuopt::mathematical_optimization::mip::test


### PR DESCRIPTION
Papilo's `replaceCol` does not hold the column locks required for the single-lock-dual-aggregation presolver to function correctly. This caused internal papilo assertions in some subMIP calls.

Fixed by adding the appropriate locks manually


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
