### PR TITLE
Guard against nullptr dereference when checking concurrent solver status

### DIFF
--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -1703,10 +1703,14 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
   f_t end_time = timer.elapsed_time();
   CUOPT_LOG_CONDITIONAL_INFO(!settings.inside_mip, "Concurrent time: %.3fs", end_time);
 
-  const auto dual_simplex_status = !settings.inside_mip ? std::get<1>(*sol_dual_simplex_ptr)
-                                                        : simplex::lp_status_t::CONCURRENT_LIMIT;
+  const auto dual_simplex_status =
+    (!settings.inside_mip && sol_dual_simplex_ptr != nullptr)
+      ? std::get<1>(*sol_dual_simplex_ptr)
+      : simplex::lp_status_t::CONCURRENT_LIMIT;
   const auto barrier_status =
-    enable_barrier ? std::get<1>(*sol_barrier_ptr) : simplex::lp_status_t::CONCURRENT_LIMIT;
+    (enable_barrier && sol_barrier_ptr != nullptr)
+      ? std::get<1>(*sol_barrier_ptr)
+      : simplex::lp_status_t::CONCURRENT_LIMIT;
   const bool dual_simplex_solved = dual_simplex_status == simplex::lp_status_t::OPTIMAL ||
                                    dual_simplex_status == simplex::lp_status_t::INFEASIBLE ||
                                    dual_simplex_status == simplex::lp_status_t::UNBOUNDED;

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -1525,6 +1525,9 @@ void run_dual_simplex_thread(
     run_dual_simplex(problem, settings, timer));
 }
 
+/**
+ * @brief Solve an LP problem using concurrent solvers (PDLP, dual simplex, barrier).
+ */
 template <typename i_t, typename f_t>
 optimization_problem_solution_t<i_t, f_t> run_concurrent(
   mip::problem_t<i_t, f_t>& problem,
@@ -1785,7 +1788,8 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
     CUOPT_LOG_CONDITIONAL_INFO(!settings.inside_mip, "Solved with PDLP");
     return sol_pdlp;
   } else if (!settings.inside_mip &&
-             sol_pdlp.get_termination_status() == pdlp_termination_status_t::ConcurrentLimit) {
+             sol_pdlp.get_termination_status() == pdlp_termination_status_t::ConcurrentLimit &&
+             sol_dual_simplex_ptr != nullptr) {
     sol_barrier_ptr.reset();
     auto& dual_simplex_solution = std::get<0>(*sol_dual_simplex_ptr);
     auto sol_dual_simplex       = convert_dual_simplex_sol(problem,

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -56,6 +56,10 @@
 #include <utility>
 #include <vector>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace cuopt::mathematical_optimization::test {
 
 constexpr double afiro_primal_objective = -464.0;
@@ -172,6 +176,59 @@ TEST(pdlp_class, concurrent_pdlp_exception_joins_worker_threads)
   EXPECT_EQ(error_status.get_error_type(), cuopt::error_type_t::ValidationError);
   EXPECT_THAT(error_status.what(),
               testing::HasSubstr("all_primal_feasible only applies in batch mode"));
+}
+
+TEST(pdlp_class, concurrent_null_solver_ptrs_inside_mip)
+{
+  const raft::handle_t handle_{};
+
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mathematical_optimization::io::mps_data_model_t<int, double> op_problem =
+    cuopt::mathematical_optimization::io::read_mps<int, double>(path, true);
+
+  auto settings       = pdlp_solver_settings_t<int, double>{};
+  settings.method     = cuopt::mathematical_optimization::method_t::Concurrent;
+  settings.presolver  = cuopt::mathematical_optimization::presolver_t::None;
+  settings.inside_mip = true;
+
+  // inside_mip skips dual simplex. Setting threads to 1 ensures barrier is also disabled
+  // (< CUOPT_CONCURRENT_LP_BARRIER_REQUIRED_THREAD_COUNT), leaving both sol_dual_simplex_ptr
+  // and sol_barrier_ptr null.
+#ifdef _OPENMP
+  const int prev_threads = omp_get_max_threads();
+  omp_set_num_threads(1);
+#endif
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+#ifdef _OPENMP
+  omp_set_num_threads(prev_threads);
+#endif
+
+  EXPECT_EQ((int)solution.get_termination_status(), CUOPT_TERMINATION_STATUS_OPTIMAL);
+}
+
+TEST(pdlp_class, concurrent_null_dual_simplex_concurrent_limit)
+{
+  const raft::handle_t handle_{};
+
+  auto path = make_path_absolute("linear_programming/afiro_original.mps");
+  cuopt::mathematical_optimization::io::mps_data_model_t<int, double> op_problem =
+    cuopt::mathematical_optimization::io::read_mps<int, double>(path, true);
+
+  auto settings       = pdlp_solver_settings_t<int, double>{};
+  settings.method     = cuopt::mathematical_optimization::method_t::Concurrent;
+  settings.presolver  = cuopt::mathematical_optimization::presolver_t::None;
+  settings.inside_mip = true;
+
+  // With inside_mip = true, dual simplex is not started (sol_dual_simplex_ptr is null).
+  // Pre-setting concurrent_halt causes PDLP to immediately exit with ConcurrentLimit.
+  // The solver must return PDLP's result without attempting to dereference
+  // sol_dual_simplex_ptr.
+  std::atomic<int> halt{1};
+  settings.concurrent_halt = &halt;
+
+  optimization_problem_solution_t<int, double> solution = solve_lp(&handle_, op_problem, settings);
+  EXPECT_EQ(solution.get_termination_status(),
+            cuopt::mathematical_optimization::pdlp_termination_status_t::ConcurrentLimit);
 }
 
 TEST(pdlp_class, run_double_very_low_accuracy)


### PR DESCRIPTION
If dual simplex or barrier did not set their solution pointers (e.g. on early termination, error, or limit), dereferencing sol_dual_simplex_ptr or sol_barrier_ptr directly causes a null pointer dereference.

Full disclosure: done with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
