### PR TITLE
Fix cuopt_mvn retry loop being silently skipped under set -e

### DIFF
--- a/java/cuopt/scripts/maven.sh
+++ b/java/cuopt/scripts/maven.sh
@@ -30,9 +30,14 @@ cuopt_mvn() {
   log="$(mktemp)"
 
   while true; do
-    # tee would otherwise report its own exit status rather than Maven's.
-    mvn "${CUOPT_MVN_ARGS[@]}" "$@" 2>&1 | tee "${log}"
-    status="${PIPESTATUS[0]}"
+    # The pipeline is the condition of this if, not a bare statement, so its failure does not
+    # trigger the caller's 'set -e' before the retry logic below gets to see it. tee would
+    # otherwise report its own exit status rather than Maven's, hence PIPESTATUS.
+    if mvn "${CUOPT_MVN_ARGS[@]}" "$@" 2>&1 | tee "${log}"; then
+      status=0
+    else
+      status="${PIPESTATUS[0]}"
+    fi
     if [[ "${status}" -eq 0 ]]; then
       rm -f "${log}"
       return 0

--- a/java/cuopt/scripts/maven.sh
+++ b/java/cuopt/scripts/maven.sh
@@ -30,9 +30,7 @@ cuopt_mvn() {
   log="$(mktemp)"
 
   while true; do
-    # The pipeline is the condition of this if, not a bare statement, so its failure does not
-    # trigger the caller's 'set -e' before the retry logic below gets to see it. tee would
-    # otherwise report its own exit status rather than Maven's, hence PIPESTATUS.
+    # Guarded by if so a failure doesn't trigger the caller's set -e before we see PIPESTATUS.
     if mvn "${CUOPT_MVN_ARGS[@]}" "$@" 2>&1 | tee "${log}"; then
       status=0
     else


### PR DESCRIPTION
## Summary
- `cuopt_mvn`'s retry/backoff loop (`java/cuopt/scripts/maven.sh`, added in #1524 to address #1820) never actually ran: `test.sh` invokes it under `set -euo pipefail`, and the loop ran `mvn ... | tee "${log}"` as a bare statement rather than as the condition of an `if`/`while`. With `pipefail` on, a failing `mvn` makes the pipeline's exit status non-zero, and `set -e` then kills the function immediately — before the code that reads `PIPESTATUS[0]` and decides whether to retry ever runs.
- Confirmed against a live failure (job [98796785653](https://github.com/NVIDIA/cuopt/actions/runs/33106999631/job/98796785653), PR #1810, 2026-08-28): a single `mvn` attempt hits a Maven Central 429, and the job fails immediately with none of `cuopt_mvn`'s retry log lines present, even though that branch already had the retry code.
- Fix: guard the pipeline as the condition of an `if` so its failure is caught by the loop instead of triggering the caller's `set -e`. Verified locally that the loop now retries with backoff on a simulated 429 and still returns cleanly on success.

## Test plan
- [ ] `java-build` CI passes
- [x] Local repro: stubbed `mvn` returning a 429-style error under `set -euo pipefail` now produces `mvn attempt 1/3 ...`, `attempt 2/3 ...`, backoff sleeps, and a final failure only after exhausting retries (previously died on attempt 1 with no retry log at all)
- [x] Local repro: stubbed `mvn` returning success still returns 0 immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)