### PR TITLE
Fix asynchronous clique table handoff

### DIFF
--- a/cpp/src/cuts/cuts.hpp
+++ b/cpp/src/cuts/cuts.hpp
@@ -665,14 +665,14 @@ class cut_generation_t {
                    const std::vector<simplex::variable_type_t>& var_types,
                    const simplex::user_problem_t<i_t, f_t>& user_problem,
                    const probing_implied_bound_t<i_t, f_t>& probing_implied_bound,
-                   std::shared_ptr<mip::clique_table_t<i_t, f_t>> clique_table = nullptr,
-                   omp_atomic_t<bool>* signal_extend                           = nullptr)
+                   std::shared_ptr<mip::clique_table_t<i_t, f_t>>& clique_table,
+                   omp_atomic_t<bool>* signal_extend = nullptr)
     : cut_pool_(cut_pool),
       knapsack_generation_(lp, settings, Arow, new_slacks, var_types),
       flow_cover_generation_(lp, settings, Arow, new_slacks),
       user_problem_(user_problem),
       probing_implied_bound_(probing_implied_bound),
-      clique_table_(std::move(clique_table)),
+      clique_table_(clique_table),
       signal_extend_(signal_extend)
   {
   }
@@ -770,7 +770,9 @@ class cut_generation_t {
   flow_cover_generation_t<i_t, f_t> flow_cover_generation_;
   const simplex::user_problem_t<i_t, f_t>& user_problem_;
   const probing_implied_bound_t<i_t, f_t>& probing_implied_bound_;
-  std::shared_ptr<mip::clique_table_t<i_t, f_t>> clique_table_;
+  // The background clique-table task publishes into the branch-and-bound owner's shared pointer.
+  // Keep a live reference so the synchronized cut pass consumes the published table.
+  std::shared_ptr<mip::clique_table_t<i_t, f_t>>& clique_table_;
   omp_atomic_t<bool>* signal_extend_{nullptr};
   fractional_conflict_subgraph_t<i_t, f_t> sub_cg_;
 };

--- a/cpp/tests/mip/cuts_test.cu
+++ b/cpp/tests/mip/cuts_test.cu
@@ -13,6 +13,7 @@
 #include <cuopt/mathematical_optimization/pdlp/solver_solution.hpp>
 #include <cuopt/mathematical_optimization/solve.hpp>
 #include <cuts/cuts.hpp>
+#include <mip_heuristics/mip_constants.hpp>
 #include <mip_heuristics/presolve/conflict_graph/clique_table.cuh>
 #include <mip_heuristics/problem/problem.cuh>
 #include <utilities/common_utils.hpp>
@@ -1183,6 +1184,29 @@ TEST(cuts, clique_phase4_tree_depth_limit_smoke)
     EXPECT_NEAR(
       root_only_solution.get_objective_value(), deeper_solution.get_objective_value(), 1e-6);
   }
+}
+
+TEST(cuts, async_clique_table_closes_triangle_root_gap)
+{
+  const raft::handle_t handle{};
+  auto problem = create_pairwise_triangle_set_packing_problem();
+
+  mip_solver_settings_t<int, double> settings;
+  settings.time_limit      = 10.0;
+  settings.presolver       = presolver_t::None;
+  settings.node_limit      = 0;
+  settings.num_cpu_threads = CUOPT_MIP_CLIQUE_CUTS_REQUIRED_THREAD_COUNT;
+  disable_non_clique_cuts(settings);
+
+  benchmark_info_t benchmark_info;
+  settings.benchmark_info_ptr = &benchmark_info;
+  auto solution               = solve_mip(&handle, problem, settings);
+
+  EXPECT_NE(solution.get_termination_status(), mip_termination_status_t::Infeasible);
+  ASSERT_FALSE(std::isnan(benchmark_info.root_lp_no_cuts));
+  ASSERT_FALSE(std::isnan(benchmark_info.root_lp_with_cuts));
+  EXPECT_NEAR(benchmark_info.root_lp_no_cuts, -1.5, kCliqueTestTol);
+  EXPECT_NEAR(benchmark_info.root_lp_with_cuts, -1.0, kCliqueTestTol);
 }
 
 TEST(cuts, clique_phase5_ignores_non_binary_variables)


### PR DESCRIPTION
The root-cut generator could retain a stale null snapshot of the clique table while that table was being constructed asynchronously.

Race sequence:
- branch_and_bound_t::clique_table_ is initially null.
- An asynchronous task starts building the table.
- cut_generation_t is constructed and copies the still-null shared_ptr.
- The asynchronous task publishes the completed table.
- Root separation waits for the task, but its copied pointer remains null.
- Conflict-graph clique cuts and the conflict-graph portion of Zero-Half cuts are skipped.


Metric | Main | Clique fix | Change
-- | -- | -- | --
Root completion | 167 | 166 | -1
Total root-time geomean, N=160 | 3.760 s | 3.987 s | +6.02%
Total root-time mean | 23.879 s | 27.087 s | +3.208 s
Root gap closed, N=159 | 30.955% | 30.986% | +0.030 pp
Root-gap better/tied/worse | — | 11/140/8 | Essentially neutral


Instance | Root time: main → fix | Ratio | Root gap: main → fix | Change
-- | -- | -- | -- | --
ns1208400 | 4.06 → 54.05 s | 13.31× | 0.000% → 0.000% | 0.000 pp
proteindesign122trx11p8 | 7.34 → 21.46 s | 2.92× | 20.667% → 23.961% | +3.293 pp
proteindesign121hz512p9 | 10.01 → 24.29 s | 2.43× | 16.683% → 18.288% | +1.605 pp
comp21-2idx | 14.46 → 23.62 s | 1.63× | 50.676% → 54.248% | +3.573 pp

Three regressions bought stronger root bounds. `ns1208400` incurred the largest cost without any root-gap improvement.

