### PR TITLE
RoutingClient: match Client's (host, port, tls=...) signature

### DIFF
--- a/python/cuopt/cuopt/grpc/client/grpc_client.pyx
+++ b/python/cuopt/cuopt/grpc/client/grpc_client.pyx
@@ -970,13 +970,26 @@ cdef class RoutingClient:
 
     cdef unique_ptr[grpc_python_client_t] _client
 
-    def __cinit__(self, str target="localhost:50051"):
-        host, _, port = target.rpartition(":")
-        if not host:
-            host, port = target, "50051"
+    def __cinit__(self, str host, int port, *, tls=None):
+        """
+        Connect to ``cuopt_grpc_server`` at ``host:port``.
+
+        ``tls`` controls transport security, same as :class:`Client`:
+
+        * ``None`` (default) — read ``CUOPT_TLS_*`` from the environment.
+        * ``False`` — plain TCP; ignore ``CUOPT_TLS_*``.
+        * :class:`TlsConfig` — explicit TLS/mTLS; omit ``root_certs`` to use the
+          system/default CA trust store.
+        """
+        if tls is not None and tls is not False and not isinstance(tls, TlsConfig):
+            raise TypeError("tls must be None, False, or TlsConfig")
+
+        cdef grpc_python_client_connect_options_t options
         cdef string host_cpp = host.encode("utf-8")
         cdef string err
-        self._client.reset(new grpc_python_client_t(host_cpp, int(port)))
+
+        options = _connect_options_from_tls(tls)
+        self._client.reset(new grpc_python_client_t(host_cpp, port, options))
         if not self._client.get().connect(err):
             raise RoutingSolveError(
                 "failed to connect: " + err.decode("utf-8")

--- a/python/cuopt/cuopt/grpc/routing/__init__.py
+++ b/python/cuopt/cuopt/grpc/routing/__init__.py
@@ -12,7 +12,7 @@ Build a :class:`cuopt.routing.DataModel` and solve it on a remote
     dm = routing.DataModel(n_locations, n_fleet)
     dm.add_cost_matrix(cost)
     ...
-    client = RoutingClient("gpu-host:50051")
+    client = RoutingClient("gpu-host", 50051)
     solution = client.solve(dm)
 """
 

--- a/python/cuopt/cuopt/tests/routing/test_routing_grpc_client.py
+++ b/python/cuopt/cuopt/tests/routing/test_routing_grpc_client.py
@@ -25,6 +25,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _client():
+    host, _, port = (_SERVER or "").rpartition(":")
+    return grpc_routing.RoutingClient(host, int(port))
+
+
 def _small_vrp():
     dm = routing.DataModel(5, 2)
     cost = np.array(
@@ -46,7 +51,7 @@ def test_remote_solve_matches_local():
     settings.set_time_limit(2)
     local = routing.Solve(_small_vrp(), settings)
 
-    client = grpc_routing.RoutingClient(_SERVER)
+    client = _client()
     remote = client.solve(_small_vrp(), {"time_limit": 2.0})
 
     assert remote["status"] == 0, remote["status_message"]
@@ -57,7 +62,7 @@ def test_remote_solve_matches_local():
 
 
 def test_submit_wait_result_lifecycle():
-    client = grpc_routing.RoutingClient(_SERVER)
+    client = _client()
     job_id = client.submit(_small_vrp(), {"time_limit": 1.0})
     assert job_id
     client.wait(job_id, timeout=30)

--- a/python/cuopt/cuopt/tests/routing/test_routing_grpc_client_tls.py
+++ b/python/cuopt/cuopt/tests/routing/test_routing_grpc_client_tls.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TLS/mTLS coverage for the compiled VRP gRPC client (cuopt.grpc.routing).
+
+Unlike test_routing_grpc_client.py, these tests do not need
+CUOPT_GRPC_SERVER -- the tls_server_info/mtls_server_info fixtures start
+their own cuopt_grpc_server subprocess (skipped if the test TLS certs are
+not found).
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from cuopt import routing
+from cuopt.grpc.linear_programming import TlsConfig
+
+grpc_routing = pytest.importorskip("cuopt.grpc.routing")
+
+
+def _small_vrp():
+    dm = routing.DataModel(5, 2)
+    cost = np.array(
+        [
+            [0, 1, 2, 2, 1],
+            [1, 0, 1, 2, 2],
+            [2, 1, 0, 1, 2],
+            [2, 2, 1, 0, 1],
+            [1, 2, 2, 1, 0],
+        ],
+        dtype=np.float32,
+    )
+    dm.add_cost_matrix(cost)
+    return dm
+
+
+def test_rejects_invalid_tls_argument():
+    with pytest.raises(TypeError):
+        grpc_routing.RoutingClient("localhost", 1, tls="bogus")
+
+
+@pytest.mark.xdist_group(name="grpc_server")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+class TestRoutingClientTls:
+    def test_submit_with_explicit_tls_config(self, tls_server_info):
+        cert_dir = tls_server_info["cert_dir"]
+        client = grpc_routing.RoutingClient(
+            "localhost",
+            tls_server_info["port"],
+            tls=TlsConfig(os.path.join(cert_dir, "ca.crt")),
+        )
+        solution = client.solve(_small_vrp(), {"time_limit": 2.0})
+        assert solution["status"] == 0, solution["status_message"]
+
+    def test_tls_server_rejects_plain_client(self, tls_server_info):
+        with pytest.raises(grpc_routing.RoutingSolveError):
+            grpc_routing.RoutingClient(
+                "localhost", tls_server_info["port"], tls=False
+            )
+
+    def test_submit_with_explicit_mtls_config(self, mtls_server_info):
+        cert_dir = mtls_server_info["cert_dir"]
+        client = grpc_routing.RoutingClient(
+            "localhost",
+            mtls_server_info["port"],
+            tls=TlsConfig(
+                os.path.join(cert_dir, "ca.crt"),
+                client_cert=os.path.join(cert_dir, "client.crt"),
+                client_key=os.path.join(cert_dir, "client.key"),
+            ),
+        )
+        solution = client.solve(_small_vrp(), {"time_limit": 2.0})
+        assert solution["status"] == 0, solution["status_message"]
+
+    def test_mtls_server_rejects_missing_client_cert(self, mtls_server_info):
+        cert_dir = mtls_server_info["cert_dir"]
+        with pytest.raises(grpc_routing.RoutingSolveError):
+            grpc_routing.RoutingClient(
+                "localhost",
+                mtls_server_info["port"],
+                tls=TlsConfig(os.path.join(cert_dir, "ca.crt")),
+            )


### PR DESCRIPTION
## Summary

Fixes #1839. `cuopt.grpc.routing.RoutingClient` diverged from the LP/MIP `cuopt.grpc.linear_programming.Client`: it took a single `"host:port"` string and had no way to configure TLS, even though it reuses the exact same `grpc_python_client_t` C++ shim `Client` uses -- which already had TLS support (via a `grpc_python_client_connect_options_t` overload) more than 5 weeks before `RoutingClient` was added. See #1839 for the full chronology and evidence this was an oversight from a POC-scoped first cut (#1597), not a deliberate design choice -- it never came up in that PR's review, unlike every other follow-up from it.

## Changes

- `RoutingClient.__cinit__` now takes `(host: str, port: int, *, tls=None)`, mirroring `Client.__init__` exactly: `tls=None` reads `CUOPT_TLS_*` from the environment (same default as before), `tls=False` forces plain TCP, `tls=TlsConfig(...)` sets explicit TLS/mTLS. Reuses the existing `_connect_options_from_tls()` helper and the TLS-options constructor overload `Client` already used -- no new C++ needed, both `.pxd` overloads were already declared.
- Updated the two existing call sites: the `cuopt.grpc.routing` package docstring example, and `test_routing_grpc_client.py`'s `_client()` helper (parses `CUOPT_GRPC_SERVER=host:port` into the two args now).
- Added `test_routing_grpc_client_tls.py`: an offline `TypeError`-on-bad-`tls`-value test, plus a `TestRoutingClientTls` class mirroring `TestGrpcClientTls` from the LP test suite (TLS submit, plain-client-against-TLS-server rejection, mTLS submit, mTLS-missing-client-cert rejection) using the existing `tls_server_info`/`mtls_server_info` fixtures -- these don't need `CUOPT_GRPC_SERVER`, they start their own server subprocess.

This is a breaking signature change, not additive -- `RoutingClient` was added in #1597 and isn't in a stable release yet (the docs describing it, #1838, are still in review), so there's no compatibility surface to preserve.

## Out of scope

- 2 GiB chunked upload/download -- already tracked separately in #1629, a materially larger feature (server + client, mirroring the LP/MIP chunked path).
- Log/incumbent streaming parity -- #1630.

## Test plan

- [x] `.pyx` → `.cxx` Cython transpile and C++ compile clean (`ninja cuopt/grpc/client/CMakeFiles/grpc_client_grpc_client.dir/grpc_client.cxx.o`).
- [x] Full extension module links clean (`ninja grpc_client_grpc_client`).
- [x] Pre-commit hooks pass (ruff, pydocstyle, copyright, etc.).
- [ ] Live pytest run against a `cuopt_grpc_server` -- the installed dev environment's `cuopt` package predates the `grpc/routing` merge (#1597), so a full reinstall would be needed locally; CI's environment builds from this branch and should exercise the new tests.
