### PR TITLE
move server LPData transform into a standalone function

### DIFF
--- a/python/cuopt_server/cuopt_server/tests/test_lp_data_transformation.py
+++ b/python/cuopt_server/cuopt_server/tests/test_lp_data_transformation.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+import numpy as np
+
+from cuopt_server.utils.linear_programming.data_definition import LPData
+from cuopt_server.utils.linear_programming.data_transformation import (
+    transform_lp_data,
+)
+
+
+def _sample_lp_dict():
+    return {
+        "csr_constraint_matrix": {
+            "offsets": [0, 2],
+            "indices": [0, 1],
+            "values": [1.0, 1.0],
+        },
+        "constraint_bounds": {
+            "upper_bounds": [5000.0],
+            "lower_bounds": ["ninf"],
+            "types": ["L"],
+        },
+        "objective_data": {
+            "coefficients": [1.2, 1.7],
+            "scalability_factor": 1.0,
+            "offset": 0.0,
+        },
+        "variable_bounds": {
+            "upper_bounds": ["inf", "inf"],
+            "lower_bounds": [0.0, 0.0],
+        },
+        "initial_solution": {
+            "primal": [1.0, 2.0],
+            "dual": [0.5],
+        },
+        "variable_types": ["C", "I"],
+        "variable_names": ["x", "y"],
+        "maximize": False,
+    }
+
+
+def test_transform_lp_data_converts_dict_lists_to_numpy_dtypes():
+    data = _sample_lp_dict()
+
+    transform_lp_data(data)
+
+    csr = data["csr_constraint_matrix"]
+    assert csr["offsets"].dtype == np.int32
+    assert csr["indices"].dtype == np.int32
+    assert csr["values"].dtype == np.float64
+    np.testing.assert_array_equal(
+        csr["offsets"], np.array([0, 2], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        csr["indices"], np.array([0, 1], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        csr["values"], np.array([1.0, 1.0], dtype=np.float64)
+    )
+
+    assert data["constraint_bounds"]["upper_bounds"].dtype == np.float64
+    assert data["constraint_bounds"]["types"].dtype == np.dtype("U1")
+    np.testing.assert_array_equal(
+        data["constraint_bounds"]["types"], np.array(["L"], dtype="U1")
+    )
+
+    assert data["objective_data"]["coefficients"].dtype == np.float64
+    assert data["initial_solution"]["primal"].dtype == np.float64
+    assert data["initial_solution"]["dual"].dtype == np.float64
+    assert data["variable_types"].dtype == np.dtype("U1")
+    np.testing.assert_array_equal(
+        data["variable_types"], np.array(["C", "I"], dtype="U1")
+    )
+
+    # Unmapped fields must keep their original Python types.
+    assert data["variable_names"] == ["x", "y"]
+    assert data["maximize"] is False
+    assert data["objective_data"]["offset"] == 0.0
+
+
+def test_transform_lp_data_converts_inf_and_ninf_in_dict():
+    data = _sample_lp_dict()
+
+    transform_lp_data(data)
+
+    np.testing.assert_array_equal(
+        data["constraint_bounds"]["lower_bounds"],
+        np.array([-np.inf], dtype=np.float64),
+    )
+    np.testing.assert_array_equal(
+        data["variable_bounds"]["upper_bounds"],
+        np.array([np.inf, np.inf], dtype=np.float64),
+    )
+    assert data["variable_bounds"]["lower_bounds"].dtype == np.float64
+
+
+def test_transform_lp_data_converts_lpdata_lists_to_numpy_dtypes():
+    lp_data = LPData.parse_obj(_sample_lp_dict())
+
+    transform_lp_data(lp_data)
+
+    csr = lp_data.csr_constraint_matrix
+    assert csr.offsets.dtype == np.int32
+    assert csr.indices.dtype == np.int32
+    assert csr.values.dtype == np.float64
+    np.testing.assert_array_equal(
+        csr.offsets, np.array([0, 2], dtype=np.int32)
+    )
+
+    assert lp_data.objective_data.coefficients.dtype == np.float64
+    assert lp_data.initial_solution.primal.dtype == np.float64
+    assert lp_data.initial_solution.dual.dtype == np.float64
+    assert lp_data.variable_bounds.lower_bounds.dtype == np.float64
+
+    # LPData path omits dtype for types / variable_types (numpy default).
+    assert isinstance(lp_data.constraint_bounds.types, np.ndarray)
+    assert isinstance(lp_data.variable_types, np.ndarray)
+    np.testing.assert_array_equal(lp_data.constraint_bounds.types, ["L"])
+    np.testing.assert_array_equal(lp_data.variable_types, ["C", "I"])
+
+
+def test_transform_lp_data_converts_inf_and_ninf_in_lpdata():
+    lp_data = LPData.parse_obj(_sample_lp_dict())
+
+    transform_lp_data(lp_data)
+
+    np.testing.assert_array_equal(
+        lp_data.constraint_bounds.lower_bounds,
+        np.array([-np.inf], dtype=np.float64),
+    )
+    np.testing.assert_array_equal(
+        lp_data.variable_bounds.upper_bounds,
+        np.array([np.inf, np.inf], dtype=np.float64),
+    )
+
+
+def test_transform_lp_data_leaves_non_list_values_unchanged():
+    existing = np.array([1.0, 2.0], dtype=np.float32)
+    data = {
+        "objective_data": {"coefficients": existing},
+        "variable_names": ["x", "y"],
+    }
+
+    transform_lp_data(data)
+
+    assert data["objective_data"]["coefficients"] is existing
+    assert data["variable_names"] == ["x", "y"]
+
+
+def test_transform_lp_data_mutates_in_place():
+    data = _sample_lp_dict()
+    original = data
+    nested = data["csr_constraint_matrix"]
+
+    transform_lp_data(data)
+
+    assert data is original
+    assert data["csr_constraint_matrix"] is nested
+    assert isinstance(nested["offsets"], np.ndarray)
+
+
+def test_transform_lp_data_mixed_inf_and_finite_values():
+    data = {
+        "variable_bounds": {
+            "upper_bounds": [1.5, "inf", 3.0, "ninf"],
+            "lower_bounds": ["ninf", 0.0, "inf"],
+        }
+    }
+
+    transform_lp_data(data)
+
+    np.testing.assert_array_equal(
+        data["variable_bounds"]["upper_bounds"],
+        np.array([1.5, np.inf, 3.0, -np.inf], dtype=np.float64),
+    )
+    np.testing.assert_array_equal(
+        data["variable_bounds"]["lower_bounds"],
+        np.array([-np.inf, 0.0, np.inf], dtype=np.float64),
+    )
+
+
+def test_transform_lp_data_does_not_touch_unrelated_dict_keys():
+    data = copy.deepcopy(_sample_lp_dict())
+    data["solver_config"] = {"time_limit": 5}
+
+    transform_lp_data(data)
+
+    assert data["solver_config"] == {"time_limit": 5}

--- a/python/cuopt_server/cuopt_server/utils/job_queue.py
+++ b/python/cuopt_server/cuopt_server/utils/job_queue.py
@@ -37,6 +37,9 @@ from cuopt_server.utils.exceptions import (
     exception_handler,
     http_exception_handler,
 )
+from cuopt_server.utils.linear_programming.data_transformation import (
+    transform_lp_data,
+)
 from cuopt_server.utils.logutil import message
 from cuopt_server.utils.routing.initial_solution import add_initial_sol
 
@@ -884,133 +887,7 @@ class SolverLPJob(SolverBaseJob):
         return self.LP_data
 
     def _transform(self, data):
-        np = numpy
-        tmap = {
-            "csr_constraint_matrix": {
-                "offsets": (True, np.int32),
-                "indices": (True, np.int32),
-                "values": (True, np.float64),
-            },
-            "constraint_bounds": {
-                "bounds": (True, np.float64),
-                "upper_bounds": (True, np.float64),
-                "lower_bounds": (True, np.float64),
-                "types": (True, "U1"),
-            },
-            "initial_solution": {
-                "primal": (True, np.float64),
-                "dual": (True, np.float64),
-            },
-            "objective_data": {
-                "coefficients": (True, np.float64),
-            },
-            "variable_bounds": {
-                "upper_bounds": (True, np.float64),
-                "lower_bounds": (True, np.float64),
-            },
-            "variable_types": (True, "U1"),
-        }
-
-        def modify(value, key, dtype=None, indent=""):
-            if isinstance(value, list):
-                if "inf" in value or "ninf" in value:
-                    value = [
-                        np.inf if x == "inf" else -np.inf if x == "ninf" else x
-                        for x in value
-                    ]
-                if dtype is None:
-                    return np.array(value)
-                return np.array(value, dtype)
-            return value
-
-        def apply(data, tmap, indent=""):
-            for key, value in data.items():
-                try:
-                    if isinstance(value, dict) and key in tmap:
-                        apply(value, tmap[key], indent + " ")
-                    elif key in tmap and tmap[key][0]:
-                        data[key] = modify(value, key, tmap[key][1], indent)
-                except Exception as e:
-                    logging.debug(e)
-                    logging.debug(
-                        f"{indent}exception key is {key} value is {value}"
-                    )
-                    raise
-
-        def apply_LPData(data):
-            data.csr_constraint_matrix.indices = modify(
-                data.csr_constraint_matrix.indices,
-                "csr_constraint_matrix.indices",
-                np.int32,
-            )
-            data.csr_constraint_matrix.offsets = modify(
-                data.csr_constraint_matrix.offsets,
-                "csr_constraint_matrix.offsets",
-                np.int32,
-            )
-            data.csr_constraint_matrix.values = modify(
-                data.csr_constraint_matrix.values,
-                "csr_constraint_matrix.values",
-                np.float64,
-            )
-
-            data.constraint_bounds.bounds = modify(
-                data.constraint_bounds.bounds,
-                "constraint_bounds.bounds",
-                np.float64,
-            )
-            data.constraint_bounds.upper_bounds = modify(
-                data.constraint_bounds.upper_bounds,
-                "constraint_bounds.upper_bounds",
-                np.float64,
-            )
-            data.constraint_bounds.lower_bounds = modify(
-                data.constraint_bounds.lower_bounds,
-                "constraint_bounds.lower_bounds",
-                np.float64,
-            )
-            data.constraint_bounds.types = modify(
-                data.constraint_bounds.types,
-                "constraint_bounds.types",
-            )
-
-            data.initial_solution.primal = modify(
-                data.initial_solution.primal,
-                "initial_solution.primal",
-                np.float64,
-            )
-
-            data.initial_solution.dual = modify(
-                data.initial_solution.dual, "initial_solution.dual", np.float64
-            )
-
-            data.objective_data.coefficients = modify(
-                data.objective_data.coefficients,
-                "objective_data.coefficients",
-                np.float64,
-            )
-
-            data.variable_bounds.upper_bounds = modify(
-                data.variable_bounds.upper_bounds,
-                "variable_bounds.upper_bounds",
-                np.float64,
-            )
-            data.variable_bounds.lower_bounds = modify(
-                data.variable_bounds.lower_bounds,
-                "variable_bounds.lower_bounds",
-                np.float64,
-            )
-            data.variable_types = modify(
-                data.variable_types,
-                "variable_types",
-            )
-
-        then = time.time()
-        if isinstance(data, LPData):
-            apply_LPData(data)
-        else:
-            apply(data, tmap)
-        logging.info(f"transform time {time.time() - then}")
+        transform_lp_data(data)
 
     def _load_data(self):
         if not self.transformed:

--- a/python/cuopt_server/cuopt_server/utils/linear_programming/data_transformation.py
+++ b/python/cuopt_server/cuopt_server/utils/linear_programming/data_transformation.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import time
+
+import numpy
+
+from cuopt_server.utils.linear_programming.data_definition import LPData
+
+
+def transform_lp_data(data):
+    np = numpy
+    tmap = {
+        "csr_constraint_matrix": {
+            "offsets": (True, np.int32),
+            "indices": (True, np.int32),
+            "values": (True, np.float64),
+        },
+        "constraint_bounds": {
+            "bounds": (True, np.float64),
+            "upper_bounds": (True, np.float64),
+            "lower_bounds": (True, np.float64),
+            "types": (True, "U1"),
+        },
+        "initial_solution": {
+            "primal": (True, np.float64),
+            "dual": (True, np.float64),
+        },
+        "objective_data": {
+            "coefficients": (True, np.float64),
+        },
+        "variable_bounds": {
+            "upper_bounds": (True, np.float64),
+            "lower_bounds": (True, np.float64),
+        },
+        "variable_types": (True, "U1"),
+    }
+
+    def modify(value, key, dtype=None, indent=""):
+        if isinstance(value, list):
+            if "inf" in value or "ninf" in value:
+                value = [
+                    np.inf if x == "inf" else -np.inf if x == "ninf" else x
+                    for x in value
+                ]
+            if dtype is None:
+                return np.array(value)
+            return np.array(value, dtype)
+        return value
+
+    def apply(data, tmap, indent=""):
+        for key, value in data.items():
+            try:
+                if isinstance(value, dict) and key in tmap:
+                    apply(value, tmap[key], indent + " ")
+                elif key in tmap and tmap[key][0]:
+                    data[key] = modify(value, key, tmap[key][1], indent)
+            except Exception as e:
+                logging.debug(e)
+                logging.debug(
+                    f"{indent}exception key is {key} value is {value}"
+                )
+                raise
+
+    def apply_LPData(data):
+        data.csr_constraint_matrix.indices = modify(
+            data.csr_constraint_matrix.indices,
+            "csr_constraint_matrix.indices",
+            np.int32,
+        )
+        data.csr_constraint_matrix.offsets = modify(
+            data.csr_constraint_matrix.offsets,
+            "csr_constraint_matrix.offsets",
+            np.int32,
+        )
+        data.csr_constraint_matrix.values = modify(
+            data.csr_constraint_matrix.values,
+            "csr_constraint_matrix.values",
+            np.float64,
+        )
+
+        data.constraint_bounds.bounds = modify(
+            data.constraint_bounds.bounds,
+            "constraint_bounds.bounds",
+            np.float64,
+        )
+        data.constraint_bounds.upper_bounds = modify(
+            data.constraint_bounds.upper_bounds,
+            "constraint_bounds.upper_bounds",
+            np.float64,
+        )
+        data.constraint_bounds.lower_bounds = modify(
+            data.constraint_bounds.lower_bounds,
+            "constraint_bounds.lower_bounds",
+            np.float64,
+        )
+        data.constraint_bounds.types = modify(
+            data.constraint_bounds.types,
+            "constraint_bounds.types",
+        )
+
+        data.initial_solution.primal = modify(
+            data.initial_solution.primal,
+            "initial_solution.primal",
+            np.float64,
+        )
+
+        data.initial_solution.dual = modify(
+            data.initial_solution.dual, "initial_solution.dual", np.float64
+        )
+
+        data.objective_data.coefficients = modify(
+            data.objective_data.coefficients,
+            "objective_data.coefficients",
+            np.float64,
+        )
+
+        data.variable_bounds.upper_bounds = modify(
+            data.variable_bounds.upper_bounds,
+            "variable_bounds.upper_bounds",
+            np.float64,
+        )
+        data.variable_bounds.lower_bounds = modify(
+            data.variable_bounds.lower_bounds,
+            "variable_bounds.lower_bounds",
+            np.float64,
+        )
+        data.variable_types = modify(
+            data.variable_types,
+            "variable_types",
+        )
+
+    then = time.time()
+    if isinstance(data, LPData):
+        apply_LPData(data)
+    else:
+        apply(data, tmap)
+    logging.info(f"transform time {time.time() - then}")

--- a/python/cuopt_server/cuopt_server/utils/utils.py
+++ b/python/cuopt_server/cuopt_server/utils/utils.py
@@ -1,11 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json
 import os
 
-from cuopt_server.utils.job_queue import SolverLPJob
 from cuopt_server.utils.linear_programming.data_definition import LPData
+from cuopt_server.utils.linear_programming.data_transformation import (
+    transform_lp_data,
+)
 from cuopt_server.utils.linear_programming.solver import (
     create_data_model as lp_create_data_model,
     create_solver as lp_create_solver,
@@ -74,12 +76,8 @@ def build_lp_datamodel_from_json(data):
             "requires json input"
         )
 
-    stub_id = 9999
-    stub_warnings = []
-    job = SolverLPJob(stub_id, data, None, stub_warnings)
     # transform data into digestible format
-    job._transform(job.LP_data)
-    data = job.get_data()
+    transform_lp_data(data)
 
     _, data_model = lp_create_data_model(data)
     _, solver_settings = lp_create_solver(data, None)


### PR DESCRIPTION
This is one of a series of changes to refactor the cuopt http server so that a new proxy server can be added that shares the same data conversion code but delegates solves to the gRPC server. It will run as a sidecar.

Here, we are moving an LPData transform function out of a class into a standalone function. It converts lists to numpy arrays and "inf" and "ninf" to numpy infinity values, etc.