### PR TITLE
Routing: Fix vector lifetimes in breaks unit test

### DIFF
--- a/cpp/tests/routing/unit_tests/breaks.cu
+++ b/cpp/tests/routing/unit_tests/breaks.cu
@@ -406,6 +406,7 @@ TEST(vehicle_breaks, non_uniform_breaks)
   data_model.set_order_service_times(v_order_service.data());
   data_model.set_break_locations(v_break_locations.data(), v_break_locations.size());
 
+  std::vector<rmm::device_uvector<int>> v_e_vec, v_l_vec, v_d_vec;
   for (int b = 0; b < num_breaks; ++b) {
     std::vector<int> e(vehicle_num), l(vehicle_num), d(vehicle_num);
     for (int v = 0; v < vehicle_num; ++v) {
@@ -413,10 +414,11 @@ TEST(vehicle_breaks, non_uniform_breaks)
       l[v] = break_latest[v * num_breaks + b];
       d[v] = break_duration[v * num_breaks + b];
     }
-    auto v_e = cuopt::device_copy(e, stream);
-    auto v_l = cuopt::device_copy(l, stream);
-    auto v_d = cuopt::device_copy(d, stream);
-    data_model.add_break_dimension(v_e.data(), v_l.data(), v_d.data());
+    v_e_vec.push_back(cuopt::device_copy(e, stream));
+    v_l_vec.push_back(cuopt::device_copy(l, stream));
+    v_d_vec.push_back(cuopt::device_copy(d, stream));
+    data_model.add_break_dimension(
+      v_e_vec.back().data(), v_l_vec.back().data(), v_d_vec.back().data());
   }
 
   cuopt::routing::solver_settings_t<int, float> settings;


### PR DESCRIPTION
In vehicle_breaks.non_uniform_breaks, device_uvector instances v_e, v_l, and v_d were allocated inside the loop and destroyed at the end of each iteration, leaving dangling device pointers registered in data_model.add_break_dimension(). Store them in outer vectors so their lifetimes persist across solve().

Full disclosure: generated with the help of Gemini AI.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
