### PR TITLE
Unconditionally stop early_cpufj if launched

### DIFF
--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -674,7 +674,7 @@ mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_p
       early_gpufj.reset();  // Free GPU memory
     }
 
-    if (early_cpufj && run_presolve && presolve_result_opt.has_value()) {
+    if (early_cpufj) {
       early_cpufj->stop();
       if (early_cpufj->solution_found()) {
         CUOPT_LOG_DEBUG(


### PR DESCRIPTION
If early_cpufj was started, it should be stopped and joined regardless of whether presolve finished with a result or failed/timed out, matching the behavior of early_structural.

Full disclosure: done with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
