### PR TITLE
Provide std::mutex fallback for omp_mutex_t when OpenMP is disabled

### DIFF
--- a/cpp/src/utilities/omp_helpers.hpp
+++ b/cpp/src/utilities/omp_helpers.hpp
@@ -24,12 +24,46 @@ std::pair<i_t, i_t> calculate_index_range(i_t k, double total, double n)
 }  // namespace cuopt
 
 #ifdef _OPENMP
-
 #include <omp.h>
+#else
+#include <mutex>
+#endif
 #include <memory>
 #include <utility>
 
 namespace cuopt {
+
+#ifndef _OPENMP
+class omp_mutex_t {
+ public:
+  omp_mutex_t() : mutex(new std::mutex()) { }
+
+  omp_mutex_t(const omp_mutex_t&) = delete;
+
+  omp_mutex_t(omp_mutex_t&& other) { *this = std::move(other); }
+
+  omp_mutex_t& operator=(const omp_mutex_t&) = delete;
+
+  omp_mutex_t& operator=(omp_mutex_t&& other)
+  {
+    if (&other != this) {
+      mutex = std::move(other.mutex);
+    }
+    return *this;
+  }
+
+  void lock() { mutex->lock(); }
+
+  void unlock() { mutex->unlock(); }
+
+  bool try_lock() { return mutex->try_lock(); }
+
+ private:
+  std::unique_ptr<std::mutex> mutex;
+};
+#endif  // !_OPENMP
+
+#ifdef _OPENMP
 
 // Wrapper of omp_lock_t. Optionally, you can provide a hint as defined in
 // https://www.openmp.org/spec-html/5.1/openmpse39.html#x224-2570003.9
@@ -67,6 +101,7 @@ class omp_mutex_t {
  private:
   std::unique_ptr<omp_lock_t> mutex;
 };
+#endif  // _OPENMP
 
 // Empty class with the same methods as `omp_mutex_t`. This is mainly used for cleanly disabling
 // the `omp_mutex_t` via type alias (`lock` and `unlock` are replaced by NOOPs).


### PR DESCRIPTION
When compiling without OpenMP, provide standard library std::mutex fallback wrapper functions to allow compiling omp_mutex_t locks.

Full disclosure: done with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
