### PR TITLE
Avoid integer overflow with infinite time limit in CPU Feasibility Jump

### DIFF
--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
+ 
+#include <cuopt/error.hpp>
 
 #include <mip_heuristics/mip_constants.hpp>
 
@@ -1893,11 +1895,21 @@ std::unique_ptr<fj_cpu_climber_t<i_t, f_t>> fj_t<i_t, f_t>::create_cpu_climber(
 template <typename i_t, typename f_t>
 void cpufj_solve(fj_cpu_climber_t<i_t, f_t>* fj_cpu, f_t in_time_limit, double work_unit_limit)
 {
+  cuopt_expects(
+    !std::isnan(in_time_limit), error_type_t::ValidationError, "time_limit cannot be NaN");
+  cuopt_expects(in_time_limit >= static_cast<f_t>(0),
+                error_type_t::ValidationError,
+                "time_limit cannot be negative");
+
   i_t local_mins  = 0;
   auto loop_start = std::chrono::high_resolution_clock::now();
-  auto time_limit = (in_time_limit < std::numeric_limits<f_t>::infinity())
-                        ? std::chrono::milliseconds(static_cast<i_t>(std::floor(in_time_limit * 1000.0)))
-                        : std::chrono::milliseconds::max();
+  using ms_rep    = std::chrono::milliseconds::rep;
+  constexpr double max_seconds =
+    static_cast<double>(std::chrono::milliseconds::max().count() / 1000 - 1000);
+  auto time_limit =
+    (!std::isfinite(in_time_limit) || in_time_limit >= max_seconds)
+      ? std::chrono::milliseconds::max()
+      : std::chrono::milliseconds(static_cast<ms_rep>(std::floor(in_time_limit * 1000.0)));
   auto loop_time_start = std::chrono::high_resolution_clock::now();
 
   fj_cpu->rng.seed(fj_cpu->settings.seed);
@@ -1908,10 +1920,10 @@ void cpufj_solve(fj_cpu_climber_t<i_t, f_t>* fj_cpu, f_t in_time_limit, double w
   fj_cpu->iterations_since_best = 0;
 
   while (!fj_cpu->halted && !fj_cpu->preemption_flag.load()) {
-    // Check if 5 seconds have passed
-    auto now = std::chrono::high_resolution_clock::now();
-    if (in_time_limit < std::numeric_limits<f_t>::infinity() &&
-        now - loop_time_start > time_limit) {
+    // Check if time limit has passed
+    auto now     = std::chrono::high_resolution_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - loop_time_start);
+    if (std::isfinite(in_time_limit) && elapsed > time_limit) {
       CUOPT_LOG_TRACE("%sTime limit of %.4f seconds reached, breaking loop at iteration %d",
                       fj_cpu->log_prefix.c_str(),
                       time_limit.count() / 1000.f,

--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -1895,7 +1895,9 @@ void cpufj_solve(fj_cpu_climber_t<i_t, f_t>* fj_cpu, f_t in_time_limit, double w
 {
   i_t local_mins  = 0;
   auto loop_start = std::chrono::high_resolution_clock::now();
-  auto time_limit = std::chrono::milliseconds(static_cast<i_t>(std::floor(in_time_limit * 1000.0)));
+  auto time_limit = (in_time_limit < std::numeric_limits<f_t>::infinity())
+                        ? std::chrono::milliseconds(static_cast<i_t>(std::floor(in_time_limit * 1000.0)))
+                        : std::chrono::milliseconds::max();
   auto loop_time_start = std::chrono::high_resolution_clock::now();
 
   fj_cpu->rng.seed(fj_cpu->settings.seed);

--- a/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/fj_cpu.cu
@@ -1923,7 +1923,7 @@ void cpufj_solve(fj_cpu_climber_t<i_t, f_t>* fj_cpu, f_t in_time_limit, double w
     // Check if time limit has passed
     auto now     = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - loop_time_start);
-    if (std::isfinite(in_time_limit) && elapsed > time_limit) {
+    if (std::isfinite(in_time_limit) && elapsed >= time_limit) {
       CUOPT_LOG_TRACE("%sTime limit of %.4f seconds reached, breaking loop at iteration %d",
                       fj_cpu->log_prefix.c_str(),
                       time_limit.count() / 1000.f,

--- a/cpp/tests/mip/unit_test.cu
+++ b/cpp/tests/mip/unit_test.cu
@@ -8,9 +8,12 @@
 #include "../linear_programming/utilities/pdlp_test_utilities.cuh"
 #include "mip_utils.cuh"
 
+#include <cuopt/error.hpp>
 #include <cuopt/mathematical_optimization/io/parser.hpp>
 #include <cuopt/mathematical_optimization/solve.hpp>
+#include <mip_heuristics/feasibility_jump/fj_cpu.cuh>
 #include <mip_heuristics/mip_scaling_strategy.cuh>
+#include <mip_heuristics/solution/solution.cuh>
 #include <pdlp/utilities/problem_checking.cuh>
 #include <utilities/common_utils.hpp>
 #include <utilities/copy_helpers.hpp>
@@ -19,6 +22,8 @@
 #include <raft/core/handle.hpp>
 
 #include <gtest/gtest.h>
+
+#include <limits>
 
 namespace cuopt::mathematical_optimization::test {
 
@@ -336,6 +341,84 @@ TEST(ScalingIntegrity, NoObjectiveScalingPreservesIntegerCoefficients)
   }
   EXPECT_EQ(violations, 0) << violations
                            << " integer coefficients lost integrality after scaling (no-obj mode)";
+}
+
+TEST(CpuFeasibilityJump, TimeLimitCornerCases)
+{
+  raft::handle_t handle;
+  auto mps_problem = create_std_milp_problem(false);
+  auto op_problem  = mps_data_model_to_optimization_problem(&handle, mps_problem);
+  mip::problem_t<int, double> problem(op_problem);
+  problem.preprocess_problem();
+  mip::solution_t<int, double> solution(problem);
+  thrust::fill(
+    handle.get_thrust_policy(), solution.assignment.begin(), solution.assignment.end(), 0.0);
+  solution.clamp_within_bounds();
+
+  std::atomic<bool> preemption_flag{false};
+  mip::fj_settings_t fj_settings;
+  fj_settings.iteration_limit = 1;
+
+  auto make_climber = [&]() {
+    return mip::init_fj_cpu_standalone(problem, solution, preemption_flag, 42, fj_settings);
+  };
+
+  // Default positive-infinite limit
+  {
+    auto climber = make_climber();
+    EXPECT_NO_THROW(mip::cpufj_solve(climber.get()));
+  }
+
+  // Explicit positive-infinite limit
+  {
+    auto climber = make_climber();
+    EXPECT_NO_THROW(mip::cpufj_solve(climber.get(), std::numeric_limits<double>::infinity()));
+  }
+
+  // Normal finite limit
+  {
+    auto climber = make_climber();
+    EXPECT_NO_THROW(mip::cpufj_solve(climber.get(), 10.0));
+  }
+
+  // Oversized finite limit (must not overflow integer conversion)
+  {
+    auto climber = make_climber();
+    EXPECT_NO_THROW(mip::cpufj_solve(climber.get(), 1e12));
+  }
+
+  // Negative limit must throw ValidationError
+  {
+    auto climber = make_climber();
+    try {
+      mip::cpufj_solve(climber.get(), -1.0);
+      FAIL() << "expected cuopt::logic_error with ValidationError";
+    } catch (const cuopt::logic_error& e) {
+      EXPECT_EQ(e.get_error_type(), cuopt::error_type_t::ValidationError);
+    }
+  }
+
+  // Negative infinity must throw ValidationError
+  {
+    auto climber = make_climber();
+    try {
+      mip::cpufj_solve(climber.get(), -std::numeric_limits<double>::infinity());
+      FAIL() << "expected cuopt::logic_error with ValidationError";
+    } catch (const cuopt::logic_error& e) {
+      EXPECT_EQ(e.get_error_type(), cuopt::error_type_t::ValidationError);
+    }
+  }
+
+  // NaN limit must throw ValidationError
+  {
+    auto climber = make_climber();
+    try {
+      mip::cpufj_solve(climber.get(), std::numeric_limits<double>::quiet_NaN());
+      FAIL() << "expected cuopt::logic_error with ValidationError";
+    } catch (const cuopt::logic_error& e) {
+      EXPECT_EQ(e.get_error_type(), cuopt::error_type_t::ValidationError);
+    }
+  }
 }
 
 }  // namespace cuopt::mathematical_optimization::test


### PR DESCRIPTION
When in_time_limit is infinity, multiplying by 1000 and casting to an integer causes undefined behavior / integer overflow (trapping under UBSan). Guard against infinity and use std::chrono::milliseconds::max().

Full disclosure: done with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
