### PR TITLE
Remove unused cusolver/curand deps from libcuopt

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -31,8 +31,6 @@ dependencies:
 - libabseil
 - libboost-devel
 - libcudss-dev >=0.7,<0.8
-- libcurand-dev
-- libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
 - libnvjitlink-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -31,8 +31,6 @@ dependencies:
 - libabseil
 - libboost-devel
 - libcudss-dev >=0.7,<0.8
-- libcurand-dev
-- libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
 - libnvjitlink-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -31,8 +31,6 @@ dependencies:
 - libabseil
 - libboost-devel
 - libcudss-dev >=0.7,<0.8
-- libcurand-dev
-- libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
 - libnvjitlink-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -31,8 +31,6 @@ dependencies:
 - libabseil
 - libboost-devel
 - libcudss-dev >=0.7,<0.8
-- libcurand-dev
-- libcusolver-dev
 - libcusparse-dev
 - libgrpc >=1.78.0,<1.80.0a0
 - libnvjitlink-dev

--- a/conda/recipes/libcuopt/recipe.yaml
+++ b/conda/recipes/libcuopt/recipe.yaml
@@ -85,7 +85,6 @@ cache:
       - rapids-logger =0.3
       - cuda-nvtx-dev
       - libcudss-dev >=0.7,<0.8
-      - libcurand-dev
       - libcusparse-dev
       - libnvjitlink-dev
       - libboost-devel
@@ -158,7 +157,6 @@ outputs:
           - cuda-nvtx
           - cuda-version
           - libcudss
-          - libcurand
           - libcusparse
           - librmm
           - libboost
@@ -206,7 +204,6 @@ outputs:
         by_name:
           - cuda-nvtx
           - cuda-version
-          - libcurand
           - libcusparse
           - libcudss
           - librmm

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -720,8 +720,6 @@ endif ()
 # - link libraries --------------------------------------------------------------------------------
 
 set(CUOPT_PRIVATE_CUDA_LIBS
-        CUDA::curand
-        CUDA::cusolver
         TBB::tbb
         OpenMP::OpenMP_CXX)
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -749,8 +749,6 @@ dependencies:
       - output_types: [conda]
         packages:
           - libcudss-dev >=0.7,<0.8
-          - libcurand-dev
-          - libcusolver-dev
           - libcusparse-dev
           - cuda-nvtx-dev
           - libnvjitlink-dev


### PR DESCRIPTION
Neither `cusolver` nor `curand` is referenced anywhere in `cpp/src`, and no RAFT header cuOpt includes touches either library. Verified with a full local build: `nm -D --undefined-only` on the resulting `libcuopt.so` shows zero `cusolver`/`curand` symbols among its 762 undefined dynamic symbols.

`libcusolver-dev`/`libcurand-dev` removed from `dependencies.yaml` (conda environments regenerated). `libcurand-dev` and its `ignore_run_exports` entry removed from `recipe.yaml` — `cusolver` was never explicitly declared there, only inherited via `libraft-headers`.

`curand` was added deliberately in the past (not just inherited), despite the same zero-usage finding — see git blame on the removed `CUDA::curand` line (`9f241a19`, around when the barrier method moved to cuDSS for sparse Cholesky/LDLT) for context worth a second look.

Out of scope: the `cuda_wheels` pip/wheel install path (separate distribution channel, untested here), and switching `libraft-headers` → `libraft-headers-only` (bigger change, needs its own conda-build validation).