### PR TITLE
Routing: Guard diagonal element lookup against negative offsets in top_k

### DIFF
--- a/cpp/src/routing/util_kernels/top_k.cuh
+++ b/cpp/src/routing/util_kernels/top_k.cuh
@@ -108,8 +108,10 @@ DI int top_k_indices_per_row(i_t row_id,
   // If the column index matches the row id then the element we are dealing with
   // lies on the diagonal of the matrix. We want these costs to be double max()
   if constexpr (write_diagonal) {
-    if (threadIdx.x == ((row_id - col_offset) / items_per_thread)) {
-      sort_cost[(row_id - col_offset) % items_per_thread] = get_default<output_t>();
+    if (row_id >= col_offset) {
+      if (threadIdx.x == ((row_id - col_offset) / items_per_thread)) {
+        sort_cost[(row_id - col_offset) % items_per_thread] = get_default<output_t>();
+      }
     }
   }
   // Populate column ids based on thread id
@@ -146,8 +148,10 @@ DI int top_k_indices_per_row(i_t row_id,
     // If the column index matches the row id then the element we are dealing with
     // lies on the diagonal of the matrix. We want these costs to be double max()
     if constexpr (write_diagonal) {
-      if (threadIdx.x == ((row_id - col_offset) / loads_per_thread)) {
-        load_cost[(row_id - col_offset) % loads_per_thread] = get_default<output_t>();
+      if (row_id >= col_offset) {
+        if (threadIdx.x == ((row_id - col_offset) / loads_per_thread)) {
+          load_cost[(row_id - col_offset) % loads_per_thread] = get_default<output_t>();
+        }
       }
     }
     __syncthreads();


### PR DESCRIPTION
When row_id < col_offset, row_id - col_offset is negative. In C++, integer division with negative operands truncates toward zero (e.g. -1 / 16 == 0), causing thread 0 to mistakenly match threadIdx.x == 0 and index sort_cost[-1] or load_cost[-1].

Guard the diagonal replacement with `if (row_id >= col_offset)` so that negative offsets are not evaluated.

<!--

Thank you for contributing to cuOpt :)

Here are some guidelines to help the review process go smoothly.

Many thanks in advance for your cooperation!

Note: The pull request title will be included in the CHANGELOG.
-->


## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
