### PR TITLE
Fix vendored PSLP writing a stray infeasible-message printf to native stdout

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -292,10 +292,13 @@ FetchContent_MakeAvailable(papilo)
 
 # PSLP - Lightweight C presolver for linear programs
 # https://github.com/dance858/PSLP
+#
+# Pinned past v0.0.11 to a commit rather than a tag: fixes a stray infeasible-message printf
+# that ignored verbose=false (dance858/PSLP#55). Move to a released tag once one includes it.
 FetchContent_Declare(
         pslp
         GIT_REPOSITORY "https://github.com/dance858/PSLP.git"
-        GIT_TAG "v0.0.11"
+        GIT_TAG "12d37dd9ab5ee848b3ec5da17f4cf8e805d58cd6"
         GIT_PROGRESS TRUE
         EXCLUDE_FROM_ALL
         SYSTEM


### PR DESCRIPTION
## Summary

- `run_presolver()` in vendored PSLP (`dance858/PSLP`, pinned at `v0.0.11`) prints `"PSLP declares problem as infeasible[.| or unbounded.]"` unconditionally, unlike every other console message in that function, which are all gated behind `stgs->verbose` (`print_start_message`, `print_end_message`, etc).
- cuOpt already sets `verbose = false` when calling PSLP (`third_party_presolve.cpp`) specifically to keep it silent -- this one message was just missed upstream, so it writes straight to the process's native stdout regardless.
- Found while investigating the Java bindings' "Corrupted channel" Surefire crash on #1818: a raw native write there bypasses `System.out` and corrupts Maven Surefire's forked-JVM protocol, which also multiplexes over stdout. Confirmed directly by reading the exact corrupted text out of a captured Surefire `.dumpstream` artifact.
- The infeasible/unbounded status itself is unaffected by this fix -- it already flows back to the caller through `run_presolver()`'s typed return value, not by parsing this printed text.

## Fix

Filed and fixed upstream: https://github.com/dance858/PSLP/pull/55. Until a release containing it ships, pin `cpp/CMakeLists.txt`'s `GIT_TAG` past `v0.0.11` directly at the merge commit, rather than patching the vendored source locally.

## Test plan

- [x] Confirmed via a captured `.dumpstream` artifact that this exact message was the corrupted text.
- [x] `ProblemIntegrationTest`'s infeasible-solve test case (Java bindings) exercises this code path directly.
- [ ] CI passes clean.

Split out of #1825, which originally carried this alongside an unrelated fix (routing cuOpt's own console logging through `System.out`).