### PR TITLE
Fix compilation with Clang / LLVM

### DIFF
--- a/cpp/src/dual_simplex/presolve.cpp
+++ b/cpp/src/dual_simplex/presolve.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cuopt/logger_macros.hpp>
 #include <iostream>
 
 namespace cuopt::mathematical_optimization::simplex {

--- a/cpp/src/grpc/server/grpc_pipe_serialization.hpp
+++ b/cpp/src/grpc/server/grpc_pipe_serialization.hpp
@@ -61,7 +61,7 @@ inline bool read_protobuf_from_pipe(int fd, google::protobuf::MessageLite& msg)
   uint32_t size;
   if (!read_from_pipe(fd, &size, sizeof(size))) return false;
   if (size > kMaxProtobufMessageBytes) return false;
-  if (size == 0) return msg.ParseFromArray(nullptr, 0);
+  if (size == 0) return msg.ParseFromArray(static_cast<const void*>(nullptr), 0);
   std::vector<uint8_t> buf(size);
   if (!read_from_pipe(fd, buf.data(), size)) return false;
   return msg.ParseFromArray(buf.data(), static_cast<int>(size));

--- a/cpp/src/io/utilities/error.hpp
+++ b/cpp/src/io/utilities/error.hpp
@@ -6,6 +6,7 @@
 /* clang-format on */
 #pragma once
 
+#include <cstdlib>
 #include <string>
 
 #include <stdarg.h>

--- a/cpp/src/mip_heuristics/diversity/multi_armed_bandit.cu
+++ b/cpp/src/mip_heuristics/diversity/multi_armed_bandit.cu
@@ -137,7 +137,7 @@ void mab_t::add_mab_reward(int option_id,
                            double offspring_quality,
                            Func work_normalized_reward)
 {
-  double epsilon                      = max(1e-6, 1e-4 * fabs(best_feasible_quality));
+  double epsilon                      = std::max(1e-6, 1e-4 * fabs(best_feasible_quality));
   bool is_better_than_best_feasible   = offspring_quality + epsilon < best_feasible_quality;
   bool is_better_than_best_of_parents = offspring_quality + epsilon < best_of_parents_quality;
   if (option_id >= 0 && option_id < static_cast<int>(mab_arm_stats_.size())) {

--- a/cpp/src/mip_heuristics/diversity/population.cu
+++ b/cpp/src/mip_heuristics/diversity/population.cu
@@ -213,7 +213,7 @@ std::vector<solution_t<i_t, f_t>> population_t<i_t, f_t>::get_external_solutions
         new_best_feasible_objective = h_entry.objective;
       }
 
-      longest_wait_time = max(longest_wait_time, h_entry.timer.elapsed_time());
+      longest_wait_time = std::max(longest_wait_time, h_entry.timer.elapsed_time());
       solution_t<i_t, f_t> sol(*problem_ptr);
       sol.copy_new_assignment(h_entry.solution);
       sol.compute_feasibility();
@@ -412,7 +412,7 @@ void population_t<i_t, f_t>::adjust_weights_according_to_best_feasible()
                     best().get_objective());
     cuopt_assert(weighted_violation_of_best > 1e-10, "Weighted violation of best is not positive");
     // fixme
-    weighted_violation_of_best = max(weighted_violation_of_best, 1e-10);
+    weighted_violation_of_best = std::max(weighted_violation_of_best, 1e-10);
     f_t quality_difference     = best_feasible().get_quality(weights) - best().get_quality(weights);
     CUOPT_LOG_DEBUG("quality_difference %f best_feasible_quality %f best_quality %f",
                     quality_difference,
@@ -423,7 +423,7 @@ void population_t<i_t, f_t>::adjust_weights_according_to_best_feasible()
     f_t increase_ratio =
       (quality_difference * infeasibility_balance_ratio) / weighted_violation_of_best;
     infeasibility_importance *= (1 + increase_ratio);
-    infeasibility_importance = min(max_infeasibility_weight, infeasibility_importance);
+    infeasibility_importance = std::min(max_infeasibility_weight, infeasibility_importance);
     normalize_weights();
     update_qualities();
     cuopt_assert(test_invariant(), "Population invariant doesn't hold");

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
@@ -573,7 +573,7 @@ class fj_t {
       {
         f_t cstr_tolerance = get_cstr_tolerance<i_t, f_t>(
           c_lb, c_ub, pb.tolerances.absolute_tolerance, pb.tolerances.relative_tolerance);
-        return max((f_t)1e-12, cstr_tolerance - MACHINE_EPSILON);
+        return std::max((f_t)1e-12, cstr_tolerance - MACHINE_EPSILON);
       }
       HDI f_t get_corrected_tolerance(i_t cstr) const
       {

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
@@ -1283,7 +1283,6 @@ template <typename i_t, typename f_t>
 __global__ void handle_local_minimum_kernel(typename fj_t<i_t, f_t>::climber_data_t::view_t fj)
 {
   raft::random::PCGenerator rng(fj.settings->seed + *fj.iterations, 0, 0);
-  __shared__ typename fj_t<i_t, f_t>::move_score_t shmem[2 * raft::WarpSize];
   if (*fj.break_condition) return;
 
   // did we reach a local minimum?

--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -920,15 +920,15 @@ static void smooth_weights(fj_cpu_climber_t<i_t, f_t>& fj_cpu)
     // consider only satisfied constraints
     if (fj_cpu.violated_constraints.count(cstr_idx)) continue;
 
-    f_t weight_l = max((f_t)0, fj_cpu.h_cstr_left_weights[cstr_idx] - 1);
-    f_t weight_r = max((f_t)0, fj_cpu.h_cstr_right_weights[cstr_idx] - 1);
+    f_t weight_l = std::max((f_t)0, fj_cpu.h_cstr_left_weights[cstr_idx] - 1);
+    f_t weight_r = std::max((f_t)0, fj_cpu.h_cstr_right_weights[cstr_idx] - 1);
 
     fj_cpu.h_cstr_left_weights[cstr_idx]  = weight_l;
     fj_cpu.h_cstr_right_weights[cstr_idx] = weight_r;
   }
 
   if (fj_cpu.h_objective_weight > 0 && fj_cpu.h_incumbent_objective >= fj_cpu.h_best_objective) {
-    fj_cpu.h_objective_weight = max((f_t)0, fj_cpu.h_objective_weight - 1);
+    fj_cpu.h_objective_weight = std::max((f_t)0, fj_cpu.h_objective_weight - 1);
   }
 }
 
@@ -971,10 +971,10 @@ static void update_weights(fj_cpu_climber_t<i_t, f_t>& fj_cpu)
 
     if (curr_lower_excess < 0.) {
       fj_cpu.h_cstr_left_weights[cstr_idx] = new_weight;
-      fj_cpu.max_weight                    = max(fj_cpu.max_weight, new_weight);
+      fj_cpu.max_weight                    = std::max(fj_cpu.max_weight, new_weight);
     } else {
       fj_cpu.h_cstr_right_weights[cstr_idx] = new_weight;
-      fj_cpu.max_weight                     = max(fj_cpu.max_weight, new_weight);
+      fj_cpu.max_weight                     = std::max(fj_cpu.max_weight, new_weight);
     }
 
     // Invalidate related cached move scores
@@ -1428,9 +1428,9 @@ static thrust::tuple<fj_move_t, fj_staged_score_t> find_lift_move(
             continue;
           } else {
             if (cstr_coeff * sign < 0) {
-              lfd_lb = max(lfd_lb, delta);
+              lfd_lb = std::max(lfd_lb, delta);
             } else {
-              lfd_ub = min(lfd_ub, delta);
+              lfd_ub = std::min(lfd_ub, delta);
             }
           }
         }

--- a/cpp/src/mip_heuristics/presolve/probing_cache.cu
+++ b/cpp/src/mip_heuristics/presolve/probing_cache.cu
@@ -514,8 +514,8 @@ void compute_cache_for_var(i_t var_idx,
     // TODO do the check in parallel
     for (size_t i = 0; i < h_improved_lower_bounds_0.size(); i++) {
       if (i == (size_t)var_idx) { continue; }
-      f_t lower_bound = min(h_improved_lower_bounds_0[i], h_improved_lower_bounds_1[i]);
-      f_t upper_bound = max(h_improved_upper_bounds_0[i], h_improved_upper_bounds_1[i]);
+      f_t lower_bound = std::min(h_improved_lower_bounds_0[i], h_improved_lower_bounds_1[i]);
+      f_t upper_bound = std::max(h_improved_upper_bounds_0[i], h_improved_upper_bounds_1[i]);
       cuopt_assert(h_var_bounds[i].x <= lower_bound, "lower bound violation");
       cuopt_assert(h_var_bounds[i].y >= upper_bound, "upper bound violation");
       // check why we might have invalid lower and upper bound here
@@ -568,9 +568,9 @@ void apply_modification_queue_to_problem(
       if (var_bounds_modifications.count(var_idx) == 0) {
         var_bounds_modifications[var_idx] = std::make_pair(lb, ub);
       } else {
-        var_bounds_modifications[var_idx].first = max(var_bounds_modifications[var_idx].first, lb);
+        var_bounds_modifications[var_idx].first = std::max(var_bounds_modifications[var_idx].first, lb);
         var_bounds_modifications[var_idx].second =
-          min(var_bounds_modifications[var_idx].second, ub);
+          std::min(var_bounds_modifications[var_idx].second, ub);
       }
     }
   }
@@ -943,7 +943,7 @@ bool compute_probing_cache(bound_presolve_t<i_t, f_t>& bound_presolve,
   double work_used                  = 0.0;
   // Work is only folded in at the step barrier, so the step size is also the granularity at which
   // the budget can be enforced: too large and a single step runs effectively unbudgeted.
-  const size_t step_size = min(step_size_hint, priority_indices.size());
+  const size_t step_size = std::min(step_size_hint, priority_indices.size());
 
   // The pool buffers above were allocated on the main stream.
   // Each OMP thread below uses its own stream, so we must ensure all allocations
@@ -1010,7 +1010,7 @@ bool compute_probing_cache(bound_presolve_t<i_t, f_t>& bound_presolve,
                problem.handle_ptr->get_stream());
     problem.handle_ptr->sync_stream();
     if (n_of_implied_singletons - last_it_implied_singletons <
-        (size_t)std::max(2, (min(100, problem.n_variables / 50)))) {
+        (size_t)std::max(2, (std::min(100, problem.n_variables / 50)))) {
       early_exit = true;
     }
     last_it_implied_singletons = n_of_implied_singletons;

--- a/cpp/src/mip_heuristics/presolve/probing_cache.cu
+++ b/cpp/src/mip_heuristics/presolve/probing_cache.cu
@@ -568,7 +568,8 @@ void apply_modification_queue_to_problem(
       if (var_bounds_modifications.count(var_idx) == 0) {
         var_bounds_modifications[var_idx] = std::make_pair(lb, ub);
       } else {
-        var_bounds_modifications[var_idx].first = std::max(var_bounds_modifications[var_idx].first, lb);
+        var_bounds_modifications[var_idx].first =
+          std::max(var_bounds_modifications[var_idx].first, lb);
         var_bounds_modifications[var_idx].second =
           std::min(var_bounds_modifications[var_idx].second, ub);
       }

--- a/cpp/src/mip_heuristics/utils.cuh
+++ b/cpp/src/mip_heuristics/utils.cuh
@@ -112,7 +112,7 @@ HDI f_t round_nearest(f_t val, f_t lb, f_t ub, f_t int_tol, raft::random::PCGene
     f_t t = 2 * w * (1 - w);
     if (w > 0.5) { t = 1 - t; }
     f_t result = floor(val + t);
-    return max(int_lb, min(result, int_ub));
+    return raft::max(int_lb, raft::min(result, int_ub));
   }
 }
 

--- a/cpp/src/utilities/timer.hpp
+++ b/cpp/src/utilities/timer.hpp
@@ -71,7 +71,7 @@ class timer_t {
     auto diff_from_now = begin - steady_now;
 
     // Apply that same difference to the current system clock time point
-    std::chrono::system_clock::time_point sys_t = sys_now + diff_from_now;
+    auto sys_t = sys_now + diff_from_now;
 
     // Convert the resulting system_clock time point to microseconds since the system epoch
     auto us_since_epoch =

--- a/cpp/tests/utilities/common_utils.hpp
+++ b/cpp/tests/utilities/common_utils.hpp
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/tests/utilities/common_utils.hpp
+++ b/cpp/tests/utilities/common_utils.hpp
@@ -10,7 +10,9 @@
 #include <cuopt/error.hpp>
 #include <utilities/macros.cuh>
 
+#include <cstdlib>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Several fixes required when building cuOpt with Clang rather than nvcc:
- Qualify min() and max() calls with std:: or raft:: to prevent lookup errors in Clang.
- Add missing standard headers (<cstdlib>, <sstream>, <cuopt/logger_macros.hpp>).
- Remove unused __shared__ array in handle_local_minimum_kernel.
- Deduce sys_t type using auto in timer_t.
- Explicitly cast nullptr in protobuf ParseFromArray.

Full disclosure: done with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
