### PR TITLE
Adopt CUDA stream compatibility accessors

### DIFF
--- a/cpp/include/cuopt/mathematical_optimization/mip/solver_settings.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/mip/solver_settings.hpp
@@ -19,6 +19,8 @@
 #include <cuopt/mathematical_optimization/pdlp/solver_settings.hpp>
 #include <cuopt/mathematical_optimization/utilities/internals.hpp>
 
+#include <cuda/stream>
+
 #include <raft/core/device_span.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -90,7 +92,8 @@ class mip_solver_settings_t {
    */
   void add_initial_solution(const f_t* initial_solution,
                             i_t size,
-                            rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                            rmm::cuda_stream_view stream = cuda::stream_ref{
+                              cudaStream_t{cudaStreamDefault}});
 
   /**
    * @brief Get the callback for the user solution

--- a/cpp/include/cuopt/mathematical_optimization/optimization_problem_solution.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/optimization_problem_solution.hpp
@@ -65,7 +65,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
                solution_.get_primal_solution().data(),
                solution_.get_primal_solution().size(),
                stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -77,7 +77,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
                solution_.get_dual_solution().data(),
                solution_.get_dual_solution().size(),
                stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -88,7 +88,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     auto stream = reduced_cost.stream();
     std::vector<f_t> result(reduced_cost.size());
     raft::copy(result.data(), reduced_cost.data(), reduced_cost.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -154,7 +154,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
                ws.current_primal_solution_.data(),
                ws.current_primal_solution_.size(),
                stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -167,7 +167,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     std::vector<f_t> result(ws.current_dual_solution_.size());
     raft::copy(
       result.data(), ws.current_dual_solution_.data(), ws.current_dual_solution_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -180,7 +180,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     std::vector<f_t> result(ws.initial_primal_average_.size());
     raft::copy(
       result.data(), ws.initial_primal_average_.data(), ws.initial_primal_average_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -193,7 +193,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     std::vector<f_t> result(ws.initial_dual_average_.size());
     raft::copy(
       result.data(), ws.initial_dual_average_.data(), ws.initial_dual_average_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -205,7 +205,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     auto stream = ws.current_ATY_.stream();
     std::vector<f_t> result(ws.current_ATY_.size());
     raft::copy(result.data(), ws.current_ATY_.data(), ws.current_ATY_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -218,7 +218,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     std::vector<f_t> result(ws.sum_primal_solutions_.size());
     raft::copy(
       result.data(), ws.sum_primal_solutions_.data(), ws.sum_primal_solutions_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -230,7 +230,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
     auto stream = ws.sum_dual_solutions_.stream();
     std::vector<f_t> result(ws.sum_dual_solutions_.size());
     raft::copy(result.data(), ws.sum_dual_solutions_.data(), ws.sum_dual_solutions_.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -245,7 +245,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
                ws.last_restart_duality_gap_primal_solution_.data(),
                ws.last_restart_duality_gap_primal_solution_.size(),
                stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -260,7 +260,7 @@ class gpu_lp_solution_t : public lp_solution_interface_t<i_t, f_t> {
                ws.last_restart_duality_gap_dual_solution_.data(),
                ws.last_restart_duality_gap_dual_solution_.size(),
                stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 
@@ -406,7 +406,7 @@ class gpu_mip_solution_t : public mip_solution_interface_t<i_t, f_t> {
     std::vector<f_t> result(solution_.get_solution().size());
     raft::copy(
       result.data(), solution_.get_solution().data(), solution_.get_solution().size(), stream);
-    stream.synchronize();
+    stream.sync();
     return result;
   }
 

--- a/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/pdlp/solver_settings.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <cuopt/mathematical_optimization/constants.h>
+
+#include <cuda/stream>
 #include <cuopt/export.hpp>
 #include <cuopt/mathematical_optimization/cpu_pdlp_warm_start_data.hpp>
 #include <cuopt/mathematical_optimization/pdlp/pdlp_hyper_params.cuh>
@@ -151,7 +153,8 @@ class pdlp_solver_settings_t {
    */
   void set_initial_primal_solution(const f_t* initial_primal_solution,
                                    i_t size,
-                                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                   rmm::cuda_stream_view stream = cuda::stream_ref{
+                                     cudaStream_t{cudaStreamDefault}});
 
   /**
    * @brief Set an initial dual solution.
@@ -165,7 +168,8 @@ class pdlp_solver_settings_t {
    */
   void set_initial_dual_solution(const f_t* initial_dual_solution,
                                  i_t size,
-                                 rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                 rmm::cuda_stream_view stream = cuda::stream_ref{
+                                   cudaStream_t{cudaStreamDefault}});
 
   /** TODO batch mode: tmp
    * @brief Set an initial step size.
@@ -200,11 +204,12 @@ class pdlp_solver_settings_t {
    * @param constraint_mapping Constraints indices to scatter to in case the new
    * problem has less constraints
    */
-  void set_pdlp_warm_start_data(pdlp_warm_start_data_t<i_t, f_t>& pdlp_warm_start_data_view,
-                                const rmm::device_uvector<i_t>& var_mapping =
-                                  rmm::device_uvector<i_t>{0, rmm::cuda_stream_default},
-                                const rmm::device_uvector<i_t>& constraint_mapping =
-                                  rmm::device_uvector<i_t>{0, rmm::cuda_stream_default});
+  void set_pdlp_warm_start_data(
+    pdlp_warm_start_data_t<i_t, f_t>& pdlp_warm_start_data_view,
+    const rmm::device_uvector<i_t>& var_mapping =
+      rmm::device_uvector<i_t>{0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}},
+    const rmm::device_uvector<i_t>& constraint_mapping = rmm::device_uvector<i_t>{
+      0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}});
 
   // Same but for the Cython interface
   void set_pdlp_warm_start_data(const f_t* current_primal_solution,

--- a/cpp/include/cuopt/mathematical_optimization/solver_settings.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/solver_settings.hpp
@@ -10,6 +10,8 @@
 #include <cuopt/export.hpp>
 #include <cuopt/mathematical_optimization/pdlp/pdlp_warm_start_data.hpp>
 
+#include <cuda/stream>
+
 #include <raft/core/device_span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -52,10 +54,12 @@ class solver_settings_t {
 
   void set_initial_pdlp_primal_solution(const f_t* initial_primal_solution,
                                         i_t size,
-                                        rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                        rmm::cuda_stream_view stream = cuda::stream_ref{
+                                          cudaStream_t{cudaStreamDefault}});
   void set_initial_pdlp_dual_solution(const f_t* initial_dual_solution,
                                       i_t size,
-                                      rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                      rmm::cuda_stream_view stream = cuda::stream_ref{
+                                        cudaStream_t{cudaStreamDefault}});
   void set_pdlp_warm_start_data(const f_t* current_primal_solution,
                                 const f_t* current_dual_solution,
                                 const f_t* initial_primal_average,
@@ -82,7 +86,8 @@ class solver_settings_t {
   // MIP Settings
   void add_initial_mip_solution(const f_t* initial_solution,
                                 i_t size,
-                                rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                                rmm::cuda_stream_view stream = cuda::stream_ref{
+                                  cudaStream_t{cudaStreamDefault}});
   void set_mip_callback(internals::base_solution_callback_t* callback = nullptr,
                         void* user_data                               = nullptr);
 

--- a/cpp/include/cuopt/mathematical_optimization/utilities/segmented_sum_handler.cuh
+++ b/cpp/include/cuopt/mathematical_optimization/utilities/segmented_sum_handler.cuh
@@ -22,7 +22,7 @@ struct segmented_sum_handler_t {
                             i_t problem_size)
   {
     cub::DeviceSegmentedReduce::Sum(
-      nullptr, byte_needed_, input, output, batch_size, problem_size, stream_view_);
+      nullptr, byte_needed_, input, output, batch_size, problem_size, stream_view_.get());
 
     segmented_sum_storage_.resize(byte_needed_, stream_view_);
 
@@ -32,7 +32,7 @@ struct segmented_sum_handler_t {
                                     output,
                                     batch_size,
                                     problem_size,
-                                    stream_view_);
+                                    stream_view_.get());
   }
 
   template <typename InputIteratorT, typename ReductionOpT>

--- a/cpp/include/cuopt/mathematical_optimization/utilities/segmented_sum_handler.cuh
+++ b/cpp/include/cuopt/mathematical_optimization/utilities/segmented_sum_handler.cuh
@@ -51,9 +51,9 @@ struct segmented_sum_handler_t {
                                        problem_size,
                                        reduction_op,
                                        initial_value,
-                                       stream_view_.value());
+                                       stream_view_.get());
 
-    segmented_sum_storage_.resize(byte_needed_, stream_view_.value());
+    segmented_sum_storage_.resize(byte_needed_, stream_view_.get());
 
     cub::DeviceSegmentedReduce::Reduce(segmented_sum_storage_.data(),
                                        byte_needed_,
@@ -63,7 +63,7 @@ struct segmented_sum_handler_t {
                                        problem_size,
                                        reduction_op,
                                        initial_value,
-                                       stream_view_.value());
+                                       stream_view_.get());
   }
 
   size_t byte_needed_;

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -387,7 +387,8 @@ class barrier_reduce_helper_t {
       return;
     }
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Reduce(nullptr, temp_storage_bytes, in, out, size, op, init, stream_view.get());
+    cub::DeviceReduce::Reduce(
+      nullptr, temp_storage_bytes, in, out, size, op, init, stream_view.get());
     d_temp_storage_.resize(temp_storage_bytes, stream_view);
     cub::DeviceReduce::Reduce(
       d_temp_storage_.data(), temp_storage_bytes, in, out, size, op, init, stream_view.get());
@@ -409,7 +410,8 @@ class barrier_reduce_helper_t {
     size_t temp_storage_bytes = 0;
     cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, in, out, size, stream_view.get());
     d_temp_storage_.resize(temp_storage_bytes, stream_view);
-    cub::DeviceReduce::Sum(d_temp_storage_.data(), temp_storage_bytes, in, out, size, stream_view.get());
+    cub::DeviceReduce::Sum(
+      d_temp_storage_.data(), temp_storage_bytes, in, out, size, stream_view.get());
   }
 
   void dot_async(Slot slot,
@@ -418,8 +420,14 @@ class barrier_reduce_helper_t {
                  cublasHandle_t cublas_handle,
                  rmm::cuda_stream_view stream_view)
   {
-    RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(
-      cublas_handle, a.size(), a.data(), 1, b.data(), 1, d_results_.data() + slot, stream_view.get()));
+    RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(cublas_handle,
+                                                    a.size(),
+                                                    a.data(),
+                                                    1,
+                                                    b.data(),
+                                                    1,
+                                                    d_results_.data() + slot,
+                                                    stream_view.get()));
   }
 
   rmm::device_uvector<f_t> d_results_;

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -225,7 +225,7 @@ static void recover_linear_orthant_dz(raft::device_span<const f_t> target,
       return target_val - (z_val * dx_val) / x_val;
     },
     stream.get());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 }
 
 template <typename f_t>
@@ -255,7 +255,7 @@ static void fill_linear_cc_rhs(raft::device_span<f_t> out,
       return is_direct_free_linear ? f_t(0) : (-(dx_aff_val * dz_aff_val) + new_mu);
     },
     stream.get());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 }
 
 // Batches the independent GPU reductions/dot-products needed by
@@ -847,7 +847,7 @@ class iteration_data_t {
       raft::copy(
         device_A_x_values.data(), device_AD.x.data(), device_AD.x.size(), handle_ptr->get_stream());
       device_AD.to_compressed_row(device_A, handle_ptr->get_stream());
-      RAFT_CHECK_CUDA(handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     }
 
     if (settings.concurrent_halt != nullptr && *settings.concurrent_halt == 1) { return; }
@@ -1031,7 +1031,7 @@ class iteration_data_t {
                            const f_t d_j = span_diag[j];
                            span_x[span_diag_indices[j]] = -q_diag - d_j - dual_perturb_value;
                          });
-      RAFT_CHECK_CUDA(handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
       thrust::for_each_n(rmm::exec_policy(handle_ptr->get_stream()),
                          thrust::make_counting_iterator<i_t>(n),
@@ -1041,7 +1041,7 @@ class iteration_data_t {
                           primal_perturb_value = primal_perturb] __device__(i_t j) {
                            span_x[span_diag_indices[j]] = primal_perturb_value;
                          });
-      RAFT_CHECK_CUDA(handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
       if (has_soc) {
         if (cones().has_sparse_cones()) {
@@ -1057,7 +1057,7 @@ class iteration_data_t {
                                                 cone_kkt_data_.sparse_expansion_D,
                                                 handle_ptr->get_stream(),
                                                 dual_perturb);
-          RAFT_CHECK_CUDA(handle_ptr->get_stream());
+          RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
         }
         if (cones().n_dense_cones() > 0) {
           scatter_dense_hessian_into_augmented(cones(),
@@ -1068,7 +1068,7 @@ class iteration_data_t {
                                                cone_kkt_data_.dense_cone_ids,
                                                handle_ptr->get_stream(),
                                                dual_perturb);
-          RAFT_CHECK_CUDA(handle_ptr->get_stream());
+          RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
         }
       }
       handle_ptr->sync_stream();
@@ -1104,7 +1104,7 @@ class iteration_data_t {
           d_num_flag.data(),
           d_inv_diag.size(),
           stream_view_.get());
-        RAFT_CHECK_CUDA(stream_view_);
+        RAFT_CHECK_CUDA(stream_view_.get());
       } else {
         d_inv_diag_prime.resize(inv_diag.size(), stream_view_);
         raft::copy(d_inv_diag_prime.data(), d_inv_diag.data(), inv_diag.size(), stream_view_);
@@ -1124,7 +1124,7 @@ class iteration_data_t {
                           span_col_ind = cuopt::make_span(device_AD.col_index)] __device__(i_t i) {
                            span_x[i] *= span_scale[span_col_ind[i]];
                          });
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
     if (settings_.concurrent_halt != nullptr && *settings_.concurrent_halt == 1) { return; }
     if (first_call) {
@@ -1918,7 +1918,7 @@ class iteration_data_t {
                                     u.size(),
                                     cuda::std::multiplies<>{},
                                     stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
 
     // y = alpha * A * w + beta * v = alpha * A * Dinv * A^T * y + beta * v
     cusparse_view.spmv(alpha, cusparse_u, beta, cusparse_v);
@@ -1940,7 +1940,7 @@ class iteration_data_t {
                                     u.size(),
                                     cuda::std::multiplies<>{},
                                     stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     cusparse_view_.spmv(alpha, u, beta, v);
   }
 
@@ -2023,7 +2023,7 @@ class iteration_data_t {
                                                 d_r1_.data(),
                                                 linear_n,
                                                 stream_view_);
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
 
     // r1 <- D * x_1 + H x_1 on cone rows
@@ -2044,7 +2044,7 @@ class iteration_data_t {
           n,
           m,
           handle_ptr->get_stream());
-        RAFT_CHECK_CUDA(stream_view_);
+        RAFT_CHECK_CUDA(stream_view_.get());
       }
       if (cones().n_dense_cones() > 0) {
         launch_dense_hessian_matvec(
@@ -2052,7 +2052,7 @@ class iteration_data_t {
           cones(),
           raft::device_span<f_t>(d_r1_.data() + cone_start(), m_c),
           stream_view_);
-        RAFT_CHECK_CUDA(stream_view_);
+        RAFT_CHECK_CUDA(stream_view_.get());
       }
     }
 
@@ -2749,7 +2749,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
       data.d_upper_bounds_.size(),
       [] HD(f_t upper_j, f_t w_k, f_t x_j) { return upper_j - w_k - x_j; },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
   }
 
   // Compute dual_residual = c - A'*y - z + E*v + Q*x
@@ -2758,7 +2758,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
                                   data.d_dual_residual_.size(),
                                   cuda::std::minus<>{},
                                   stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   auto descr_dual_residual = data.cusparse_view_.create_vector(data.d_dual_residual_);
   if (data.Q.n > 0) {
     data.cusparse_Q_view_.spmv(1.0, cusparse_d_x.get(), 1.0, descr_dual_residual.get());
@@ -2776,7 +2776,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
       data.d_upper_bounds_.size(),
       [] HD(f_t dual_residual_j, f_t v_k) { return dual_residual_j + v_k; },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
   }
 
   // Compute complementarity_xz_residual = x.*z
@@ -2785,14 +2785,14 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
                                   data.d_complementarity_xz_residual_.size(),
                                   cuda::std::multiplies<>{},
                                   stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   // Compute complementarity_wv_residual = w.*v
   cub::DeviceTransform::Transform(cuda::std::make_tuple(d_w.data(), d_v.data()),
                                   data.d_complementarity_wv_residual_.data(),
                                   data.d_complementarity_wv_residual_.size(),
                                   cuda::std::multiplies<>{},
                                   stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -2901,7 +2901,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
                                       cuda::std::divides<>{},
                                       stream_view_.get());
     }
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
 
     // Upper-bound slacks: D_j += v_k/w_k.
     if (data.n_upper_bounds > 0) {
@@ -2914,7 +2914,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_upper_bounds_.size(),
         [] HD(f_t v_k, f_t w_k, f_t diag_j) { return diag_j + (v_k / w_k); },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
 
     // ADAT-only: fold diagonal Q and direct-free regularization (augmented KKT keeps Q explicit).
@@ -2927,7 +2927,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           data.d_diag_.size(),
           [] HD(f_t Q_diag_j, f_t diag_j) { return diag_j + Q_diag_j; },
           stream_view_.get());
-        RAFT_CHECK_CUDA(stream_view_);
+        RAFT_CHECK_CUDA(stream_view_.get());
 
         cub::DeviceTransform::Transform(
           cuda::std::make_tuple(
@@ -2949,7 +2949,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           },
           stream_view_.get());
       }
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
 
       // inv_diag and h = A*inv_diag*... are only used for the ADAT solve path.
       cub::DeviceTransform::Transform(
@@ -2958,7 +2958,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_diag_.size(),
         [] HD(f_t diag) { return f_t(1) / diag; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
   }
 
@@ -3037,7 +3037,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           return (complementarity_wv_rhs - v * bound_rhs) / w;
         },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
     cub::DeviceTransform::Transform(
       cuda::std::make_tuple(data.d_tmp3_.data(),
@@ -3051,7 +3051,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         return tmp3 + dual_rhs - comp_term;
       },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     raft::copy(data.d_r1_.data(), data.d_tmp3_.data(), data.d_tmp3_.size(), stream_view_);
     raft::copy(data.d_r1_prime_.data(), data.d_tmp3_.data(), data.d_tmp3_.size(), stream_view_);
   }
@@ -3131,7 +3131,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dy_.data(), data.d_augmented_soln_.data() + lp.num_cols, lp.num_rows, stream_view_);
     {
       raft::common::nvtx::range fun_scope("Barrier: augmented solve sync");
-      RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+      stream_view_.sync();
     }
 
     // TMP should only be init once
@@ -3145,7 +3145,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         lp.num_cols,
         [] HD(f_t inv_diag, f_t tmp3) { return inv_diag * tmp3; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
       data.cusparse_view_.spmv(1, data.cusparse_tmp4_.get(), 1, data.cusparse_h_.get());
     }
 
@@ -3244,7 +3244,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           return {dx, dx * diag};
         },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
 
       data.cusparse_view_.transpose_spmv(
         -1.0, data.cusparse_dy_.get(), 1.0, data.cusparse_dx_residual_.get());
@@ -3254,7 +3254,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_dx_residual_.size(),
         [] HD(f_t dx_residual, f_t r1_prime) { return dx_residual + r1_prime; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
     }
 
     // Not put on the GPU since debug only
@@ -3300,7 +3300,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         d_dx_residual_5.size(),
         [] HD(f_t ind_diag, f_t r1) { return ind_diag * r1; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
       // TMP should be done just one in the constructor
       data.cusparse_dx_residual_5_ = data.cusparse_view_.create_vector(d_dx_residual_5);
       data.cusparse_dx_residual_6_ = data.cusparse_view_.create_vector(d_dx_residual_6);
@@ -3332,7 +3332,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         d_dx_residual_3.size(),
         [] HD(f_t ind_diag, f_t r1_prime) { return ind_diag * r1_prime; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
       // TMP vector creation should only be done once
       data.cusparse_dx_residual_3_ = data.cusparse_view_.create_vector(d_dx_residual_3);
       data.cusparse_dx_residual_4_ = data.cusparse_view_.create_vector(d_dx_residual_4);
@@ -3447,7 +3447,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       raft::device_span<const f_t>(data.d_dz_.data(), linear_size),
       raft::device_span<const f_t>(data.d_dx_.data(), linear_size),
       raft::device_span<const f_t>(data.d_x_.data(), linear_size));
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     const f_t xz_residual_norm =
       device_vector_norm_inf<i_t, f_t>(data.d_xz_residual_, stream_view_);
     max_residual = std::max(max_residual, xz_residual_norm);
@@ -3471,7 +3471,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         return (v * gathered_dx - bound_rhs * v + complementarity_wv_rhs) / w;
       },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
   }
 
   if (debug) {
@@ -3494,7 +3494,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         return -v * gathered_dx + w * dv - complementarity_wv_rhs + v * bound_rhs;
       },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     const f_t dv_residual_norm = device_vector_norm_inf<i_t, f_t>(d_dv_residual, stream_view_);
     max_residual               = std::max(max_residual, dv_residual_norm);
     if (dv_residual_norm > 1e-2) {
@@ -3532,7 +3532,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dual_residual_.size(),
       [] HD(f_t dual_residual, f_t dz, f_t dual_rhs) { return dual_residual + dz - dual_rhs; },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     const f_t dual_residual_norm =
       device_vector_norm_inf<i_t, f_t>(data.d_dual_residual_, stream_view_);
     max_residual = std::max(max_residual, dual_residual_norm);
@@ -3553,7 +3553,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dw_.size(),
       [] HD(f_t dw, f_t gathered_dx) { return dw - gathered_dx; },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
 
     if (debug) {
       // dw_residual <- dw + E'*dx - bound_rhs
@@ -3567,7 +3567,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_dw_residual_.size(),
         [] HD(f_t dw, f_t gathered_dx, f_t bound_rhs) { return dw + gathered_dx - bound_rhs; },
         stream_view_.get());
-      RAFT_CHECK_CUDA(stream_view_);
+      RAFT_CHECK_CUDA(stream_view_.get());
       const f_t dw_residual_norm =
         device_vector_norm_inf<i_t, f_t>(data.d_dw_residual_, stream_view_);
       max_residual = std::max(max_residual, dw_residual_norm);
@@ -3593,7 +3593,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         return v * dw + w * dv - complementarity_wv_rhs;
       },
       stream_view_.get());
-    RAFT_CHECK_CUDA(stream_view_);
+    RAFT_CHECK_CUDA(stream_view_.get());
     const f_t wv_residual_norm =
       device_vector_norm_inf<i_t, f_t>(data.d_wv_residual_, stream_view_);
     max_residual = std::max(max_residual, wv_residual_norm);
@@ -3622,7 +3622,7 @@ void fill_linear_complementarity_target(iteration_data_t<i_t, f_t>& data,
       return complementarity_xz_rhs / x_val;
     },
     stream.get());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 }
 
 template <typename i_t, typename f_t>
@@ -3640,7 +3640,7 @@ void fill_affine_cone_complementarity_target(iteration_data_t<i_t, f_t>& data,
   cub::DeviceTransform::Transform(
     cones.z.data(), cone_target.data(), m_c, [] HD(f_t z_val) { return -z_val; }, stream.get());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 }
 
 template <typename i_t, typename f_t>
@@ -3704,7 +3704,7 @@ void barrier_solver_t<i_t, f_t>::compute_affine_rhs(iteration_data_t<i_t, f_t>& 
     raft::device_span<const f_t>(data.d_complementarity_wv_residual_.data(),
                                  data.d_complementarity_wv_residual_.size()),
     stream_view_);
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
 
   fill_linear_complementarity_target<i_t, f_t>(
     data,
@@ -3859,7 +3859,7 @@ void barrier_solver_t<i_t, f_t>::compute_cc_rhs(iteration_data_t<i_t, f_t>& data
     data.d_complementarity_wv_rhs_.size(),
     [new_mu] HD(f_t dw_aff, f_t dv_aff) { return -(dw_aff * dv_aff) + new_mu; },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   // Zero the corrector RHS on device
   RAFT_CUDA_TRY(
     cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_.get()));
@@ -3903,7 +3903,7 @@ void barrier_solver_t<i_t, f_t>::compute_final_direction(iteration_data_t<i_t, f
       return {dw + dw_aff, dv + dv_aff};
     },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(
       data.d_dx_aff_.data(), data.d_dz_aff_.data(), data.d_dx_.data(), data.d_dz_.data()),
@@ -3913,14 +3913,14 @@ void barrier_solver_t<i_t, f_t>::compute_final_direction(iteration_data_t<i_t, f
       return {dx + dx_aff, dz + dz_aff};
     },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_dy_aff_.data(), data.d_dy_.data()),
     data.d_dy_.data(),
     data.d_dy_.size(),
     [] HD(f_t dy_aff, f_t dy) { return dy + dy_aff; },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -3977,7 +3977,7 @@ void barrier_solver_t<i_t, f_t>::compute_next_iterate(iteration_data_t<i_t, f_t>
       return {w + step_primal * dw, v + step_dual * dv};
     },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_x_.data(), data.d_z_.data(), data.d_dx_.data(), data.d_dz_.data()),
     thrust::make_zip_iterator(data.d_x_.data(), data.d_z_.data()),
@@ -3986,14 +3986,14 @@ void barrier_solver_t<i_t, f_t>::compute_next_iterate(iteration_data_t<i_t, f_t>
       return {x + step_primal * dx, z + step_dual * dz};
     },
     stream_view_.get());
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_y_.data(), data.d_dy_.data()),
     data.d_y_.data(),
     data.d_y_.size(),
     [step_dual] HD(f_t y, f_t dy) { return y + step_dual * dy; },
     stream_view_);
-  RAFT_CHECK_CUDA(stream_view_);
+  RAFT_CHECK_CUDA(stream_view_.get());
   // Do not handle free variables for quadratic problems
   i_t num_free_variables = presolve_info.free_variable_pairs.size() / 2;
   if (num_free_variables > 0 && data.Q.n == 0) {
@@ -4199,7 +4199,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::check_for_suboptimal_solution(
     raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
     raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
     raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
     data.to_solution(lp,
                      iter,
                      primal_objective,
@@ -4590,7 +4590,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
           raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
           raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
           raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
-          RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+          stream_view_.sync();
           data.w_save                                 = data.w;
           data.x_save                                 = data.x;
           data.y_save                                 = data.y;
@@ -4660,7 +4660,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
         raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
         raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
         raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-        RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+        stream_view_.sync();
         data.to_solution(lp,
                          iter,
                          primal_objective,
@@ -4700,7 +4700,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
     raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
     raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
     raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
     data.to_solution(lp,
                      iter,
                      primal_objective,

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -383,7 +383,7 @@ class barrier_reduce_helper_t {
   {
     f_t* out = d_results_.data() + slot;
     if (size == 0) {
-      RAFT_CUDA_TRY(cudaMemsetAsync(out, 0, sizeof(f_t), stream_view.value()));
+      RAFT_CUDA_TRY(cudaMemsetAsync(out, 0, sizeof(f_t), stream_view.get()));
       return;
     }
     size_t temp_storage_bytes = 0;

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -4000,7 +4000,7 @@ void barrier_solver_t<i_t, f_t>::compute_next_iterate(iteration_data_t<i_t, f_t>
     data.d_y_.data(),
     data.d_y_.size(),
     [step_dual] HD(f_t y, f_t dy) { return y + step_dual * dy; },
-    stream_view_);
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_.get());
   // Do not handle free variables for quadratic problems
   i_t num_free_variables = presolve_info.free_variable_pairs.size() / 2;

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -4107,7 +4107,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_z_.data(),
                                                   1,
                                                   d_xz.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_w_.size(),
                                                   data.d_w_.data(),
@@ -4115,7 +4115,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_v_.data(),
                                                   1,
                                                   d_wv.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_x_.size(),
                                                   data.d_x_.data(),
@@ -4123,7 +4123,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_dual_residual_.data(),
                                                   1,
                                                   d_rdx.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_y_.size(),
                                                   data.d_y_.data(),
@@ -4131,7 +4131,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_primal_residual_.data(),
                                                   1,
                                                   d_rpy.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_bound_residual_.size(),
                                                   data.d_bound_residual_.data(),
@@ -4139,7 +4139,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_v_.data(),
                                                   1,
                                                   d_rwv.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_primal_residual_.size(),
                                                   data.d_primal_residual_.data(),
@@ -4147,7 +4147,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_primal_residual_.data(),
                                                   1,
                                                   d_p.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(lp.handle_ptr->get_cublas_handle(),
                                                   data.d_y_.size(),
                                                   data.d_y_.data(),
@@ -4155,7 +4155,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
                                                   data.d_y_.data(),
                                                   1,
                                                   d_y.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   f_t xz  = d_xz.value(stream_view_);
   f_t wv  = d_wv.value(stream_view_);
   f_t rdx = d_rdx.value(stream_view_);

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -343,7 +343,7 @@ class barrier_reduce_helper_t {
   void sync(rmm::cuda_stream_view stream_view)
   {
     raft::copy(h_results_.data(), d_results_.data(), static_cast<i_t>(kCount), stream_view);
-    stream_view.synchronize();
+    stream_view.sync();
   }
 
   // Raw reduced values; the caller combines these into residual norms, mu, and objectives.
@@ -4156,7 +4156,7 @@ void barrier_solver_t<i_t, f_t>::compute_residual_norms_mu_and_objective(
   f_t p   = d_p.value(stream_view_);
   f_t y   = d_y.value(stream_view_);
 
-  stream_view_.synchronize();
+  stream_view_.sync();
 
   f_t objective_gap_1 = primal_objective - dual_objective;
   f_t objective_gap_2 = xz + wv + rdx - rpy + rwv;

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -3023,8 +3023,8 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
   // unscaled input to ADAT's h = primal_rhs + A*inv_diag*tmp3.
   {
     raft::common::nvtx::range fun_scope("Barrier: GPU assemble primal RHS");
-    RAFT_CUDA_TRY(
-      cudaMemsetAsync(data.d_tmp3_.data(), 0, sizeof(f_t) * data.d_tmp3_.size(), stream_view_.get()));
+    RAFT_CUDA_TRY(cudaMemsetAsync(
+      data.d_tmp3_.data(), 0, sizeof(f_t) * data.d_tmp3_.size(), stream_view_.get()));
     if (data.n_upper_bounds > 0) {
       cub::DeviceTransform::Transform(
         cuda::std::make_tuple(data.d_bound_rhs_.data(),
@@ -3861,7 +3861,8 @@ void barrier_solver_t<i_t, f_t>::compute_cc_rhs(iteration_data_t<i_t, f_t>& data
     stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   // Zero the corrector RHS on device
-  RAFT_CUDA_TRY(cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(
+    cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     data.d_dual_rhs_.data(), 0, sizeof(f_t) * data.d_dual_rhs_.size(), stream_view_.get()));
   if (data.n_upper_bounds > 0) {

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -659,7 +659,7 @@ class iteration_data_t {
         d_inv_diag_prime.data(),
         d_num_flag.data(),
         inv_diag.size(),
-        stream_view_));
+        stream_view_.get()));
 
       d_flag_buffer.resize(flag_buffer_size, stream_view_);
     }
@@ -1103,7 +1103,7 @@ class iteration_data_t {
           d_inv_diag_prime.data(),
           d_num_flag.data(),
           d_inv_diag.size(),
-          stream_view_);
+          stream_view_.get());
         RAFT_CHECK_CUDA(stream_view_);
       } else {
         d_inv_diag_prime.resize(inv_diag.size(), stream_view_);
@@ -3024,7 +3024,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
   {
     raft::common::nvtx::range fun_scope("Barrier: GPU assemble primal RHS");
     RAFT_CUDA_TRY(
-      cudaMemsetAsync(data.d_tmp3_.data(), 0, sizeof(f_t) * data.d_tmp3_.size(), stream_view_));
+      cudaMemsetAsync(data.d_tmp3_.data(), 0, sizeof(f_t) * data.d_tmp3_.size(), stream_view_.get()));
     if (data.n_upper_bounds > 0) {
       cub::DeviceTransform::Transform(
         cuda::std::make_tuple(data.d_bound_rhs_.data(),
@@ -3131,7 +3131,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dy_.data(), data.d_augmented_soln_.data() + lp.num_cols, lp.num_rows, stream_view_);
     {
       raft::common::nvtx::range fun_scope("Barrier: augmented solve sync");
-      RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
     }
 
     // TMP should only be init once
@@ -3861,14 +3861,14 @@ void barrier_solver_t<i_t, f_t>::compute_cc_rhs(iteration_data_t<i_t, f_t>& data
     stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   // Zero the corrector RHS on device
-  RAFT_CUDA_TRY(cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_));
+  RAFT_CUDA_TRY(cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    data.d_dual_rhs_.data(), 0, sizeof(f_t) * data.d_dual_rhs_.size(), stream_view_));
+    data.d_dual_rhs_.data(), 0, sizeof(f_t) * data.d_dual_rhs_.size(), stream_view_.get()));
   if (data.n_upper_bounds > 0) {
     RAFT_CUDA_TRY(cudaMemsetAsync(
-      data.d_bound_rhs_.data(), 0, sizeof(f_t) * data.d_bound_rhs_.size(), stream_view_));
+      data.d_bound_rhs_.data(), 0, sizeof(f_t) * data.d_bound_rhs_.size(), stream_view_.get()));
     RAFT_CUDA_TRY(
-      cudaMemsetAsync(data.d_dw_.data(), 0, sizeof(f_t) * data.d_dw_.size(), stream_view_));
+      cudaMemsetAsync(data.d_dw_.data(), 0, sizeof(f_t) * data.d_dw_.size(), stream_view_.get()));
   }
   data.cone_combined_step_ = has_soc;
   data.cone_sigma_mu_      = has_soc ? new_mu : f_t(0);
@@ -4198,7 +4198,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::check_for_suboptimal_solution(
     raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
     raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
     raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
     data.to_solution(lp,
                      iter,
                      primal_objective,
@@ -4589,7 +4589,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
           raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
           raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
           raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
-          RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+          RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
           data.w_save                                 = data.w;
           data.x_save                                 = data.x;
           data.y_save                                 = data.y;
@@ -4659,7 +4659,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
         raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
         raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
         raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-        RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+        RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
         data.to_solution(lp,
                          iter,
                          primal_objective,
@@ -4699,7 +4699,7 @@ lp_status_t barrier_solver_t<i_t, f_t>::solve(f_t start_time, lp_solution_t<i_t,
     raft::copy(data.y.data(), data.d_y_.data(), data.d_y_.size(), stream_view_);
     raft::copy(data.z.data(), data.d_z_.data(), data.d_z_.size(), stream_view_);
     raft::copy(data.v.data(), data.d_v_.data(), data.d_v_.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
     data.to_solution(lp,
                      iter,
                      primal_objective,

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -139,7 +139,7 @@ template <typename f_t>
   f_t* a, f_t* b, f_t* out, int size, rmm::cuda_stream_view stream)
 {
   cub::DeviceTransform::Transform(
-    cuda::std::make_tuple(a, b), out, size, cuda::std::multiplies<>{}, stream.value());
+    cuda::std::make_tuple(a, b), out, size, cuda::std::multiplies<>{}, stream.get());
 }
 
 // out[i] = is_direct_free_linear[i] ? 0 : a[i] * b[i]
@@ -152,7 +152,7 @@ template <typename f_t>
     out,
     size,
     [] __host__ __device__(f_t x_j, f_t d_j, int free_j) { return free_j ? f_t{0} : x_j * d_j; },
-    stream.value());
+    stream.get());
 }
 
 template <typename f_t>
@@ -164,7 +164,7 @@ template <typename f_t>
     out,
     size,
     [alpha, beta] __host__ __device__(f_t a, f_t b) { return alpha * a + beta * b; },
-    stream.value());
+    stream.get());
 }
 
 // Step size computation for nonnegative and free variables. Fuses two independent
@@ -224,7 +224,7 @@ static void recover_linear_orthant_dz(raft::device_span<const f_t> target,
       if (is_direct_free) return f_t(0);
       return target_val - (z_val * dx_val) / x_val;
     },
-    stream.value());
+    stream.get());
   RAFT_CHECK_CUDA(stream);
 }
 
@@ -235,7 +235,7 @@ static void negate_complementarity_rhs(raft::device_span<f_t> out,
 {
   if (out.empty()) return;
   cub::DeviceTransform::Transform(
-    residual.data(), out.data(), out.size(), [] HD(f_t rhs) { return -rhs; }, stream.value());
+    residual.data(), out.data(), out.size(), [] HD(f_t rhs) { return -rhs; }, stream.get());
 }
 
 template <typename i_t, typename f_t>
@@ -254,7 +254,7 @@ static void fill_linear_cc_rhs(raft::device_span<f_t> out,
     [new_mu] HD(f_t dx_aff_val, f_t dz_aff_val, i_t is_direct_free_linear) {
       return is_direct_free_linear ? f_t(0) : (-(dx_aff_val * dz_aff_val) + new_mu);
     },
-    stream.value());
+    stream.get());
   RAFT_CHECK_CUDA(stream);
 }
 
@@ -1539,7 +1539,7 @@ class iteration_data_t {
       return chol->solve(d_b, d_x);
     } else {
       raft::copy(inv_diag.data(), d_inv_diag.data(), d_inv_diag.size(), stream_view_);
-      stream_view_.synchronize();
+      stream_view_.sync();
       dense_vector_t<i_t, f_t> b = host_copy(d_b, stream_view_);
       dense_vector_t<i_t, f_t> x = host_copy(d_x, stream_view_);
 
@@ -1549,7 +1549,7 @@ class iteration_data_t {
       raft::copy(d_b.data(), b.data(), b.size(), stream_view_);
       d_x.resize(x.size(), stream_view_);
       raft::copy(d_x.data(), x.data(), x.size(), stream_view_);
-      stream_view_.synchronize();  // host x can go out of scope before copy finishes
+      stream_view_.sync();  // host x can go out of scope before copy finishes
 
       return out;
     }
@@ -1917,7 +1917,7 @@ class iteration_data_t {
                                     u.data(),
                                     u.size(),
                                     cuda::std::multiplies<>{},
-                                    stream_view_.value());
+                                    stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
 
     // y = alpha * A * w + beta * v = alpha * A * Dinv * A^T * y + beta * v
@@ -1939,7 +1939,7 @@ class iteration_data_t {
                                     u.data(),
                                     u.size(),
                                     cuda::std::multiplies<>{},
-                                    stream_view_.value());
+                                    stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
     cusparse_view_.spmv(alpha, u, beta, v);
   }
@@ -2542,7 +2542,7 @@ int barrier_solver_t<i_t, f_t>::initial_point(iteration_data_t<i_t, f_t>& data)
     // x = Dinv*(F*u - A'*q)
     // Fu <- -1.0 * A' * q + 1.0 * Fu
     data.cusparse_view_.transpose_spmv(-1.0, q, 1.0, Fu);
-    data.handle_ptr->get_stream().synchronize();
+    data.handle_ptr->get_stream().sync();
 
     // x <- Dinv * (F*u - A'*q)
     data.inv_diag.pairwise_product(Fu, data.x);
@@ -2560,7 +2560,7 @@ int barrier_solver_t<i_t, f_t>::initial_point(iteration_data_t<i_t, f_t>& data)
   dense_vector_t<i_t, f_t> init_primal_residual(lp.num_rows);
   init_primal_residual = lp.rhs;
   data.cusparse_view_.spmv(1.0, data.x, -1.0, init_primal_residual);
-  data.handle_ptr->get_stream().synchronize();
+  data.handle_ptr->get_stream().sync();
 #ifdef PRINT_INFO
   settings.log.printf("||b - A * x||: %.16e\n", vector_norm2<i_t, f_t>(init_primal_residual));
 #endif
@@ -2748,7 +2748,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
       data.d_bound_residual_.data(),
       data.d_upper_bounds_.size(),
       [] HD(f_t upper_j, f_t w_k, f_t x_j) { return upper_j - w_k - x_j; },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
   }
 
@@ -2757,7 +2757,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
                                   data.d_dual_residual_.data(),
                                   data.d_dual_residual_.size(),
                                   cuda::std::minus<>{},
-                                  stream_view_.value());
+                                  stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   auto descr_dual_residual = data.cusparse_view_.create_vector(data.d_dual_residual_);
   if (data.Q.n > 0) {
@@ -2775,7 +2775,7 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
       thrust::make_permutation_iterator(data.d_dual_residual_.data(), data.d_upper_bounds_.data()),
       data.d_upper_bounds_.size(),
       [] HD(f_t dual_residual_j, f_t v_k) { return dual_residual_j + v_k; },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
   }
 
@@ -2784,14 +2784,14 @@ void barrier_solver_t<i_t, f_t>::gpu_compute_residuals(const rmm::device_uvector
                                   data.d_complementarity_xz_residual_.data(),
                                   data.d_complementarity_xz_residual_.size(),
                                   cuda::std::multiplies<>{},
-                                  stream_view_.value());
+                                  stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   // Compute complementarity_wv_residual = w.*v
   cub::DeviceTransform::Transform(cuda::std::make_tuple(d_w.data(), d_v.data()),
                                   data.d_complementarity_wv_residual_.data(),
                                   data.d_complementarity_wv_residual_.size(),
                                   cuda::std::multiplies<>{},
-                                  stream_view_.value());
+                                  stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
 }
 
@@ -2893,13 +2893,13 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           constexpr f_t free_var_reg = 1e-7;
           return is_direct_free_linear ? free_var_reg : (z_j / x_j);
         },
-        stream_view_.value());
+        stream_view_.get());
     } else {
       cub::DeviceTransform::Transform(cuda::std::make_tuple(data.d_z_.data(), data.d_x_.data()),
                                       data.d_diag_.data(),
                                       linear_size,
                                       cuda::std::divides<>{},
-                                      stream_view_.value());
+                                      stream_view_.get());
     }
     RAFT_CHECK_CUDA(stream_view_);
 
@@ -2913,7 +2913,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         thrust::make_permutation_iterator(data.d_diag_.data(), data.d_upper_bounds_.data()),
         data.d_upper_bounds_.size(),
         [] HD(f_t v_k, f_t w_k, f_t diag_j) { return diag_j + (v_k / w_k); },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
     }
 
@@ -2926,7 +2926,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           data.d_diag_.data(),
           data.d_diag_.size(),
           [] HD(f_t Q_diag_j, f_t diag_j) { return diag_j + Q_diag_j; },
-          stream_view_.value());
+          stream_view_.get());
         RAFT_CHECK_CUDA(stream_view_);
 
         cub::DeviceTransform::Transform(
@@ -2938,7 +2938,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
             if (!is_direct_free_linear || q_jj > f_t(0)) return diag_j;
             return diag_j + free_var_reg;
           },
-          stream_view_.value());
+          stream_view_.get());
       } else {
         cub::DeviceTransform::Transform(
           cuda::std::make_tuple(data.d_diag_.data(), data.d_is_direct_free_linear_.data()),
@@ -2947,7 +2947,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           [free_var_reg] HD(f_t diag_j, i_t is_direct_free_linear) {
             return is_direct_free_linear ? (diag_j + free_var_reg) : diag_j;
           },
-          stream_view_.value());
+          stream_view_.get());
       }
       RAFT_CHECK_CUDA(stream_view_);
 
@@ -2957,7 +2957,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_inv_diag.data(),
         data.d_diag_.size(),
         [] HD(f_t diag) { return f_t(1) / diag; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
     }
   }
@@ -3036,7 +3036,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         [] HD(f_t bound_rhs, f_t v, f_t complementarity_wv_rhs, f_t w) {
           return (complementarity_wv_rhs - v * bound_rhs) / w;
         },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
     }
     cub::DeviceTransform::Transform(
@@ -3050,7 +3050,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         const f_t comp_term = is_direct_free_linear ? f_t(0) : target;
         return tmp3 + dual_rhs - comp_term;
       },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
     raft::copy(data.d_r1_.data(), data.d_tmp3_.data(), data.d_tmp3_.size(), stream_view_);
     raft::copy(data.d_r1_prime_.data(), data.d_tmp3_.data(), data.d_tmp3_.size(), stream_view_);
@@ -3144,7 +3144,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_tmp4_.data(),
         lp.num_cols,
         [] HD(f_t inv_diag, f_t tmp3) { return inv_diag * tmp3; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
       data.cusparse_view_.spmv(1, data.cusparse_tmp4_.get(), 1, data.cusparse_h_.get());
     }
@@ -3243,7 +3243,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
           const f_t dx = inv_diag * r1;
           return {dx, dx * diag};
         },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
 
       data.cusparse_view_.transpose_spmv(
@@ -3253,7 +3253,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_dx_residual_.data(),
         data.d_dx_residual_.size(),
         [] HD(f_t dx_residual, f_t r1_prime) { return dx_residual + r1_prime; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
     }
 
@@ -3299,7 +3299,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         d_dx_residual_5.data(),
         d_dx_residual_5.size(),
         [] HD(f_t ind_diag, f_t r1) { return ind_diag * r1; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
       // TMP should be done just one in the constructor
       data.cusparse_dx_residual_5_ = data.cusparse_view_.create_vector(d_dx_residual_5);
@@ -3331,7 +3331,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         d_dx_residual_3.data(),
         d_dx_residual_3.size(),
         [] HD(f_t ind_diag, f_t r1_prime) { return ind_diag * r1_prime; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
       // TMP vector creation should only be done once
       data.cusparse_dx_residual_3_ = data.cusparse_view_.create_vector(d_dx_residual_3);
@@ -3438,7 +3438,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         [] HD(f_t complementarity_xz_rhs, f_t z_val, f_t dz_val, f_t dx_val, f_t x_val) {
           return z_val * dx_val + x_val * dz_val - complementarity_xz_rhs;
         },
-        stream_view_.value());
+        stream_view_.get());
     };
     compute_linear_xz_residual(
       raft::device_span<f_t>(data.d_xz_residual_.data(), linear_size),
@@ -3470,7 +3470,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       [] HD(f_t v, f_t gathered_dx, f_t bound_rhs, f_t complementarity_wv_rhs, f_t w) {
         return (v * gathered_dx - bound_rhs * v + complementarity_wv_rhs) / w;
       },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
   }
 
@@ -3493,7 +3493,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       [] HD(f_t v, f_t gathered_dx, f_t dv, f_t bound_rhs, f_t complementarity_wv_rhs, f_t w) {
         return -v * gathered_dx + w * dv - complementarity_wv_rhs + v * bound_rhs;
       },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
     const f_t dv_residual_norm = device_vector_norm_inf<i_t, f_t>(d_dv_residual, stream_view_);
     max_residual               = std::max(max_residual, dv_residual_norm);
@@ -3531,7 +3531,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dual_residual_.data(),
       data.d_dual_residual_.size(),
       [] HD(f_t dual_residual, f_t dz, f_t dual_rhs) { return dual_residual + dz - dual_rhs; },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
     const f_t dual_residual_norm =
       device_vector_norm_inf<i_t, f_t>(data.d_dual_residual_, stream_view_);
@@ -3552,7 +3552,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       data.d_dw_.data(),
       data.d_dw_.size(),
       [] HD(f_t dw, f_t gathered_dx) { return dw - gathered_dx; },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
 
     if (debug) {
@@ -3566,7 +3566,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
         data.d_dw_residual_.data(),
         data.d_dw_residual_.size(),
         [] HD(f_t dw, f_t gathered_dx, f_t bound_rhs) { return dw + gathered_dx - bound_rhs; },
-        stream_view_.value());
+        stream_view_.get());
       RAFT_CHECK_CUDA(stream_view_);
       const f_t dw_residual_norm =
         device_vector_norm_inf<i_t, f_t>(data.d_dw_residual_, stream_view_);
@@ -3592,7 +3592,7 @@ i_t barrier_solver_t<i_t, f_t>::gpu_compute_search_direction(iteration_data_t<i_
       [] HD(f_t complementarity_wv_rhs, f_t w, f_t v, f_t dw, f_t dv) {
         return v * dw + w * dv - complementarity_wv_rhs;
       },
-      stream_view_.value());
+      stream_view_.get());
     RAFT_CHECK_CUDA(stream_view_);
     const f_t wv_residual_norm =
       device_vector_norm_inf<i_t, f_t>(data.d_wv_residual_, stream_view_);
@@ -3621,7 +3621,7 @@ void fill_linear_complementarity_target(iteration_data_t<i_t, f_t>& data,
       if (is_direct_free_linear) return f_t(0);
       return complementarity_xz_rhs / x_val;
     },
-    stream.value());
+    stream.get());
   RAFT_CHECK_CUDA(stream);
 }
 
@@ -3638,7 +3638,7 @@ void fill_affine_cone_complementarity_target(iteration_data_t<i_t, f_t>& data,
   auto cone_target =
     raft::device_span<f_t>(data.d_complementarity_target_.data() + cone_var_start, m_c);
   cub::DeviceTransform::Transform(
-    cones.z.data(), cone_target.data(), m_c, [] HD(f_t z_val) { return -z_val; }, stream.value());
+    cones.z.data(), cone_target.data(), m_c, [] HD(f_t z_val) { return -z_val; }, stream.get());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
   RAFT_CHECK_CUDA(stream);
 }
@@ -3858,7 +3858,7 @@ void barrier_solver_t<i_t, f_t>::compute_cc_rhs(iteration_data_t<i_t, f_t>& data
     data.d_complementarity_wv_rhs_.data(),
     data.d_complementarity_wv_rhs_.size(),
     [new_mu] HD(f_t dw_aff, f_t dv_aff) { return -(dw_aff * dv_aff) + new_mu; },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   // Zero the corrector RHS on device
   RAFT_CUDA_TRY(cudaMemsetAsync(data.d_h_.data(), 0, sizeof(f_t) * data.d_h_.size(), stream_view_));
@@ -3901,7 +3901,7 @@ void barrier_solver_t<i_t, f_t>::compute_final_direction(iteration_data_t<i_t, f
     [] HD(f_t dw_aff, f_t dv_aff, f_t dw, f_t dv) -> thrust::tuple<f_t, f_t> {
       return {dw + dw_aff, dv + dv_aff};
     },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(
@@ -3911,14 +3911,14 @@ void barrier_solver_t<i_t, f_t>::compute_final_direction(iteration_data_t<i_t, f
     [] HD(f_t dx_aff, f_t dz_aff, f_t dx, f_t dz) -> thrust::tuple<f_t, f_t> {
       return {dx + dx_aff, dz + dz_aff};
     },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_dy_aff_.data(), data.d_dy_.data()),
     data.d_dy_.data(),
     data.d_dy_.size(),
     [] HD(f_t dy_aff, f_t dy) { return dy + dy_aff; },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
 }
 
@@ -3975,7 +3975,7 @@ void barrier_solver_t<i_t, f_t>::compute_next_iterate(iteration_data_t<i_t, f_t>
     [step_primal, step_dual] HD(f_t w, f_t v, f_t dw, f_t dv) -> thrust::tuple<f_t, f_t> {
       return {w + step_primal * dw, v + step_dual * dv};
     },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_x_.data(), data.d_z_.data(), data.d_dx_.data(), data.d_dz_.data()),
@@ -3984,7 +3984,7 @@ void barrier_solver_t<i_t, f_t>::compute_next_iterate(iteration_data_t<i_t, f_t>
     [step_primal, step_dual] HD(f_t x, f_t z, f_t dx, f_t dz) -> thrust::tuple<f_t, f_t> {
       return {x + step_primal * dx, z + step_dual * dz};
     },
-    stream_view_.value());
+    stream_view_.get());
   RAFT_CHECK_CUDA(stream_view_);
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(data.d_y_.data(), data.d_dy_.data()),

--- a/cpp/src/barrier/barrier.cu
+++ b/cpp/src/barrier/barrier.cu
@@ -387,10 +387,10 @@ class barrier_reduce_helper_t {
       return;
     }
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Reduce(nullptr, temp_storage_bytes, in, out, size, op, init, stream_view);
+    cub::DeviceReduce::Reduce(nullptr, temp_storage_bytes, in, out, size, op, init, stream_view.get());
     d_temp_storage_.resize(temp_storage_bytes, stream_view);
     cub::DeviceReduce::Reduce(
-      d_temp_storage_.data(), temp_storage_bytes, in, out, size, op, init, stream_view);
+      d_temp_storage_.data(), temp_storage_bytes, in, out, size, op, init, stream_view.get());
   }
 
   void norm_inf_async(Slot slot, const f_t* in, i_t size, rmm::cuda_stream_view stream_view)
@@ -407,9 +407,9 @@ class barrier_reduce_helper_t {
   {
     f_t* out                  = d_results_.data() + slot;
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, in, out, size, stream_view);
+    cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, in, out, size, stream_view.get());
     d_temp_storage_.resize(temp_storage_bytes, stream_view);
-    cub::DeviceReduce::Sum(d_temp_storage_.data(), temp_storage_bytes, in, out, size, stream_view);
+    cub::DeviceReduce::Sum(d_temp_storage_.data(), temp_storage_bytes, in, out, size, stream_view.get());
   }
 
   void dot_async(Slot slot,
@@ -419,7 +419,7 @@ class barrier_reduce_helper_t {
                  rmm::cuda_stream_view stream_view)
   {
     RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(
-      cublas_handle, a.size(), a.data(), 1, b.data(), 1, d_results_.data() + slot, stream_view));
+      cublas_handle, a.size(), a.data(), 1, b.data(), 1, d_results_.data() + slot, stream_view.get()));
   }
 
   rmm::device_uvector<f_t> d_results_;

--- a/cpp/src/barrier/csr_kkt_build.cuh
+++ b/cpp/src/barrier/csr_kkt_build.cuh
@@ -524,7 +524,7 @@ void build_augmented_csr_metadata(const cone_data_t<i_t, f_t>& cones,
                i_t(-1));
   if (n_sparse > 0) {
     const size_t grid = raft::ceildiv<size_t>(n_sparse, augmented_csr_block_size);
-    scatter_sparse_ids_by_cone_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.value()>>>(
+    scatter_sparse_ids_by_cone_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.get()>>>(
       cuopt::make_span(metadata.sparse_ids_by_cone),
       cuopt::make_span(cones.sparse_cone_ids),
       n_sparse);
@@ -548,14 +548,14 @@ void build_augmented_csr_metadata(const cone_data_t<i_t, f_t>& cones,
       rmm::exec_policy(stream), is_dense_cone.begin(), is_dense_cone.end(), dense_prefix.begin());
 
     const size_t grid = raft::ceildiv<size_t>(n_cones, augmented_csr_block_size);
-    build_dense_ids_by_cone_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.value()>>>(
+    build_dense_ids_by_cone_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.get()>>>(
       cuopt::make_span(metadata.dense_ids_by_cone),
       cuopt::make_span(cones.cone_is_sparse),
       cuopt::make_span(dense_prefix),
       n_cones);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
-    compact_dense_cone_ids_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.value()>>>(
+    compact_dense_cone_ids_kernel<i_t><<<grid, augmented_csr_block_size, 0, stream.get()>>>(
       cuopt::make_span(metadata.dense_cone_ids),
       cuopt::make_span(dense_prefix),
       cuopt::make_span(cones.cone_is_sparse),
@@ -564,12 +564,11 @@ void build_augmented_csr_metadata(const cone_data_t<i_t, f_t>& cones,
 
     rmm::device_uvector<size_t> dense_block_sizes(n_dense, stream);
     const size_t dense_grid = raft::ceildiv<size_t>(n_dense, augmented_csr_block_size);
-    build_dense_block_sizes_kernel<i_t>
-      <<<dense_grid, augmented_csr_block_size, 0, stream.value()>>>(
-        cuopt::make_span(dense_block_sizes),
-        cuopt::make_span(metadata.dense_cone_ids),
-        cuopt::make_span(cones.cone_offsets),
-        n_dense);
+    build_dense_block_sizes_kernel<i_t><<<dense_grid, augmented_csr_block_size, 0, stream.get()>>>(
+      cuopt::make_span(dense_block_sizes),
+      cuopt::make_span(metadata.dense_cone_ids),
+      cuopt::make_span(cones.cone_offsets),
+      n_dense);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
     thrust::exclusive_scan(rmm::exec_policy(stream),
@@ -612,7 +611,7 @@ void build_augmented_csr_metadata(const cone_data_t<i_t, f_t>& cones,
 
     const size_t entry_grid = raft::ceildiv<size_t>(m_c, augmented_csr_block_size);
     build_dense_cone_entry_rank_kernel<i_t>
-      <<<entry_grid, augmented_csr_block_size, 0, stream.value()>>>(
+      <<<entry_grid, augmented_csr_block_size, 0, stream.get()>>>(
         cuopt::make_span(metadata.dense_cone_entry_rank),
         cuopt::make_span(cones.element_cone_ids),
         cuopt::make_span(cones.cone_is_sparse),
@@ -650,7 +649,7 @@ i_t build_augmented_csr_on_device(i_t n,
   {
     raft::common::nvtx::range scope("Barrier: augmented: device CSR count");
     const size_t grid = raft::ceildiv<size_t>(factorization_size, augmented_csr_block_size);
-    count_augmented_row_nnz_kernel<i_t, f_t><<<grid, augmented_csr_block_size, 0, stream.value()>>>(
+    count_augmented_row_nnz_kernel<i_t, f_t><<<grid, augmented_csr_block_size, 0, stream.get()>>>(
       factorization_size,
       n,
       m,
@@ -715,7 +714,7 @@ i_t build_augmented_csr_on_device(i_t n,
     raft::common::nvtx::range scope("Barrier: augmented: device CSR fill");
     auto views        = make_cone_kkt_views(cone_data, augmented_diagonal_indices);
     const size_t grid = raft::ceildiv<size_t>(factorization_size, augmented_csr_block_size);
-    fill_augmented_csr_row_kernel<i_t, f_t><<<grid, augmented_csr_block_size, 0, stream.value()>>>(
+    fill_augmented_csr_row_kernel<i_t, f_t><<<grid, augmented_csr_block_size, 0, stream.get()>>>(
       factorization_size,
       n,
       m,

--- a/cpp/src/barrier/cusparse_view.cu
+++ b/cpp/src/barrier/cusparse_view.cu
@@ -145,7 +145,7 @@ void cusparse_view_t<i_t, f_t>::init_spmv_buffer_and_preprocess(cusparseSpMatDes
                                                   y,
                                                   spmv_alg,
                                                   &buffer_size_spmv,
-                                                  handle_ptr_->get_stream()));
+                                                  handle_ptr_->get_stream().get()));
   buffer.resize(buffer_size_spmv, handle_ptr_->get_stream());
 
   my_cusparsespmv_preprocess(handle_ptr_->get_cusparse_handle(),
@@ -157,7 +157,7 @@ void cusparse_view_t<i_t, f_t>::init_spmv_buffer_and_preprocess(cusparseSpMatDes
                              y,
                              spmv_alg,
                              buffer.data(),
-                             handle_ptr_->get_stream());
+                             handle_ptr_->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -177,9 +177,9 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(raft::handle_t const* handle_ptr,
     d_zero_(zero_v<f_t>, handle_ptr->get_stream())
 {
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   // TMP matrix data should already be on the GPU
   constexpr bool debug = false;
   if (debug) { printf("A hash: %zu\n", A.hash()); }
@@ -272,7 +272,7 @@ void cusparse_view_t<i_t, f_t>::spmv(f_t alpha,
                                      y,
                                      get_spmv_alg(rows_),
                                      (f_t*)spmv_buffer_.data(),
-                                     handle_ptr_->get_stream());
+                                     handle_ptr_->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -327,7 +327,7 @@ void cusparse_view_t<i_t, f_t>::transpose_spmv(f_t alpha,
                                      y,
                                      get_spmv_alg(A_T_offsets_.size() - 1),
                                      (f_t*)spmv_buffer_transpose_.data(),
-                                     handle_ptr_->get_stream());
+                                     handle_ptr_->get_stream().get());
 }
 
 template class cusparse_view_t<int, double>;

--- a/cpp/src/barrier/cusparse_view.cu
+++ b/cpp/src/barrier/cusparse_view.cu
@@ -178,8 +178,9 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(raft::handle_t const* handle_ptr,
 {
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
   // TMP matrix data should already be on the GPU
   constexpr bool debug = false;
   if (debug) { printf("A hash: %zu\n", A.hash()); }

--- a/cpp/src/barrier/device_sparse_matrix.cuh
+++ b/cpp/src/barrier/device_sparse_matrix.cuh
@@ -269,7 +269,7 @@ class device_csc_matrix_t {
                                   col_index.size(),
                                   stream);
     // Have to sync since InclusiveSum is being run on local data (d_temp_storage)
-    stream.synchronize();
+    stream.sync();
   }
 
   csc_view_t<i_t, f_t> view()

--- a/cpp/src/barrier/device_sparse_matrix.cuh
+++ b/cpp/src/barrier/device_sparse_matrix.cuh
@@ -43,9 +43,9 @@ struct sum_reduce_helper_t {
   f_t sum(InputIteratorT input, i_t size, rmm::cuda_stream_view stream_view)
   {
     buffer_size = 0;
-    cub::DeviceReduce::Sum(nullptr, buffer_size, input, out.data(), size, stream_view);
+    cub::DeviceReduce::Sum(nullptr, buffer_size, input, out.data(), size, stream_view.get());
     buffer_data.resize(buffer_size, stream_view);
-    cub::DeviceReduce::Sum(buffer_data.data(), buffer_size, input, out.data(), size, stream_view);
+    cub::DeviceReduce::Sum(buffer_data.data(), buffer_size, input, out.data(), size, stream_view.get());
     return out.value(stream_view);
   }
 };
@@ -70,7 +70,7 @@ struct transform_reduce_helper_t {
                        rmm::cuda_stream_view stream_view)
   {
     cub::DeviceReduce::TransformReduce(
-      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view);
+      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view.get());
 
     buffer_data.resize(buffer_size, stream_view);
 
@@ -82,7 +82,7 @@ struct transform_reduce_helper_t {
                                        reduce_op,
                                        transform_op,
                                        init,
-                                       stream_view);
+                                       stream_view.get());
 
     return out.value(stream_view);
   }
@@ -124,7 +124,7 @@ struct transform_reduce_pair_helper_t {
   {
     f2_min_t<f_t> reduce_op{};
     cub::DeviceReduce::TransformReduce(
-      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view);
+      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view.get());
 
     buffer_data.resize(buffer_size, stream_view);
 
@@ -136,7 +136,7 @@ struct transform_reduce_pair_helper_t {
                                        reduce_op,
                                        transform_op,
                                        init,
-                                       stream_view);
+                                       stream_view.get());
 
     return out.value(stream_view);
   }
@@ -240,7 +240,7 @@ class device_csc_matrix_t {
   void form_col_index(rmm::cuda_stream_view stream)
   {
     col_index.resize(x.size(), stream);
-    RAFT_CUDA_TRY(cudaMemsetAsync(col_index.data(), 0, sizeof(i_t) * col_index.size(), stream));
+    RAFT_CUDA_TRY(cudaMemsetAsync(col_index.data(), 0, sizeof(i_t) * col_index.size(), stream.get()));
 
     // Scatter 1 when there is a col start in col_index
     if (col_start.size() > 2) {
@@ -260,14 +260,14 @@ class device_csc_matrix_t {
     rmm::device_buffer d_temp_storage;
     size_t temp_storage_bytes{0};
     cub::DeviceScan::InclusiveSum(
-      nullptr, temp_storage_bytes, col_index.data(), col_index.data(), col_index.size(), stream);
+      nullptr, temp_storage_bytes, col_index.data(), col_index.data(), col_index.size(), stream.get());
     d_temp_storage.resize(temp_storage_bytes, stream);
     cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
                                   temp_storage_bytes,
                                   col_index.data(),
                                   col_index.data(),
                                   col_index.size(),
-                                  stream);
+                                  stream.get());
     // Have to sync since InclusiveSum is being run on local data (d_temp_storage)
     stream.sync();
   }
@@ -394,13 +394,13 @@ void device_csc_matrix_t<i_t, f_t>::to_compressed_row(device_csr_matrix_t<i_t, f
 
   if (nz == 0) {
     // Empty matrix: row_start all zero; j/x unused.
-    RAFT_CUDA_TRY(cudaMemsetAsync(Arow.row_start.data(), 0, sizeof(i_t) * (m + 1), stream));
+    RAFT_CUDA_TRY(cudaMemsetAsync(Arow.row_start.data(), 0, sizeof(i_t) * (m + 1), stream.get()));
     return;
   }
 
   // Per-row nnz from CSC row indices i[] (one atomic add per nonzero).
   rmm::device_uvector<i_t> row_counts(m, stream);
-  RAFT_CUDA_TRY(cudaMemsetAsync(row_counts.data(), 0, sizeof(i_t) * m, stream));
+  RAFT_CUDA_TRY(cudaMemsetAsync(row_counts.data(), 0, sizeof(i_t) * m, stream.get()));
 
   thrust::for_each(exec,
                    thrust::make_counting_iterator<i_t>(0),
@@ -413,13 +413,13 @@ void device_csc_matrix_t<i_t, f_t>::to_compressed_row(device_csr_matrix_t<i_t, f
   rmm::device_buffer scan_tmp;
   std::size_t scan_bytes = 0;
   cub::DeviceScan::ExclusiveSum(
-    nullptr, scan_bytes, row_counts.data(), Arow.row_start.data(), m, stream);
+    nullptr, scan_bytes, row_counts.data(), Arow.row_start.data(), m, stream.get());
   scan_tmp.resize(scan_bytes, stream);
   cub::DeviceScan::ExclusiveSum(
-    scan_tmp.data(), scan_bytes, row_counts.data(), Arow.row_start.data(), m, stream);
+    scan_tmp.data(), scan_bytes, row_counts.data(), Arow.row_start.data(), m, stream.get());
 
   RAFT_CUDA_TRY(
-    cudaMemcpyAsync(Arow.row_start.data() + m, &nz, sizeof(i_t), cudaMemcpyHostToDevice, stream));
+    cudaMemcpyAsync(Arow.row_start.data() + m, &nz, sizeof(i_t), cudaMemcpyHostToDevice, stream.get()));
 
   // rows[]: CSC row indices (sort key). Arow.j / Arow.x hold (col, val) per flat CSC index,
   // then sort_by_key permutes j and x in place into CSR (row, col) order.

--- a/cpp/src/barrier/device_sparse_matrix.cuh
+++ b/cpp/src/barrier/device_sparse_matrix.cuh
@@ -45,7 +45,8 @@ struct sum_reduce_helper_t {
     buffer_size = 0;
     cub::DeviceReduce::Sum(nullptr, buffer_size, input, out.data(), size, stream_view.get());
     buffer_data.resize(buffer_size, stream_view);
-    cub::DeviceReduce::Sum(buffer_data.data(), buffer_size, input, out.data(), size, stream_view.get());
+    cub::DeviceReduce::Sum(
+      buffer_data.data(), buffer_size, input, out.data(), size, stream_view.get());
     return out.value(stream_view);
   }
 };
@@ -69,8 +70,15 @@ struct transform_reduce_helper_t {
                        i_t size,
                        rmm::cuda_stream_view stream_view)
   {
-    cub::DeviceReduce::TransformReduce(
-      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view.get());
+    cub::DeviceReduce::TransformReduce(nullptr,
+                                       buffer_size,
+                                       input,
+                                       out.data(),
+                                       size,
+                                       reduce_op,
+                                       transform_op,
+                                       init,
+                                       stream_view.get());
 
     buffer_data.resize(buffer_size, stream_view);
 
@@ -123,8 +131,15 @@ struct transform_reduce_pair_helper_t {
                              rmm::cuda_stream_view stream_view)
   {
     f2_min_t<f_t> reduce_op{};
-    cub::DeviceReduce::TransformReduce(
-      nullptr, buffer_size, input, out.data(), size, reduce_op, transform_op, init, stream_view.get());
+    cub::DeviceReduce::TransformReduce(nullptr,
+                                       buffer_size,
+                                       input,
+                                       out.data(),
+                                       size,
+                                       reduce_op,
+                                       transform_op,
+                                       init,
+                                       stream_view.get());
 
     buffer_data.resize(buffer_size, stream_view);
 
@@ -240,7 +255,8 @@ class device_csc_matrix_t {
   void form_col_index(rmm::cuda_stream_view stream)
   {
     col_index.resize(x.size(), stream);
-    RAFT_CUDA_TRY(cudaMemsetAsync(col_index.data(), 0, sizeof(i_t) * col_index.size(), stream.get()));
+    RAFT_CUDA_TRY(
+      cudaMemsetAsync(col_index.data(), 0, sizeof(i_t) * col_index.size(), stream.get()));
 
     // Scatter 1 when there is a col start in col_index
     if (col_start.size() > 2) {
@@ -259,8 +275,12 @@ class device_csc_matrix_t {
     // Inclusive cumulative sum to have the corresponding column for each entry
     rmm::device_buffer d_temp_storage;
     size_t temp_storage_bytes{0};
-    cub::DeviceScan::InclusiveSum(
-      nullptr, temp_storage_bytes, col_index.data(), col_index.data(), col_index.size(), stream.get());
+    cub::DeviceScan::InclusiveSum(nullptr,
+                                  temp_storage_bytes,
+                                  col_index.data(),
+                                  col_index.data(),
+                                  col_index.size(),
+                                  stream.get());
     d_temp_storage.resize(temp_storage_bytes, stream);
     cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
                                   temp_storage_bytes,
@@ -418,8 +438,8 @@ void device_csc_matrix_t<i_t, f_t>::to_compressed_row(device_csr_matrix_t<i_t, f
   cub::DeviceScan::ExclusiveSum(
     scan_tmp.data(), scan_bytes, row_counts.data(), Arow.row_start.data(), m, stream.get());
 
-  RAFT_CUDA_TRY(
-    cudaMemcpyAsync(Arow.row_start.data() + m, &nz, sizeof(i_t), cudaMemcpyHostToDevice, stream.get()));
+  RAFT_CUDA_TRY(cudaMemcpyAsync(
+    Arow.row_start.data() + m, &nz, sizeof(i_t), cudaMemcpyHostToDevice, stream.get()));
 
   // rows[]: CSC row indices (sort key). Arow.j / Arow.x hold (col, val) per flat CSC index,
   // then sort_by_key permutes j and x in place into CSR (row, col) order.

--- a/cpp/src/barrier/iterative_refinement.hpp
+++ b/cpp/src/barrier/iterative_refinement.hpp
@@ -80,7 +80,7 @@ f_t iterative_refinement_simple(T& op,
                  delta_x.data(),
                  delta_x.data() + delta_x.size(),
                  0.0);
-    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     op.solve(r, delta_x);
 
     thrust::transform(op.data_.handle_ptr->get_thrust_policy(),
@@ -89,7 +89,7 @@ f_t iterative_refinement_simple(T& op,
                       delta_x.data(),
                       x.data(),
                       thrust::plus<f_t>());
-    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     // r = b - Ax
     raft::copy(r.data(), b.data(), b.size(), x.stream());
     op.a_multiply(-1.0, x, 1.0, r);
@@ -183,7 +183,7 @@ f_t iterative_refinement_gmres(T& op,
                       V[0].data() + V[0].size(),
                       V[0].data(),
                       scale_op<f_t>{inv_rnorm});
-    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     e1.assign(m + 1, 0.0);
     e1[0] = rnorm;
 
@@ -211,7 +211,7 @@ f_t iterative_refinement_gmres(T& op,
                                         V[k + 1].data() + x.size(),
                                         V[j].data(),
                                         f_t(0));
-        RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+        RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
         H[j][k] = hij;
         // w -= H[j][k] * V[j]
         thrust::transform(op.data_.handle_ptr->get_thrust_policy(),
@@ -220,7 +220,7 @@ f_t iterative_refinement_gmres(T& op,
                           V[j].data(),
                           V[k + 1].data(),
                           subtract_scaled_op<f_t>{hij});
-        RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+        RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
       }
 
       // H[k+1][k] = ||w||
@@ -247,7 +247,7 @@ f_t iterative_refinement_gmres(T& op,
                         V[k + 1].data() + x.size(),
                         V[k + 1].data(),
                         scale_op<f_t>{inv_h});
-      RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
 
       // Apply Given's rotations to new column
       for (int i = 0; i < k; ++i) {
@@ -298,7 +298,7 @@ f_t iterative_refinement_gmres(T& op,
                  delta_x.data(),
                  delta_x.data() + delta_x.size(),
                  0.0);
-    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     for (int j = 0; j < k; ++j) {
       thrust::transform(op.data_.handle_ptr->get_thrust_policy(),
                         delta_x.data(),
@@ -306,7 +306,7 @@ f_t iterative_refinement_gmres(T& op,
                         Z[j].data(),
                         delta_x.data(),
                         axpy_op<f_t>{y[j]});
-      RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     }
 
     // Update x = x + delta_x
@@ -316,7 +316,7 @@ f_t iterative_refinement_gmres(T& op,
                       delta_x.data(),
                       x.data(),
                       thrust::plus<f_t>());
-    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(op.data_.handle_ptr->get_stream().get());
     // r = b - A*x
     raft::copy(r.data(), b.data(), b.size(), x.stream());
     op.a_multiply(-1.0, x, 1.0, r);
@@ -375,7 +375,7 @@ f_t iterative_refinement(T& op,
 
   raft::copy(x.data(), d_x.data(), x.size(), op.data_.handle_ptr->get_stream());
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(op.data_.handle_ptr->get_stream().get()));
+  op.data_.handle_ptr->get_stream().sync();
   return err;
 }
 

--- a/cpp/src/barrier/iterative_refinement.hpp
+++ b/cpp/src/barrier/iterative_refinement.hpp
@@ -375,7 +375,7 @@ f_t iterative_refinement(T& op,
 
   raft::copy(x.data(), d_x.data(), x.size(), op.data_.handle_ptr->get_stream());
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(op.data_.handle_ptr->get_stream()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(op.data_.handle_ptr->get_stream().get()));
   return err;
 }
 

--- a/cpp/src/barrier/second_order_cone_kernels.cuh
+++ b/cpp/src/barrier/second_order_cone_kernels.cuh
@@ -475,15 +475,14 @@ void launch_nt_scaling(cone_data_t<i_t, f_t>& cones, rmm::cuda_stream_view strea
 
   const size_t cone_grid_dim =
     raft::ceildiv<size_t>(static_cast<size_t>(cones.n_cones), soc_block_size);
-  nt_finalize_scaling_scalars_kernel<i_t, f_t>
-    <<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
-      cones.x, cones.z, x_scale, z_scale, cuopt::make_span(cones.eta), cone_offsets, cones.n_cones);
+  nt_finalize_scaling_scalars_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
+    cones.x, cones.z, x_scale, z_scale, cuopt::make_span(cones.eta), cone_offsets, cones.n_cones);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   const size_t element_grid_dim = raft::ceildiv<size_t>(cones.n_cone_entries, soc_block_size);
 
   auto w = cuopt::make_span(cones.w);
-  nt_write_w_kernel<i_t, f_t><<<element_grid_dim, soc_block_size, 0, stream.value()>>>(
+  nt_write_w_kernel<i_t, f_t><<<element_grid_dim, soc_block_size, 0, stream.get()>>>(
     cones.x, cones.z, x_scale, z_scale, w, cone_offsets, element_cone_ids);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -495,24 +494,24 @@ void launch_nt_scaling(cone_data_t<i_t, f_t>& cones, rmm::cuda_stream_view strea
                                     });
   cones.segmented_sum(unnormalized_tail_sq_terms, w_scale, stream);
 
-  nt_finalize_w_scale_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
+  nt_finalize_w_scale_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
     w, w_scale, w_scale, cone_offsets, cones.n_cones);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   nt_normalize_w_kernel<i_t, f_t>
-    <<<element_grid_dim, soc_block_size, 0, stream.value()>>>(w, w_scale, element_cone_ids);
+    <<<element_grid_dim, soc_block_size, 0, stream.get()>>>(w, w_scale, element_cone_ids);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Persist lambda while w_scale still stores sqrt(det_J(w_tmp)).
   nt_write_lambda_kernel<i_t, f_t>
-    <<<element_grid_dim, soc_block_size, 0, stream.value()>>>(cones.x,
-                                                              cones.z,
-                                                              x_scale,
-                                                              z_scale,
-                                                              w_scale,
-                                                              cuopt::make_span(cones.lambda),
-                                                              cone_offsets,
-                                                              element_cone_ids);
+    <<<element_grid_dim, soc_block_size, 0, stream.get()>>>(cones.x,
+                                                            cones.z,
+                                                            x_scale,
+                                                            z_scale,
+                                                            w_scale,
+                                                            cuopt::make_span(cones.lambda),
+                                                            cone_offsets,
+                                                            element_cone_ids);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // w_scale is overwritten from here
@@ -524,7 +523,7 @@ void launch_nt_scaling(cone_data_t<i_t, f_t>& cones, rmm::cuda_stream_view strea
                                     });
   cones.segmented_sum(normalized_tail_terms, w_scale, stream);
 
-  nt_finalize_head_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
+  nt_finalize_head_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
     cuopt::make_span(cones.w), w_scale, cone_offsets, cones.n_cones);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
@@ -604,16 +603,16 @@ void launch_update_scaling_sparse(cone_data_t<i_t, f_t>& cones, rmm::cuda_stream
 
   const i_t n_sparse = cones.n_sparse_cones;
   update_scaling_sparse_kernel<i_t, f_t>
-    <<<n_sparse, soc_block_size, 0, stream.value()>>>(cuopt::make_span(cones.w),
-                                                      cuopt::make_span(cones.eta),
-                                                      cuopt::make_span(cones.d),
-                                                      cuopt::make_span(cones.sparse_v),
-                                                      cuopt::make_span(cones.sparse_u),
-                                                      cuopt::make_span(cones.cone_offsets),
-                                                      cuopt::make_span(cones.sparse_cone_dims),
-                                                      cuopt::make_span(cones.sparse_cone_ids),
-                                                      cuopt::make_span(cones.sparse_entry_offsets),
-                                                      n_sparse);
+    <<<n_sparse, soc_block_size, 0, stream.get()>>>(cuopt::make_span(cones.w),
+                                                    cuopt::make_span(cones.eta),
+                                                    cuopt::make_span(cones.d),
+                                                    cuopt::make_span(cones.sparse_v),
+                                                    cuopt::make_span(cones.sparse_u),
+                                                    cuopt::make_span(cones.cone_offsets),
+                                                    cuopt::make_span(cones.sparse_cone_dims),
+                                                    cuopt::make_span(cones.sparse_cone_ids),
+                                                    cuopt::make_span(cones.sparse_entry_offsets),
+                                                    n_sparse);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -850,7 +849,7 @@ void apply_w_inv(raft::device_span<const f_t> v,
   cones.segmented_sum(tail_terms, tail_dot, stream);
 
   const size_t grid_dim = raft::ceildiv<size_t>(out.size(), soc_block_size);
-  apply_w_inv_write_kernel<i_t, f_t><<<grid_dim, soc_block_size, 0, stream.value()>>>(
+  apply_w_inv_write_kernel<i_t, f_t><<<grid_dim, soc_block_size, 0, stream.get()>>>(
     v, out, w, eta, tail_dot, cone_offsets, element_cone_ids);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
@@ -886,7 +885,7 @@ void apply_w(raft::device_span<const f_t> v,
   cones.segmented_sum(tail_terms, tail_dot, stream);
 
   const size_t grid_dim = raft::ceildiv<size_t>(out.size(), soc_block_size);
-  apply_w_write_kernel<i_t, f_t><<<grid_dim, soc_block_size, 0, stream.value()>>>(
+  apply_w_write_kernel<i_t, f_t><<<grid_dim, soc_block_size, 0, stream.get()>>>(
     v, out, w, eta, tail_dot, cone_offsets, element_cone_ids);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
@@ -921,18 +920,18 @@ void apply_hessian(raft::device_span<const f_t> v,
 
   const size_t grid_dim = raft::ceildiv<size_t>(out.size(), soc_block_size);
   apply_hessian_kernel<i_t, f_t>
-    <<<grid_dim, soc_block_size, 0, stream.value()>>>(v,
-                                                      out,
-                                                      w,
-                                                      eta,
-                                                      wv_dot,
-                                                      cone_offsets,
-                                                      element_cone_ids,
-                                                      cuopt::make_span(cones.cone_is_sparse),
-                                                      dense_cones_only,
-                                                      bias,
-                                                      output_scale,
-                                                      bias_scale);
+    <<<grid_dim, soc_block_size, 0, stream.get()>>>(v,
+                                                    out,
+                                                    w,
+                                                    eta,
+                                                    wv_dot,
+                                                    cone_offsets,
+                                                    element_cone_ids,
+                                                    cuopt::make_span(cones.cone_is_sparse),
+                                                    dense_cones_only,
+                                                    bias,
+                                                    output_scale,
+                                                    bias_scale);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1062,24 +1061,23 @@ void scatter_sparse_hessian_into_augmented(cone_data_t<i_t, f_t>& cones,
   const size_t E          = cones.n_sparse_cone_entries;
   const size_t entry_grid = raft::ceildiv<size_t>(E, soc_block_size);
   scatter_sparse_hessian_into_augmented_kernel<i_t, f_t>
-    <<<entry_grid, soc_block_size, 0, stream.value()>>>(
-      cuopt::make_span(augmented_x),
-      cuopt::make_span(Hs_diag),
-      cuopt::make_span(cones.eta),
-      cuopt::make_span(cones.d),
-      cuopt::make_span(cones.sparse_cone_ids),
-      cuopt::make_span(cones.sparse_entry_offsets),
-      n_sparse,
-      cuopt::make_span(hessian_diag_csr_indices),
-      cuopt::make_span(q_values),
-      cuopt::make_span(cones.sparse_v),
-      cuopt::make_span(cones.sparse_u),
-      cuopt::make_span(exp_v_col),
-      cuopt::make_span(exp_u_col),
-      cuopt::make_span(exp_v_row),
-      cuopt::make_span(exp_u_row),
-      cuopt::make_span(sparse_expansion_D),
-      dual_perturb);
+    <<<entry_grid, soc_block_size, 0, stream.get()>>>(cuopt::make_span(augmented_x),
+                                                      cuopt::make_span(Hs_diag),
+                                                      cuopt::make_span(cones.eta),
+                                                      cuopt::make_span(cones.d),
+                                                      cuopt::make_span(cones.sparse_cone_ids),
+                                                      cuopt::make_span(cones.sparse_entry_offsets),
+                                                      n_sparse,
+                                                      cuopt::make_span(hessian_diag_csr_indices),
+                                                      cuopt::make_span(q_values),
+                                                      cuopt::make_span(cones.sparse_v),
+                                                      cuopt::make_span(cones.sparse_u),
+                                                      cuopt::make_span(exp_v_col),
+                                                      cuopt::make_span(exp_u_col),
+                                                      cuopt::make_span(exp_v_row),
+                                                      cuopt::make_span(exp_u_row),
+                                                      cuopt::make_span(sparse_expansion_D),
+                                                      dual_perturb);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1181,21 +1179,21 @@ void launch_sparse_augmented_matvec(raft::device_span<const f_t> x,
                "expansion output size mismatch");
 
   sparse_augmented_matvec_kernel<i_t, f_t>
-    <<<n_sparse, soc_block_size, 0, stream.value()>>>(x,
-                                                      r1,
-                                                      y_exp,
-                                                      Hs_diag,
-                                                      cuopt::make_span(cones.sparse_v),
-                                                      cuopt::make_span(cones.sparse_u),
-                                                      cuopt::make_span(cones.eta),
-                                                      cuopt::make_span(cones.sparse_cone_ids),
-                                                      cuopt::make_span(cones.sparse_cone_dims),
-                                                      cuopt::make_span(cones.sparse_entry_offsets),
-                                                      cuopt::make_span(cones.cone_offsets),
-                                                      cone_var_start,
-                                                      n_primal,
-                                                      m_constraints,
-                                                      n_sparse);
+    <<<n_sparse, soc_block_size, 0, stream.get()>>>(x,
+                                                    r1,
+                                                    y_exp,
+                                                    Hs_diag,
+                                                    cuopt::make_span(cones.sparse_v),
+                                                    cuopt::make_span(cones.sparse_u),
+                                                    cuopt::make_span(cones.eta),
+                                                    cuopt::make_span(cones.sparse_cone_ids),
+                                                    cuopt::make_span(cones.sparse_cone_dims),
+                                                    cuopt::make_span(cones.sparse_entry_offsets),
+                                                    cuopt::make_span(cones.cone_offsets),
+                                                    cone_var_start,
+                                                    n_primal,
+                                                    m_constraints,
+                                                    n_sparse);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1261,16 +1259,16 @@ void scatter_dense_hessian_into_augmented(const cone_data_t<i_t, f_t>& cones,
   const i_t n_dense = cones.n_dense_cones();
   const size_t grid = raft::ceildiv<size_t>(count, soc_block_size);
   scatter_dense_hessian_into_augmented_kernel<i_t, f_t>
-    <<<grid, soc_block_size, 0, stream.value()>>>(cuopt::make_span(augmented_x),
-                                                  cuopt::make_span(csr_indices),
-                                                  cuopt::make_span(q_values),
-                                                  cuopt::make_span(cones.w),
-                                                  cuopt::make_span(cones.eta),
-                                                  cuopt::make_span(cones.cone_offsets),
-                                                  cuopt::make_span(dense_block_offsets),
-                                                  cuopt::make_span(dense_cone_ids),
-                                                  n_dense,
-                                                  dual_perturb_value);
+    <<<grid, soc_block_size, 0, stream.get()>>>(cuopt::make_span(augmented_x),
+                                                cuopt::make_span(csr_indices),
+                                                cuopt::make_span(q_values),
+                                                cuopt::make_span(cones.w),
+                                                cuopt::make_span(cones.eta),
+                                                cuopt::make_span(cones.cone_offsets),
+                                                cuopt::make_span(dense_block_offsets),
+                                                cuopt::make_span(dense_cone_ids),
+                                                n_dense,
+                                                dual_perturb_value);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1467,7 +1465,7 @@ void launch_cone_step_length(segmented_sum_t<i_t>& partitions,
     const auto n_small = partitions.small_cone_ids.size();
     const auto grid    = (n_small + warps_per_cta - 1) / warps_per_cta;
     step_length_small_kernel<i_t, f_t, warps_per_cta>
-      <<<grid, warps_per_cta * raft::WarpSize, 0, stream.value()>>>(
+      <<<grid, warps_per_cta * raft::WarpSize, 0, stream.get()>>>(
         u,
         du,
         alpha,
@@ -1480,7 +1478,7 @@ void launch_cone_step_length(segmented_sum_t<i_t>& partitions,
   if (!partitions.medium_cone_ids.is_empty()) {
     constexpr int medium_block_dim = 256;
     step_length_medium_kernel<i_t, f_t, medium_block_dim>
-      <<<partitions.medium_cone_ids.size(), medium_block_dim, 0, stream.value()>>>(
+      <<<partitions.medium_cone_ids.size(), medium_block_dim, 0, stream.get()>>>(
         u,
         du,
         alpha,
@@ -1512,14 +1510,14 @@ void launch_cone_step_length(segmented_sum_t<i_t>& partitions,
                                            input,
                                            large_sums.data() + i,
                                            dim,
-                                           stream.value()));
+                                           stream.get()));
     }
 
     raft::device_span<const step_tail_sums_t<f_t>> large_sums_c(large_sums.data(),
                                                                 large_sums.size());
     constexpr int large_solve_block_dim = 256;
     const auto grid = raft::ceildiv<size_t>(n_large, static_cast<size_t>(large_solve_block_dim));
-    step_length_large_solve_kernel<i_t, f_t><<<grid, large_solve_block_dim, 0, stream.value()>>>(
+    step_length_large_solve_kernel<i_t, f_t><<<grid, large_solve_block_dim, 0, stream.get()>>>(
       u,
       du,
       alpha,
@@ -1608,16 +1606,15 @@ void compute_combined_cone_rhs_term(raft::device_span<const f_t> dx_aff,
   // Stage both head vectors first because every tail entry needs them.
   const size_t cone_grid_dim =
     raft::ceildiv<size_t>(static_cast<size_t>(cones.n_cones), soc_block_size);
-  gather_cone_heads_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
+  gather_cone_heads_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
     scaled_dx, slot_1, cone_offsets, cones.n_cones);
-  gather_cone_heads_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
+  gather_cone_heads_kernel<i_t, f_t><<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
     scaled_dz, slot_2, cone_offsets, cones.n_cones);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   const size_t element_grid_dim = raft::ceildiv<size_t>(cones.n_cone_entries, soc_block_size);
-  combined_cone_shift_write_kernel<i_t, f_t>
-    <<<element_grid_dim, soc_block_size, 0, stream.value()>>>(
-      out, scaled_dx, scaled_dz, slot_0, slot_1, slot_2, cone_offsets, element_cone_ids, sigma_mu);
+  combined_cone_shift_write_kernel<i_t, f_t><<<element_grid_dim, soc_block_size, 0, stream.get()>>>(
+    out, scaled_dx, scaled_dz, slot_0, slot_1, slot_2, cone_offsets, element_cone_ids, sigma_mu);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   auto shift    = raft::device_span<const f_t>(out.data(), out.size());
@@ -1641,13 +1638,13 @@ void compute_combined_cone_rhs_term(raft::device_span<const f_t> dx_aff,
   cones.segmented_sum(lambda_tail_sq_terms, slot_1, stream);
 
   jordan_divide_by_lambda_scalar_kernel<i_t, f_t>
-    <<<cone_grid_dim, soc_block_size, 0, stream.value()>>>(
+    <<<cone_grid_dim, soc_block_size, 0, stream.get()>>>(
       shift, nt_point, slot_0, slot_1, slot_0, slot_1, cone_offsets, cones.n_cones);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Note that we implicitly multiply by -1 here since we are writing -p.
   jordan_divide_by_lambda_write_kernel<i_t, f_t>
-    <<<element_grid_dim, soc_block_size, 0, stream.value()>>>(
+    <<<element_grid_dim, soc_block_size, 0, stream.get()>>>(
       shift, nt_point, slot_0, slot_1, cone_offsets, element_cone_ids, scratch_cone);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 

--- a/cpp/src/barrier/second_order_cone_reduction.cuh
+++ b/cpp/src/barrier/second_order_cone_reduction.cuh
@@ -95,7 +95,7 @@ struct segmented_sum_t {
                                            input + large_cone_offsets[i],
                                            output + large_cone_ids[i],
                                            large_cone_dimensions[i],
-                                           stream.value()));
+                                           stream.get()));
       cub_workspace_bytes = std::max(cub_workspace_bytes, temp_storage_bytes);
     }
 
@@ -122,7 +122,7 @@ struct segmented_sum_t {
       const auto n_small = small_cone_ids.size();
       const auto grid    = (n_small + warps_per_cta - 1) / warps_per_cta;
       warp_per_cone_reduce_kernel<i_t, value_t, warps_per_cta>
-        <<<grid, warps_per_cta * raft::WarpSize, 0, stream.value()>>>(
+        <<<grid, warps_per_cta * raft::WarpSize, 0, stream.get()>>>(
           input, cuopt::make_span(small_cone_ids), cone_offsets, output, init);
       RAFT_CUDA_TRY(cudaPeekAtLastError());
     }
@@ -131,7 +131,7 @@ struct segmented_sum_t {
       constexpr int medium_block_dim = 256;
       const auto n_medium            = medium_cone_ids.size();
       block_per_cone_reduce_kernel<i_t, value_t, medium_block_dim>
-        <<<n_medium, medium_block_dim, 0, stream.value()>>>(
+        <<<n_medium, medium_block_dim, 0, stream.get()>>>(
           input, cuopt::make_span(medium_cone_ids), cone_offsets, output, init);
       RAFT_CUDA_TRY(cudaPeekAtLastError());
     }
@@ -147,7 +147,7 @@ struct segmented_sum_t {
                                              input + large_cone_offsets[i],
                                              output + large_cone_ids[i],
                                              large_cone_dimensions[i],
-                                             stream.value()));
+                                             stream.get()));
       }
     }
   }
@@ -199,7 +199,7 @@ struct segmented_sum_t {
       cuopt::device_copy(large_cone_ids_device, large_cone_ids, stream);
       need_sync = true;
     }
-    if (need_sync) { stream.synchronize(); }
+    if (need_sync) { stream.sync(); }
   }
 };
 

--- a/cpp/src/barrier/sparse_cholesky.cuh
+++ b/cpp/src/barrier/sparse_cholesky.cuh
@@ -144,7 +144,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       positive_definite(true),
       A_created(false),
       settings_(settings),
-      stream(handle_ptr->get_stream())
+      stream(handle_ptr->get_stream().get())
   {
     int major, minor, patch;
     cudssGetProperty(MAJOR_VERSION, &major);
@@ -221,7 +221,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       // 4. Create the green context and stream for that green
       // context CUstream barrier_green_ctx_stream;
       i_t stream_priority;
-      cudaStream_t cuda_stream    = handle_ptr_->get_stream();
+      cudaStream_t cuda_stream    = handle_ptr_->get_stream().get();
       cudaError_t priority_result = cudaStreamGetPriority(cuda_stream, &stream_priority);
       RAFT_CUDA_TRY(priority_result);
       auto cuGreenCtxCreate_func = cuopt::get_driver_entry_point("cuGreenCtxCreate");

--- a/cpp/src/barrier/sparse_cholesky.cuh
+++ b/cpp/src/barrier/sparse_cholesky.cuh
@@ -347,7 +347,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       status,
       "cudssMatrixCreateDn for x");
 #endif
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
   }
 
   ~sparse_cholesky_cudss_t() override
@@ -381,7 +381,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       CU_CHECK(
         reinterpret_cast<decltype(::cuGreenCtxDestroy)*>(cuGreenCtxDestroy_func)(barrier_green_ctx),
         reinterpret_cast<decltype(::cuGetErrorString)*>(cuGetErrorString_func));
-      handle_ptr_->get_stream().synchronize();
+      handle_ptr_->get_stream().sync();
     }
 #endif
   }
@@ -522,7 +522,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
     // TODO: Is there any way to get nonzeros in the factors?
     // TODO: Is there any way to get flops for the factorization?
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
 
     return 0;
   }
@@ -582,7 +582,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       status,
       "cudssDataGet for info");
 
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
     if (info != 0) {
       settings_.log.printf("Factorization failed info %d\n", info);
@@ -717,7 +717,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
     settings_.log.printf("Symbolic factorization time : %.2fs\n", symbolic_time);
     if (settings_.concurrent_halt != nullptr && *settings_.concurrent_halt == 1) {
       RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
-      handle_ptr_->get_stream().synchronize();
+      handle_ptr_->get_stream().sync();
       return CONCURRENT_HALT_RETURN;
     }
     int64_t lu_nz       = 0;
@@ -728,7 +728,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       "cudssDataGet for LU_NNZ");
     settings_.log.printf("Symbolic nonzeros in factor : %.2e\n", static_cast<f_t>(lu_nz) / 2.0);
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
     // TODO: Is there any way to get nonzeros in the factors?
     // TODO: Is there any way to get flops for the factorization?
 
@@ -753,7 +753,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       "cudaMemcpy for csr_values");
 
     CUDA_CALL_AND_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
 
     CUDSS_CALL_AND_CHECK(
       cudssMatrixSetValues(A, csr_values_d), status, "cudssMatrixSetValues for A");
@@ -777,7 +777,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
       status,
       "cudssDataGet for info");
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
     if (info != 0) {
       settings_.log.printf("Factorization failed info %d\n", info);
       return -1;
@@ -798,13 +798,13 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
   {
     auto d_b = cuopt::device_copy(b, handle_ptr_->get_stream());
     auto d_x = cuopt::device_copy(x, handle_ptr_->get_stream());
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
 
     i_t out = solve(d_b, d_x);
 
     raft::copy(x.data(), d_x.data(), d_x.size(), handle_ptr_->get_stream());
     // Sync so that data is on the host
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
 
     for (i_t i = 0; i < n; i++) {
       if (x[i] != x[i]) { return -1; }
@@ -815,7 +815,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
 
   i_t solve(rmm::device_uvector<f_t>& b, rmm::device_uvector<f_t>& x) override
   {
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
     if (static_cast<i_t>(b.size()) != n) {
       settings_.log.printf("Error: b.size() %d != n %d\n", b.size(), n);
       return -1;
@@ -843,7 +843,7 @@ class sparse_cholesky_cudss_t : public sparse_cholesky_base_t<i_t, f_t> {
     }
 
     CUDA_CALL_AND_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
 
 #ifdef PRINT_RHS_AND_SOLUTION_HASH
     dense_vector_t<i_t, f_t> b_host(n);

--- a/cpp/src/linear_algebra/sort_csr.cuh
+++ b/cpp/src/linear_algebra/sort_csr.cuh
@@ -50,8 +50,8 @@ void sort_csr(optimization_problem_t<i_t, f_t>& op_problem)
                                       op_problem.get_constraint_matrix_offsets().data(),
                                       op_problem.get_constraint_matrix_offsets().data() + 1,
                                       stream_view.get());
-  RAFT_CHECK_CUDA(stream_view);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  RAFT_CHECK_CUDA(stream_view.get());
+  stream_view.sync();
 }
 
 }  // namespace mathematical_optimization

--- a/cpp/src/linear_algebra/sort_csr.cuh
+++ b/cpp/src/linear_algebra/sort_csr.cuh
@@ -37,7 +37,7 @@ void sort_csr(optimization_problem_t<i_t, f_t>& op_problem)
                                       num_segments,
                                       op_problem.get_constraint_matrix_offsets().data(),
                                       op_problem.get_constraint_matrix_offsets().data() + 1,
-                                      stream_view);
+                                      stream_view.get());
   d_tmp_storage_bytes.resize(tmp_storage_bytes, stream_view);
   cub::DeviceSegmentedSort::SortPairs(d_tmp_storage_bytes.data(),
                                       tmp_storage_bytes,
@@ -49,9 +49,9 @@ void sort_csr(optimization_problem_t<i_t, f_t>& op_problem)
                                       num_segments,
                                       op_problem.get_constraint_matrix_offsets().data(),
                                       op_problem.get_constraint_matrix_offsets().data() + 1,
-                                      stream_view);
+                                      stream_view.get());
   RAFT_CHECK_CUDA(stream_view);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 }
 
 }  // namespace mathematical_optimization

--- a/cpp/src/linear_algebra/vector_math.cuh
+++ b/cpp/src/linear_algebra/vector_math.cuh
@@ -109,7 +109,7 @@ f_t vector_norm_inf(const rmm::device_uvector<f_t>& x)
     [] __host__ __device__(f_t val) { return abs(val); },
     static_cast<f_t>(0),
     thrust::maximum<f_t>{});
-  RAFT_CHECK_CUDA(x.stream());
+  RAFT_CHECK_CUDA(x.stream().get());
   return max_abs;
 }
 
@@ -125,7 +125,7 @@ f_t vector_norm2(const rmm::device_uvector<f_t>& x)
     [] __host__ __device__(f_t val) { return val * val; },
     f_t(0),
     thrust::plus<f_t>{});
-  RAFT_CHECK_CUDA(x.stream());
+  RAFT_CHECK_CUDA(x.stream().get());
   return std::sqrt(sum_of_squares);
 }
 

--- a/cpp/src/linear_algebra/vector_math.cuh
+++ b/cpp/src/linear_algebra/vector_math.cuh
@@ -53,7 +53,7 @@ f_t device_custom_vector_norm_inf(InputIteratorT in, i_t size, rmm::cuda_stream_
                             size,
                             custom_op,
                             init,
-                            stream_view);
+                            stream_view.get());
 
   d_temp_storage.resize(temp_storage_bytes, stream_view);
 
@@ -64,7 +64,7 @@ f_t device_custom_vector_norm_inf(InputIteratorT in, i_t size, rmm::cuda_stream_
                             size,
                             custom_op,
                             init,
-                            stream_view);
+                            stream_view.get());
   return d_out.value(stream_view);
 }
 

--- a/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
+++ b/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
@@ -87,7 +87,7 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
   hash_solution_kernel<i_t, f_t, TPB>
     <<<(integer_assignment.size() + TPB - 1) / TPB, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
       cuopt::make_span(integer_assignment), cuopt::make_span(reduction_buffer));
-  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
   // Get the number of blocks used in the hash_solution_kernel
   int num_blocks = (integer_assignment.size() + TPB - 1) / TPB;
 

--- a/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
+++ b/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
@@ -84,9 +84,11 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
   fill_integer_assignment(solution);
   thrust::fill(
     solution.handle_ptr->get_thrust_policy(), reduction_buffer.begin(), reduction_buffer.end(), 0);
-  hash_solution_kernel<i_t, f_t, TPB>
-    <<<(integer_assignment.size() + TPB - 1) / TPB, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
-      cuopt::make_span(integer_assignment), cuopt::make_span(reduction_buffer));
+  hash_solution_kernel<i_t, f_t, TPB><<<(integer_assignment.size() + TPB - 1) / TPB,
+                                        TPB,
+                                        0,
+                                        solution.handle_ptr->get_stream().get()>>>(
+    cuopt::make_span(integer_assignment), cuopt::make_span(reduction_buffer));
   RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
   // Get the number of blocks used in the hash_solution_kernel
   int num_blocks = (integer_assignment.size() + TPB - 1) / TPB;

--- a/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
+++ b/cpp/src/mip_heuristics/diversity/assignment_hash_map.cu
@@ -85,7 +85,7 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
   thrust::fill(
     solution.handle_ptr->get_thrust_policy(), reduction_buffer.begin(), reduction_buffer.end(), 0);
   hash_solution_kernel<i_t, f_t, TPB>
-    <<<(integer_assignment.size() + TPB - 1) / TPB, TPB, 0, solution.handle_ptr->get_stream()>>>(
+    <<<(integer_assignment.size() + TPB - 1) / TPB, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
       cuopt::make_span(integer_assignment), cuopt::make_span(reduction_buffer));
   RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
   // Get the number of blocks used in the hash_solution_kernel
@@ -103,7 +103,7 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
                               num_blocks,
                               combine_hash(),
                               0,
-                              solution.handle_ptr->get_stream());
+                              solution.handle_ptr->get_stream().get());
 
     // Allocate temporary storage
     temp_storage.resize(temp_storage_bytes, solution.handle_ptr->get_stream());
@@ -117,7 +117,7 @@ size_t assignment_hash_map_t<i_t, f_t>::hash_solution(solution_t<i_t, f_t>& solu
                               num_blocks,
                               combine_hash(),
                               0,
-                              solution.handle_ptr->get_stream());
+                              solution.handle_ptr->get_stream().get());
 
     // Return early since we've already computed the hash sum
     return hash_sum.value(solution.handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/diversity/recombiners/recombiner.cuh
+++ b/cpp/src/mip_heuristics/diversity/recombiners/recombiner.cuh
@@ -90,7 +90,7 @@ class recombiner_t {
     const i_t TPB = 128;
     i_t n_blocks  = (a.problem_ptr->n_integer_vars + TPB - 1) / TPB;
     assign_same_variables_kernel<i_t, f_t>
-      <<<n_blocks, TPB, 0, a.handle_ptr->get_stream()>>>(a.view(),
+      <<<n_blocks, TPB, 0, a.handle_ptr->get_stream().get()>>>(a.view(),
                                                          b.view(),
                                                          offspring.view(),
                                                          cuopt::make_span(remaining_indices),

--- a/cpp/src/mip_heuristics/diversity/recombiners/recombiner.cuh
+++ b/cpp/src/mip_heuristics/diversity/recombiners/recombiner.cuh
@@ -91,10 +91,10 @@ class recombiner_t {
     i_t n_blocks  = (a.problem_ptr->n_integer_vars + TPB - 1) / TPB;
     assign_same_variables_kernel<i_t, f_t>
       <<<n_blocks, TPB, 0, a.handle_ptr->get_stream().get()>>>(a.view(),
-                                                         b.view(),
-                                                         offspring.view(),
-                                                         cuopt::make_span(remaining_indices),
-                                                         n_remaining.data());
+                                                               b.view(),
+                                                               offspring.view(),
+                                                               cuopt::make_span(remaining_indices),
+                                                               n_remaining.data());
     i_t remaining_variables = this->n_remaining.value(a.handle_ptr->get_stream());
 
     auto vec_remaining_indices =

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
@@ -804,7 +804,7 @@ void fj_t<i_t, f_t>::round_remaining_fractionals(solution_t<i_t, f_t>& solution,
   data.handle_fractionals_only.set_value_async(handle_fractionals_only, climber_stream);
   data.break_condition.set_value_to_zero_async(climber_stream);
   data.temp_break_condition.set_value_to_zero_async(climber_stream);
-  climber_stream.synchronize();
+  climber_stream.sync();
 
   //  Run the fractional move selection and assignment update kernels until all have been rounded
   host_loop(solution, climber_idx);
@@ -909,7 +909,7 @@ i_t fj_t<i_t, f_t>::host_loop(solution_t<i_t, f_t>& solution, i_t climber_idx)
                  data.best_assignment.data(),
                  data.best_assignment.size(),
                  climber_stream);
-      climber_stream.synchronize();
+      climber_stream.sync();
       // this solution cost computation with the changing(or not changing) weights is needed to
       // decide whether we reset the best objective on the FIRST_FEASIBLE mode. once we get rid of
       // FIRST_FEASIBLE mode, we can remove the following too.
@@ -927,7 +927,7 @@ i_t fj_t<i_t, f_t>::host_loop(solution_t<i_t, f_t>& solution, i_t climber_idx)
                      solution.assignment.data(),
                      solution.assignment.size(),
                      climber_stream);
-          climber_stream.synchronize();
+          climber_stream.sync();
           improvement_callback(user_obj, h_assignment);
         }
       }

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
@@ -1110,11 +1110,11 @@ i_t fj_t<i_t, f_t>::solve(solution_t<i_t, f_t>& solution)
   }
 
   climber_init(0);
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   handle_ptr->sync_stream();
 
   i_t iterations = host_loop(solution);
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   handle_ptr->sync_stream();
 
   f_t effort_rate = (f_t)iterations / timer.elapsed_time();

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
@@ -499,7 +499,7 @@ void fj_t<i_t, f_t>::climber_init(i_t climber_idx, const rmm::cuda_stream_view& 
                                   row_size_it_bin,
                                   row_size_bin_prefix_sum.data(),
                                   pb_ptr->binary_indices.size(),
-                                  climber_stream);
+                                  climber_stream.get());
     if (i == 0 && temp_storage_bytes > climber->cub_storage_bytes.size())
       climber->cub_storage_bytes.resize(temp_storage_bytes, climber_stream);
   }
@@ -510,7 +510,7 @@ void fj_t<i_t, f_t>::climber_init(i_t climber_idx, const rmm::cuda_stream_view& 
                                   row_size_it_nonbin,
                                   row_size_nonbin_prefix_sum.data(),
                                   pb_ptr->nonbinary_indices.size(),
-                                  climber_stream);
+                                  climber_stream.get());
     if (i == 0 && temp_storage_bytes > climber->cub_storage_bytes.size())
       climber->cub_storage_bytes.resize(temp_storage_bytes, climber_stream);
   }
@@ -533,7 +533,7 @@ void fj_t<i_t, f_t>::climber_init(i_t climber_idx, const rmm::cuda_stream_view& 
                                       pb_ptr->n_variables,
                                       pb_ptr->related_variables_offsets.begin(),
                                       pb_ptr->related_variables_offsets.begin() + 1,
-                                      climber_stream);
+                                      climber_stream.get());
       if (i == 0 && temp_storage_bytes > climber->cub_storage_bytes.size())
         climber->cub_storage_bytes.resize(temp_storage_bytes, climber_stream);
     }
@@ -723,7 +723,7 @@ void fj_t<i_t, f_t>::run_step_device(const rmm::cuda_stream_view& climber_stream
                                data.candidate_variables.contents.data(),
                                data.candidate_variables.set_size.data(),
                                pb_ptr->n_variables,
-                               climber_stream);
+                               climber_stream.get());
     if (compaction_temp_storage_bytes > data.cub_storage_bytes.size()) {
       data.cub_storage_bytes.resize(compaction_temp_storage_bytes, climber_stream);
     }
@@ -771,7 +771,7 @@ void fj_t<i_t, f_t>::run_step_device(const rmm::cuda_stream_view& climber_stream
                                  data.candidate_variables.contents.data(),
                                  data.candidate_variables.set_size.data(),
                                  pb_ptr->n_variables,
-                                 climber_stream);
+                                 climber_stream.get());
 
       launch_select_variable_kernel<i_t, f_t>(dim3(1), dim3(256), kernel_args, climber_stream);
 

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cu
@@ -455,7 +455,7 @@ void fj_t<i_t, f_t>::climber_init(i_t climber_idx, const rmm::cuda_stream_view& 
     f_t excess = climber->violation_score.value(climber_stream);
     climber->best_excess.set_value_async(excess, climber_stream);
   }
-  climber_stream.synchronize();
+  climber_stream.sync();
 
   climber->break_condition.set_value_to_zero_async(climber_stream);
   climber->temp_break_condition.set_value_to_zero_async(climber_stream);
@@ -471,9 +471,9 @@ void fj_t<i_t, f_t>::climber_init(i_t climber_idx, const rmm::cuda_stream_view& 
   climber->iterations_until_feasible_counter.set_value_to_zero_async(climber_stream);
   climber->small_move_tabu.set_value_to_zero_async(climber_stream);
 
-  climber_stream.synchronize();
+  climber_stream.sync();
 
-  climber_stream.synchronize();
+  climber_stream.sync();
 
   view = climber->view();
 

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump.cuh
@@ -447,7 +447,7 @@ class fj_t {
                              dot_product_buffer.data(),
                              incumbent_objective.data(),
                              fj.pb_ptr->n_variables,
-                             fj.handle_ptr->get_stream());
+                             fj.handle_ptr->get_stream().get());
 
       // Allocate temporary storage
       cub_storage_bytes.resize(temp_storage_bytes, fj.handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
@@ -1442,7 +1442,7 @@ void launch_load_balancing_prepare_iteration(dim3 grid,
                                              rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchCooperativeKernel(
-    (void*)load_balancing_prepare_iteration<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_prepare_iteration<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1460,7 +1460,7 @@ void launch_update_assignment_kernel(dim3 grid,
                                      rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_assignment_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)update_assignment_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t, MTMMoveType move_type, bool is_binary_pb>
@@ -1539,7 +1539,7 @@ void launch_compute_mtm_moves_kernel(dim3 grid,
                                 blocks,
                                 kernel_args,
                                 0,
-                                stream));
+                                stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1549,7 +1549,7 @@ void launch_load_balancing_sanity_checks(dim3 grid,
                                          rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchCooperativeKernel(
-    (void*)load_balancing_sanity_checks<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_sanity_checks<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1559,7 +1559,7 @@ void launch_handle_local_minimum_kernel(dim3 grid,
                                         rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchCooperativeKernel(
-    (void*)handle_local_minimum_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)handle_local_minimum_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1577,7 +1577,7 @@ void launch_update_changed_constraints_kernel(dim3 grid,
                                               rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_changed_constraints_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)update_changed_constraints_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1587,7 +1587,7 @@ void launch_update_lift_moves_kernel(dim3 grid,
                                      rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_lift_moves_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)update_lift_moves_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1597,7 +1597,7 @@ void launch_update_breakthrough_moves_kernel(dim3 grid,
                                              rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_breakthrough_moves_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)update_breakthrough_moves_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1607,7 +1607,7 @@ void launch_select_variable_kernel(dim3 grid,
                                    rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)select_variable_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)select_variable_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1617,7 +1617,7 @@ void launch_init_lhs_and_violation(dim3 grid,
                                    rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)init_lhs_and_violation<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)init_lhs_and_violation<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1627,7 +1627,7 @@ void launch_update_best_solution_kernel(dim3 grid,
                                         rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_best_solution_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)update_best_solution_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1637,7 +1637,7 @@ void launch_load_balancing_compute_workid_mappings(dim3 grid,
                                                    rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_compute_workid_mappings<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_compute_workid_mappings<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1647,7 +1647,7 @@ void launch_load_balancing_init_cstr_bounds_csr(dim3 grid,
                                                 rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_init_cstr_bounds_csr<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_init_cstr_bounds_csr<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1657,7 +1657,7 @@ void launch_load_balancing_compute_scores_binary(dim3 grid,
                                                  rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_compute_scores_binary<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_compute_scores_binary<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1667,7 +1667,7 @@ void launch_load_balancing_mtm_compute_candidates(dim3 grid,
                                                   rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_mtm_compute_candidates<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_mtm_compute_candidates<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1677,7 +1677,7 @@ void launch_load_balancing_mtm_compute_scores(dim3 grid,
                                               rmm::cuda_stream_view stream)
 {
   RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_mtm_compute_scores<i_t, f_t>, grid, blocks, kernel_args, 0, stream));
+    (void*)load_balancing_mtm_compute_scores<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
 }
 
 // to save from compilation time, separate those and instantiate separately rather being part of a

--- a/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
+++ b/cpp/src/mip_heuristics/feasibility_jump/feasibility_jump_kernels.cu
@@ -1576,8 +1576,12 @@ void launch_update_changed_constraints_kernel(dim3 grid,
                                               void** kernel_args,
                                               rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)update_changed_constraints_kernel<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)update_changed_constraints_kernel<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1636,8 +1640,12 @@ void launch_load_balancing_compute_workid_mappings(dim3 grid,
                                                    void** kernel_args,
                                                    rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_compute_workid_mappings<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)load_balancing_compute_workid_mappings<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1646,8 +1654,12 @@ void launch_load_balancing_init_cstr_bounds_csr(dim3 grid,
                                                 void** kernel_args,
                                                 rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_init_cstr_bounds_csr<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)load_balancing_init_cstr_bounds_csr<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1656,8 +1668,12 @@ void launch_load_balancing_compute_scores_binary(dim3 grid,
                                                  void** kernel_args,
                                                  rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_compute_scores_binary<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)load_balancing_compute_scores_binary<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1666,8 +1682,12 @@ void launch_load_balancing_mtm_compute_candidates(dim3 grid,
                                                   void** kernel_args,
                                                   rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_mtm_compute_candidates<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)load_balancing_mtm_compute_candidates<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1676,8 +1696,12 @@ void launch_load_balancing_mtm_compute_scores(dim3 grid,
                                               void** kernel_args,
                                               rmm::cuda_stream_view stream)
 {
-  RAFT_CUDA_TRY(cudaLaunchKernel(
-    (void*)load_balancing_mtm_compute_scores<i_t, f_t>, grid, blocks, kernel_args, 0, stream.get()));
+  RAFT_CUDA_TRY(cudaLaunchKernel((void*)load_balancing_mtm_compute_scores<i_t, f_t>,
+                                 grid,
+                                 blocks,
+                                 kernel_args,
+                                 0,
+                                 stream.get()));
 }
 
 // to save from compilation time, separate those and instantiate separately rather being part of a

--- a/cpp/src/mip_heuristics/feasibility_jump/utils.cuh
+++ b/cpp/src/mip_heuristics/feasibility_jump/utils.cuh
@@ -45,7 +45,7 @@ struct bitmap_t {
   void clear(const rmm::cuda_stream_view& stream)
   {
     cudaMemsetAsync(
-      validity_bitmap.data(), 0, sizeof(word_t) * validity_bitmap.size(), stream.value());
+      validity_bitmap.data(), 0, sizeof(word_t) * validity_bitmap.size(), stream.get());
   }
   void clear(const raft::handle_t* handle_ptr)
   {
@@ -115,7 +115,7 @@ struct contiguous_set_t {
     set_size.set_value_to_zero_async(stream);
     // can't use thrust::fill, needs a memset node in order to be recorded in CUDA graphs
     // works bcs (uint8_t)-1 == 0xFF => (repeated 4 times) 0xFFFFFFFF == (uint32_t)-1
-    cudaMemsetAsync(index_map.data(), -1, sizeof(i_t) * index_map.size(), stream.value());
+    cudaMemsetAsync(index_map.data(), -1, sizeof(i_t) * index_map.size(), stream.get());
     validity_bitmap.clear(stream);
   }
 

--- a/cpp/src/mip_heuristics/local_search/feasibility_pump/feasibility_pump.cu
+++ b/cpp/src/mip_heuristics/local_search/feasibility_pump/feasibility_pump.cu
@@ -200,7 +200,7 @@ bool feasibility_pump_t<i_t, f_t>::linear_project_onto_polytope(solution_t<i_t, 
              obj_coefficients.data(),
              obj_coefficients.size(),
              solution.handle_ptr->get_stream());
-  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
   temp_p.presolve_data.objective_offset = obj_offset;
   // change the precision between 1. and 10-4 depending on the integer ratio
   // the lp tolerance can be pretty high
@@ -447,7 +447,7 @@ void feasibility_pump_t<i_t, f_t>::relax_general_integers(solution_t<i_t, f_t>& 
       var_types[v_idx] = copy_type;
     });
   solution.handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
   solution.problem_ptr->compute_n_integer_vars();
   solution.problem_ptr->compute_binary_var_table();
   CUOPT_LOG_DEBUG("Integers are relaxed n_int vars %d n_binary vars %d n_vars %d",

--- a/cpp/src/mip_heuristics/local_search/lagrangian.cuh
+++ b/cpp/src/mip_heuristics/local_search/lagrangian.cuh
@@ -52,7 +52,7 @@ inline rmm::device_uvector<f_t> get_weighted_lagrangian_weights(
   const i_t TPB      = 128;
   const i_t n_blocks = problem.n_variables;
   compute_lagrangian_weights_kernel<i_t, f_t>
-    <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream()>>>(
+    <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
       problem.view(),
       raft::device_span<f_t>{cstr_left_weights.data(), cstr_left_weights.size()},
       raft::device_span<f_t>{cstr_right_weights.data(), cstr_right_weights.size()},

--- a/cpp/src/mip_heuristics/local_search/rounding/bounds_repair.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/bounds_repair.cu
@@ -254,7 +254,7 @@ void bounds_repair_t<i_t, f_t>::compute_damages(problem_t<i_t, f_t>& problem, i_
   CUOPT_LOG_TRACE("Bounds repair: Computing damanges!");
   // TODO check performance, we can apply load balancing here
   const i_t TPB = 256;
-  compute_damages_kernel<i_t, f_t><<<n_candidates, TPB, 0, handle_ptr->get_stream()>>>(
+  compute_damages_kernel<i_t, f_t><<<n_candidates, TPB, 0, handle_ptr->get_stream().get()>>>(
     problem.view(),
     candidates.view(),
     make_span(cstr_violations_up),

--- a/cpp/src/mip_heuristics/local_search/rounding/bounds_repair.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/bounds_repair.cu
@@ -261,7 +261,7 @@ void bounds_repair_t<i_t, f_t>::compute_damages(problem_t<i_t, f_t>& problem, i_
     make_span(cstr_violations_down),
     make_span(bound_presolve.upd.min_activity),
     make_span(bound_presolve.upd.max_activity));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   auto sort_iterator = thrust::make_zip_iterator(
     thrust::make_tuple(candidates.cstr_delta.data(), candidates.damage.data()));
   // sort the best moves so that we can filter

--- a/cpp/src/mip_heuristics/local_search/rounding/constraint_prop.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/constraint_prop.cu
@@ -91,7 +91,7 @@ void sort_subsections(raft::device_span<i_t> vars,
                                       n_subsections,
                                       offsets.data(),
                                       offsets.data() + 1,
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
 
   // Allocate temporary storage
   d_temp_storage.resize(temp_storage_bytes, handle_ptr->get_stream());
@@ -107,7 +107,7 @@ void sort_subsections(raft::device_span<i_t> vars,
                                       n_subsections,
                                       offsets.data(),
                                       offsets.data() + 1,
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
   handle_ptr->sync_stream();
 }
 
@@ -179,7 +179,7 @@ void constraint_prop_t<i_t, f_t>::sort_by_implied_slack_consumption(solution_t<i
   auto max_activity   = selected_update ? make_span(multi_probe.upd_1.max_activity)
                                         : make_span(multi_probe.upd_0.max_activity);
   compute_implied_slack_consumption_per_var<i_t, f_t>
-    <<<vars.size(), block_dim, 0, sol.handle_ptr->get_stream()>>>(
+    <<<vars.size(), block_dim, 0, sol.handle_ptr->get_stream().get()>>>(
       sol.problem_ptr->view(),
       vars,
       min_activity,

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
@@ -275,7 +275,7 @@ void lb_bounds_repair_t<i_t, f_t>::compute_damages(
                                                          make_span(cstr_violations_up),
                                                          make_span(cstr_violations_down),
                                                          make_span_2(lb_bound_presolve.cnst_slack));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   auto sort_iterator = thrust::make_zip_iterator(
     thrust::make_tuple(candidates.cstr_delta.data(), candidates.damage.data()));
   // sort the best moves so that we can filter

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
@@ -268,13 +268,13 @@ void lb_bounds_repair_t<i_t, f_t>::compute_damages(
   // TODO check performance, we can apply load balancing here
   const i_t TPB = 256;
   using f_t2    = typename type_2<f_t>::type;
-  compute_damages_kernel<i_t, f_t, f_t2>
-    <<<n_candidates, TPB, 0, handle_ptr->get_stream().get()>>>(original_problem.view(),
-                                                         candidates.view(),
-                                                         make_span_2(problem.variable_bounds),
-                                                         make_span(cstr_violations_up),
-                                                         make_span(cstr_violations_down),
-                                                         make_span_2(lb_bound_presolve.cnst_slack));
+  compute_damages_kernel<i_t, f_t, f_t2><<<n_candidates, TPB, 0, handle_ptr->get_stream().get()>>>(
+    original_problem.view(),
+    candidates.view(),
+    make_span_2(problem.variable_bounds),
+    make_span(cstr_violations_up),
+    make_span(cstr_violations_down),
+    make_span_2(lb_bound_presolve.cnst_slack));
   RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   auto sort_iterator = thrust::make_zip_iterator(
     thrust::make_tuple(candidates.cstr_delta.data(), candidates.damage.data()));

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_bounds_repair.cu
@@ -269,7 +269,7 @@ void lb_bounds_repair_t<i_t, f_t>::compute_damages(
   const i_t TPB = 256;
   using f_t2    = typename type_2<f_t>::type;
   compute_damages_kernel<i_t, f_t, f_t2>
-    <<<n_candidates, TPB, 0, handle_ptr->get_stream()>>>(original_problem.view(),
+    <<<n_candidates, TPB, 0, handle_ptr->get_stream().get()>>>(original_problem.view(),
                                                          candidates.view(),
                                                          make_span_2(problem.variable_bounds),
                                                          make_span(cstr_violations_up),

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
@@ -585,7 +585,7 @@ void sort_subsections(raft::device_span<i_t> vars,
                                       n_subsections,
                                       offsets.data(),
                                       offsets.data() + 1,
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
 
   // Allocate temporary storage
   d_temp_storage.resize(temp_storage_bytes, handle_ptr->get_stream());
@@ -601,7 +601,7 @@ void sort_subsections(raft::device_span<i_t> vars,
                                       n_subsections,
                                       offsets.data(),
                                       offsets.data() + 1,
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
   handle_ptr->sync_stream();
 }
 

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
@@ -760,7 +760,7 @@ bool lb_constraint_prop_t<i_t, f_t>::find_integer(
   timer_t& timer,
   std::optional<std::vector<thrust::pair<f_t, f_t>>> probing_candidates)
 {
-  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream().get());
   if (orig_sol.problem_ptr->n_integer_vars == 0) {
     cuopt_func_call(orig_sol.test_variable_bounds());
     return orig_sol.compute_feasibility();
@@ -779,7 +779,7 @@ bool lb_constraint_prop_t<i_t, f_t>::find_integer(
 
   lb_bounds_update.settings.time_limit      = max_timer.remaining_time();
   lb_bounds_update.settings.iteration_limit = 20;
-  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream().get());
 
   if (max_timer.check_time_limit()) {
     CUOPT_LOG_DEBUG("Time limit is reached before bounds prop rounding!");
@@ -793,7 +793,7 @@ bool lb_constraint_prop_t<i_t, f_t>::find_integer(
              orig_sol.problem_ptr->n_integer_vars,
              orig_sol.handle_ptr->get_stream());
   CUOPT_LOG_DEBUG("LB Bounds propagation rounding: unset vars %lu", unset_integer_vars.size());
-  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream().get());
 
   // this is needed for the sort inside of the loop
   // infeasible cnst_slack invalid

--- a/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/lb_constraint_prop.cu
@@ -372,7 +372,7 @@ void lb_constraint_prop_t<i_t, f_t>::sort_by_implied_slack_consumption(
   const i_t block_dim = 128;
   lb_bounds_update.calculate_constraint_slack(original_problem.handle_ptr);
   compute_implied_slack_consumption_per_var<i_t, f_t, f_t2>
-    <<<vars.size(), block_dim, 0, original_problem.handle_ptr->get_stream()>>>(
+    <<<vars.size(), block_dim, 0, original_problem.handle_ptr->get_stream().get()>>>(
       original_problem.view(),
       vars,
       make_span_2(lb_bounds_update.cnst_slack),

--- a/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
@@ -53,7 +53,7 @@ bool check_brute_force_rounding(solution_t<i_t, f_t>& solution)
 
     // // try all configs in parallel and compute feasibility
     brute_force_check_kernel<i_t, f_t>
-      <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream()>>>(solution.view(),
+      <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(),
                                                                 n_integers_to_round,
                                                                 cuopt::make_span(var_map),
                                                                 cuopt::make_span(constraint_buf),
@@ -61,7 +61,7 @@ bool check_brute_force_rounding(solution_t<i_t, f_t>& solution)
     if (best_config.value(solution.handle_ptr->get_stream()) != -1) {
       CUOPT_LOG_DEBUG("Feasible found during brute force rounding!");
       // apply the feasible rounding
-      apply_feasible_rounding_kernel<i_t, f_t><<<1, TPB, 0, solution.handle_ptr->get_stream()>>>(
+      apply_feasible_rounding_kernel<i_t, f_t><<<1, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
         solution.view(), n_integers_to_round, cuopt::make_span(var_map), best_config.data());
       solution.handle_ptr->sync_stream();
       bool feas = solution.compute_feasibility();
@@ -83,7 +83,7 @@ bool invoke_simple_rounding(solution_t<i_t, f_t>& solution)
   rmm::device_scalar<bool> successful(true_v, solution.handle_ptr->get_stream());
   i_t TPB = 128;
   simple_rounding_kernel<i_t, f_t>
-    <<<2048, TPB, 0, solution.handle_ptr->get_stream()>>>(solution.view(), successful.data());
+    <<<2048, TPB, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(), successful.data());
   if (!successful.value(solution.handle_ptr->get_stream())) {
     CUOPT_LOG_DEBUG("Simple rounding failed");
     solution.copy_from(sol_copy);
@@ -112,7 +112,7 @@ void invoke_round_nearest(solution_t<i_t, f_t>& solution, uint64_t seed)
 
   i_t n_blocks = (solution.problem_ptr->n_integer_vars + TPB - 1) / TPB;
   nearest_rounding_kernel<i_t, f_t>
-    <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream()>>>(solution.view(), seed);
+    <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(), seed);
   RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
 }
 
@@ -129,7 +129,7 @@ void invoke_random_round_nearest(solution_t<i_t, f_t>& solution,
                   n_integers,
                   solution.problem_ptr->n_integer_vars);
   rmm::device_scalar<i_t> n_randomly_rounded(zero_v<i_t>, solution.handle_ptr->get_stream());
-  random_nearest_rounding_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.handle_ptr->get_stream()>>>(
+  random_nearest_rounding_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
     solution.view(), seed_rng.next_u64(), n_randomly_rounded.data());
   i_t h_n_random_rounds = n_randomly_rounded.value(solution.handle_ptr->get_stream());
   CUOPT_LOG_TRACE("Randomly rounded integers %d", h_n_random_rounds);
@@ -145,7 +145,7 @@ void invoke_random_round_nearest(solution_t<i_t, f_t>& solution,
                     shuffled_indices.end(),
                     rng);
     random_rounding_kernel<i_t, f_t>
-      <<<1, 1, 0, solution.handle_ptr->get_stream()>>>(solution.view(),
+      <<<1, 1, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(),
                                                        seed_rng.next_u64(),
                                                        shuffled_indices.data(),
                                                        n_randomly_rounded.data(),

--- a/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
@@ -53,16 +53,18 @@ bool check_brute_force_rounding(solution_t<i_t, f_t>& solution)
 
     // // try all configs in parallel and compute feasibility
     brute_force_check_kernel<i_t, f_t>
-      <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(),
-                                                                n_integers_to_round,
-                                                                cuopt::make_span(var_map),
-                                                                cuopt::make_span(constraint_buf),
-                                                                best_config.data());
+      <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
+        solution.view(),
+        n_integers_to_round,
+        cuopt::make_span(var_map),
+        cuopt::make_span(constraint_buf),
+        best_config.data());
     if (best_config.value(solution.handle_ptr->get_stream()) != -1) {
       CUOPT_LOG_DEBUG("Feasible found during brute force rounding!");
       // apply the feasible rounding
-      apply_feasible_rounding_kernel<i_t, f_t><<<1, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
-        solution.view(), n_integers_to_round, cuopt::make_span(var_map), best_config.data());
+      apply_feasible_rounding_kernel<i_t, f_t>
+        <<<1, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
+          solution.view(), n_integers_to_round, cuopt::make_span(var_map), best_config.data());
       solution.handle_ptr->sync_stream();
       bool feas = solution.compute_feasibility();
       cuopt_assert(feas, "Solution must be feasible!");
@@ -129,8 +131,9 @@ void invoke_random_round_nearest(solution_t<i_t, f_t>& solution,
                   n_integers,
                   solution.problem_ptr->n_integer_vars);
   rmm::device_scalar<i_t> n_randomly_rounded(zero_v<i_t>, solution.handle_ptr->get_stream());
-  random_nearest_rounding_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
-    solution.view(), seed_rng.next_u64(), n_randomly_rounded.data());
+  random_nearest_rounding_kernel<i_t, f_t>
+    <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(
+      solution.view(), seed_rng.next_u64(), n_randomly_rounded.data());
   i_t h_n_random_rounds = n_randomly_rounded.value(solution.handle_ptr->get_stream());
   CUOPT_LOG_TRACE("Randomly rounded integers %d", h_n_random_rounds);
   i_t additional_roundings_needed = n_target_random_rounds - h_n_random_rounds;
@@ -146,10 +149,10 @@ void invoke_random_round_nearest(solution_t<i_t, f_t>& solution,
                     rng);
     random_rounding_kernel<i_t, f_t>
       <<<1, 1, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(),
-                                                       seed_rng.next_u64(),
-                                                       shuffled_indices.data(),
-                                                       n_randomly_rounded.data(),
-                                                       additional_roundings_needed);
+                                                             seed_rng.next_u64(),
+                                                             shuffled_indices.data(),
+                                                             n_randomly_rounded.data(),
+                                                             additional_roundings_needed);
     h_n_random_rounds = n_randomly_rounded.value(solution.handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Randomly rounded integers, after adding close integers too %d",
                     h_n_random_rounds);

--- a/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
+++ b/cpp/src/mip_heuristics/local_search/rounding/simple_rounding.cu
@@ -113,7 +113,7 @@ void invoke_round_nearest(solution_t<i_t, f_t>& solution, uint64_t seed)
   i_t n_blocks = (solution.problem_ptr->n_integer_vars + TPB - 1) / TPB;
   nearest_rounding_kernel<i_t, f_t>
     <<<n_blocks, TPB, 0, solution.handle_ptr->get_stream().get()>>>(solution.view(), seed);
-  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -155,7 +155,7 @@ void invoke_random_round_nearest(solution_t<i_t, f_t>& solution,
                     h_n_random_rounds);
   }
   solution.round_nearest(seed_rng.next_u64());
-  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(solution.handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/mip_scaling_strategy.cu
+++ b/cpp/src/mip_heuristics/mip_scaling_strategy.cu
@@ -165,7 +165,7 @@ void compute_row_inf_norm(
                                                    matrix_offsets.data() + 1,
                                                    max_op_t<f_t>{},
                                                    f_t(0),
-                                                   stream_view));
+                                                   stream_view.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -203,7 +203,7 @@ void compute_row_integer_gcd(
                                                    matrix_offsets.data() + 1,
                                                    gcd_op_t{},
                                                    std::int64_t{0},
-                                                   stream_view));
+                                                   stream_view.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -236,7 +236,7 @@ void compute_big_m_skip_rows(
                                                    matrix_offsets.data() + 1,
                                                    max_op_t<f_t>{},
                                                    f_t(0),
-                                                   stream_view));
+                                                   stream_view.get()));
   size_t min_bytes = temp_storage_bytes;
   RAFT_CUDA_TRY(cub::DeviceSegmentedReduce::Reduce(temp_storage.data(),
                                                    min_bytes,
@@ -247,7 +247,7 @@ void compute_big_m_skip_rows(
                                                    matrix_offsets.data() + 1,
                                                    min_op_t<f_t>{},
                                                    std::numeric_limits<f_t>::infinity(),
-                                                   stream_view));
+                                                   stream_view.get()));
   size_t count_bytes = temp_storage_bytes;
   RAFT_CUDA_TRY(cub::DeviceSegmentedReduce::Reduce(temp_storage.data(),
                                                    count_bytes,
@@ -258,7 +258,7 @@ void compute_big_m_skip_rows(
                                                    matrix_offsets.data() + 1,
                                                    thrust::plus<i_t>{},
                                                    i_t(0),
-                                                   stream_view));
+                                                   stream_view.get()));
 
   auto row_begin = thrust::make_zip_iterator(
     thrust::make_tuple(row_inf_norm.begin(), row_min_nonzero.begin(), row_nonzero_count.begin()));
@@ -435,7 +435,7 @@ size_t dry_run_cub(
                                                    matrix_offsets.data() + 1,
                                                    max_op_t<f_t>{},
                                                    f_t(0),
-                                                   stream_view));
+                                                   stream_view.get()));
   temp_storage_bytes = std::max(temp_storage_bytes, current_required_bytes);
 
   auto coeff_nonzero_min_iter =
@@ -449,7 +449,7 @@ size_t dry_run_cub(
                                                    matrix_offsets.data() + 1,
                                                    min_op_t<f_t>{},
                                                    std::numeric_limits<f_t>::infinity(),
-                                                   stream_view));
+                                                   stream_view.get()));
   temp_storage_bytes = std::max(temp_storage_bytes, current_required_bytes);
 
   auto coeff_nonzero_count_iter =
@@ -463,7 +463,7 @@ size_t dry_run_cub(
                                                    matrix_offsets.data() + 1,
                                                    thrust::plus<i_t>{},
                                                    i_t(0),
-                                                   stream_view));
+                                                   stream_view.get()));
   temp_storage_bytes = std::max(temp_storage_bytes, current_required_bytes);
 
   if (variable_types.size() == static_cast<size_t>(op_problem.get_n_variables())) {
@@ -482,7 +482,7 @@ size_t dry_run_cub(
                                                      matrix_offsets.data() + 1,
                                                      gcd_op_t{},
                                                      std::int64_t{0},
-                                                     stream_view));
+                                                     stream_view.get()));
     temp_storage_bytes = std::max(temp_storage_bytes, current_required_bytes);
   }
 
@@ -678,7 +678,7 @@ void mip_scaling_strategy_t<i_t, f_t>::scale_problem(bool do_objective_scaling)
                                   ref_log2_values.data() + median_idx,
                                   sizeof(double),
                                   cudaMemcpyDeviceToHost,
-                                  stream_view_));
+                                  stream_view_.get()));
     handle_ptr_->sync_stream();
     f_t target_norm = static_cast<f_t>(exp2(h_median_log2));
     cuopt_assert(std::isfinite(static_cast<double>(target_norm)), "target_norm must be finite");

--- a/cpp/src/mip_heuristics/presolve/block_bve.cu
+++ b/cpp/src/mip_heuristics/presolve/block_bve.cu
@@ -762,12 +762,12 @@ double bve_project_batch_gpu(const raft::handle_t& handle,
       // sentinel 0xFFFFFFFF (every byte 0xFF) marks a boundary pattern with no feasible interior
       // yet
       RAFT_CUDA_TRY(
-        cudaMemsetAsync(d_witness.data(), 0xFF, d_witness.size() * sizeof(uint32_t), stream));
+        cudaMemsetAsync(d_witness.data(), 0xFF, d_witness.size() * sizeof(uint32_t), stream.get()));
 
       // one warp per row, one CTA per (block, m, am) assignment, grid-strided
       const int64_t total = (int64_t)num * (int64_t)patterns * ((int64_t)1 << na);
       const int grid      = std::min(total, int64_t{65535});
-      bve_enumerate_kernel<i_t, f_t><<<grid, cta_dim, shmem, stream>>>(num,
+      bve_enumerate_kernel<i_t, f_t><<<grid, cta_dim, shmem, stream.get()>>>(num,
                                                                        nb,
                                                                        na,
                                                                        nrows,

--- a/cpp/src/mip_heuristics/presolve/block_bve.cu
+++ b/cpp/src/mip_heuristics/presolve/block_bve.cu
@@ -768,16 +768,16 @@ double bve_project_batch_gpu(const raft::handle_t& handle,
       const int64_t total = (int64_t)num * (int64_t)patterns * ((int64_t)1 << na);
       const int grid      = std::min(total, int64_t{65535});
       bve_enumerate_kernel<i_t, f_t><<<grid, cta_dim, shmem, stream.get()>>>(num,
-                                                                       nb,
-                                                                       na,
-                                                                       nrows,
-                                                                       tol,
-                                                                       d_coeffs.data(),
-                                                                       d_local_var.data(),
-                                                                       d_row_start.data(),
-                                                                       d_lower.data(),
-                                                                       d_upper.data(),
-                                                                       d_witness.data());
+                                                                             nb,
+                                                                             na,
+                                                                             nrows,
+                                                                             tol,
+                                                                             d_coeffs.data(),
+                                                                             d_local_var.data(),
+                                                                             d_row_start.data(),
+                                                                             d_lower.data(),
+                                                                             d_upper.data(),
+                                                                             d_witness.data());
       RAFT_CUDA_TRY(cudaGetLastError());
 
       // Unscaled op counts: host pack/unpack touches + one coeff read per assignment.

--- a/cpp/src/mip_heuristics/presolve/bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/bounds_presolve.cu
@@ -123,7 +123,7 @@ bool bound_presolve_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb
   upd.bounds_changed.set_value_async(zero, pb.handle_ptr->get_stream());
   update_bounds_kernel<i_t, f_t, n_threads>
     <<<pb.n_variables, n_threads, 0, pb.handle_ptr->get_stream().get()>>>(pb.view(), upd.view());
-  RAFT_CHECK_CUDA(pb.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(pb.handle_ptr->get_stream().get());
   i_t h_bounds_changed = upd.bounds_changed.value(pb.handle_ptr->get_stream());
   return h_bounds_changed != zero;
 }
@@ -165,7 +165,7 @@ void bound_presolve_t<i_t, f_t>::set_bounds(
                      var_ub[pair.first] = pair.second;
                    });
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -283,7 +283,7 @@ bool bound_presolve_t<i_t, f_t>::calculate_infeasible_redundant_constraints(prob
                    thrust::make_tuple<i_t, i_t>(0, 0),
                    tuple_plus_t<i_t>{});
 
-  RAFT_CHECK_CUDA(pb.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(pb.handle_ptr->get_stream().get());
 
   if (redund_constraints_count > 0) {
     CUOPT_LOG_TRACE("Redundant constraint count %d", redund_constraints_count);

--- a/cpp/src/mip_heuristics/presolve/bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/bounds_presolve.cu
@@ -100,7 +100,7 @@ void bound_presolve_t<i_t, f_t>::calculate_activity(problem_t<i_t, f_t>& pb)
 
   constexpr auto n_threads = 256;
   calc_activity_kernel<i_t, f_t, n_threads>
-    <<<pb.n_constraints, n_threads, 0, pb.handle_ptr->get_stream()>>>(pb.view(), upd.view());
+    <<<pb.n_constraints, n_threads, 0, pb.handle_ptr->get_stream().get()>>>(pb.view(), upd.view());
 }
 
 template <typename i_t, typename f_t>
@@ -122,7 +122,7 @@ bool bound_presolve_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb
     pb.tolerances.absolute_tolerance / context.settings.semi_continuous_big_m;
   upd.bounds_changed.set_value_async(zero, pb.handle_ptr->get_stream());
   update_bounds_kernel<i_t, f_t, n_threads>
-    <<<pb.n_variables, n_threads, 0, pb.handle_ptr->get_stream()>>>(pb.view(), upd.view());
+    <<<pb.n_variables, n_threads, 0, pb.handle_ptr->get_stream().get()>>>(pb.view(), upd.view());
   RAFT_CHECK_CUDA(pb.handle_ptr->get_stream());
   i_t h_bounds_changed = upd.bounds_changed.value(pb.handle_ptr->get_stream());
   return h_bounds_changed != zero;

--- a/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
+++ b/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
@@ -677,7 +677,7 @@ void conditional_bound_strengthening_t<i_t, f_t>::solve(problem_t<i_t, f_t>& pro
   update_constraint_bounds_kernel<i_t, f_t, TPB><<<n_blocks, TPB, sh_size>>>(
     problem.view(), cuopt::make_span(constraint_pairs), cuopt::make_span(locks_per_constraint));
 
-  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(problem.handle_ptr->get_stream().get());
   problem.handle_ptr->sync_stream();
 
 #ifdef DEBUG_COND_BOUNDS_PROP

--- a/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
+++ b/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
@@ -215,7 +215,7 @@ void spgemm_cusparse([[maybe_unused]] rmm::device_uvector<i_t>& offsetsA,
 
   check_cusparse_status(cusparseSpGEMM_copy(
     handle, opA, opB, &alpha, matA, matB, &beta, matC, computeType, alg, spgemmDesc));
-  stream.synchronize();
+  stream.sync();
 
   cusparseSpGEMM_destroyDescr(spgemmDesc);
   cusparseDestroySpMat(matA);

--- a/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
+++ b/cpp/src/mip_heuristics/presolve/conditional_bound_strengthening.cu
@@ -85,7 +85,7 @@ void spgemm_cusparse([[maybe_unused]] rmm::device_uvector<i_t>& offsetsA,
   auto stream = offsetsA.stream();
   cusparseHandle_t handle;
   cusparseCreate(&handle);
-  cusparseSetStream(handle, stream);
+  cusparseSetStream(handle, stream.get());
 
   int m    = offsetsA.size() - 1;
   int n    = offsetsB.size() - 1;

--- a/cpp/src/mip_heuristics/presolve/lb_probing_cache.cu
+++ b/cpp/src/mip_heuristics/presolve/lb_probing_cache.cu
@@ -279,7 +279,7 @@ inline std::vector<i_t> compute_prioritized_integer_indices(
   CUOPT_LOG_INFO("prioritized integer_indices n_integer_vars %d", problem.pb->n_integer_vars);
   // compute the min var slack
   compute_min_slack_per_var<i_t, f_t>
-    <<<problem.pb->n_integer_vars, 128, 0, problem.handle_ptr->get_stream()>>>(
+    <<<problem.pb->n_integer_vars, 128, 0, problem.handle_ptr->get_stream().get()>>>(
       problem.pb->view(),
       make_span_2(bound_presolve.cnst_slack),
       make_span(min_slack_per_var),

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
@@ -491,7 +491,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::calculate_constraint_slack_iter(
     // writes nans to constraint activities that are infeasible
     //-> less expensive checks for update bounds step
     raft::common::nvtx::range scope("act_cuda_task_graph");
-    cudaGraphLaunch(calc_slack_erase_inf_cnst_exec, handle_ptr->get_stream());
+    cudaGraphLaunch(calc_slack_erase_inf_cnst_exec, handle_ptr->get_stream().get());
   }
   infeas_cnst_slack_set_to_nan = true;
   RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
@@ -505,7 +505,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::calculate_constraint_slack(
   h_bounds_changed = 0;
   {
     raft::common::nvtx::range scope("act_cuda_task_graph");
-    cudaGraphLaunch(calc_slack_exec, handle_ptr->get_stream());
+    cudaGraphLaunch(calc_slack_exec, handle_ptr->get_stream().get());
   }
   infeas_cnst_slack_set_to_nan = false;
   RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
@@ -518,7 +518,7 @@ bool load_balanced_bounds_presolve_t<i_t, f_t>::update_bounds_from_slack(
   // bounds_changed is copied to h_bounds_changed in upd_bnd_exec
   {
     raft::common::nvtx::range scope("upd_cuda_task_graph");
-    cudaGraphLaunch(upd_bnd_exec, handle_ptr->get_stream());
+    cudaGraphLaunch(upd_bnd_exec, handle_ptr->get_stream().get());
   }
   RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   constexpr i_t zero = 0;

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
@@ -188,22 +188,22 @@ bool build_graph(managed_stream_pool& streams,
   }
 
   cudaStreamEndCapture(handle_ptr->get_stream().get(), &graph);
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   if (graph_exec != nullptr) {
     cudaGraphExecDestroy(graph_exec);
     cudaGraphInstantiate(&graph_exec, graph);
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   } else {
     cudaGraphInstantiate(&graph_exec, graph);
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   }
 
   cudaGraphDestroy(graph);
   graph_created = true;
 
-  handle_ptr->get_stream().synchronize();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  handle_ptr->get_stream().sync();
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   return graph_created;
 }
@@ -234,7 +234,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::setup(
                                                            heavy_degree_cutoff,
                                                            problem.cnst_bin_offsets,
                                                            problem.offsets);
-  RAFT_CHECK_CUDA(stream_heavy_cnst);
+  RAFT_CHECK_CUDA(stream_heavy_cnst.get());
 
   num_blocks_heavy_vars = create_heavy_item_block_segments(stream_heavy_vars,
                                                            heavy_vars_vertex_ids,
@@ -243,7 +243,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::setup(
                                                            heavy_degree_cutoff,
                                                            problem.vars_bin_offsets,
                                                            problem.reverse_offsets);
-  RAFT_CHECK_CUDA(stream_heavy_vars);
+  RAFT_CHECK_CUDA(stream_heavy_vars.get());
 
   tmp_act.resize(2 * num_blocks_heavy_cnst, stream_heavy_cnst);
   tmp_bnd.resize(2 * num_blocks_heavy_vars, stream_heavy_vars);
@@ -254,7 +254,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::setup(
   std::tie(is_vars_sub_warp_single_bin, vars_sub_warp_count) =
     sub_warp_meta(stream, warp_vars_offsets, warp_vars_id_offsets, pb->vars_bin_offsets, 4);
 
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   streams.sync_test_all_issued();
 
   if (!calc_slack_erase_inf_cnst_graph_created) {
@@ -494,7 +494,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::calculate_constraint_slack_iter(
     cudaGraphLaunch(calc_slack_erase_inf_cnst_exec, handle_ptr->get_stream());
   }
   infeas_cnst_slack_set_to_nan = true;
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -508,7 +508,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::calculate_constraint_slack(
     cudaGraphLaunch(calc_slack_exec, handle_ptr->get_stream());
   }
   infeas_cnst_slack_set_to_nan = false;
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -520,7 +520,7 @@ bool load_balanced_bounds_presolve_t<i_t, f_t>::update_bounds_from_slack(
     raft::common::nvtx::range scope("upd_cuda_task_graph");
     cudaGraphLaunch(upd_bnd_exec, handle_ptr->get_stream());
   }
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   constexpr i_t zero = 0;
   return (zero < h_bounds_changed);
 }
@@ -602,7 +602,7 @@ bool load_balanced_bounds_presolve_t<i_t, f_t>::calculate_infeasible_redundant_c
       thrust::reduce(handle_ptr->get_thrust_policy(), detect_iter, detect_iter + pb->n_constraints);
 
     handle_ptr->sync_stream();
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   } else {
     auto detect_iter = thrust::make_transform_iterator(
       thrust::make_zip_iterator(thrust::make_tuple(pb->constraint_lower_bounds.begin(),
@@ -614,7 +614,7 @@ bool load_balanced_bounds_presolve_t<i_t, f_t>::calculate_infeasible_redundant_c
     infeas_constraints_count =
       thrust::reduce(handle_ptr->get_thrust_policy(), detect_iter, detect_iter + pb->n_constraints);
     handle_ptr->sync_stream();
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   }
   if (infeas_constraints_count > 0) {
     CUOPT_LOG_TRACE("LB Infeasible constraint count %d", infeas_constraints_count);

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
@@ -172,8 +172,8 @@ bool build_graph(managed_stream_pool& streams,
   cudaEvent_t fork_stream_event;
   cudaEventCreate(&fork_stream_event);
 
-  cudaStreamBeginCapture(handle_ptr->get_stream(), cudaStreamCaptureModeThreadLocal);
-  cudaEventRecord(fork_stream_event, handle_ptr->get_stream());
+  cudaStreamBeginCapture(handle_ptr->get_stream().get(), cudaStreamCaptureModeThreadLocal);
+  cudaEventRecord(fork_stream_event, handle_ptr->get_stream().get());
 
   // dry-run - managed pool tracks how many streams were issued
   d_func();
@@ -184,10 +184,10 @@ bool build_graph(managed_stream_pool& streams,
   auto activity_done = streams.create_events_on_issued();
   streams.reset_issued();
   for (auto& e : activity_done) {
-    cudaStreamWaitEvent(handle_ptr->get_stream(), e);
+    cudaStreamWaitEvent(handle_ptr->get_stream().get(), e);
   }
 
-  cudaStreamEndCapture(handle_ptr->get_stream(), &graph);
+  cudaStreamEndCapture(handle_ptr->get_stream().get(), &graph);
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
 
   if (graph_exec != nullptr) {

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cu
@@ -215,7 +215,7 @@ void load_balanced_bounds_presolve_t<i_t, f_t>::setup(
   pb              = &problem;
   auto handle_ptr = pb->handle_ptr;
   auto stream     = handle_ptr->get_stream();
-  stream.synchronize();
+  stream.sync();
   host_bounds.resize(2 * pb->n_variables);
   cnst_slack.resize(2 * pb->n_constraints, stream);
   vars_bnd.resize(2 * pb->n_variables, stream);

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cuh
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cuh
@@ -103,7 +103,7 @@ class managed_stream_pool {
   {
     for (int i = 0; i < end_unsycned + 1; ++i) {
       streams_[i].synchronize();
-      RAFT_CHECK_CUDA(streams_[i].value());
+      RAFT_CHECK_CUDA(streams_[i].view().get());
     }
     end_unsycned = -1;
     next_stream  = 0;

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cuh
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve.cuh
@@ -75,7 +75,7 @@ class managed_stream_pool {
   void wait_issued_on_event(cudaEvent_t e)
   {
     for (int i = 0; i < end_unsycned + 1; ++i) {
-      cudaStreamWaitEvent(streams_[i].view(), e, 0);
+      cudaStreamWaitEvent(streams_[i].view().get(), e, 0);
     }
   }
 
@@ -94,7 +94,7 @@ class managed_stream_pool {
       cudaEventCreate(&e);
     }
     for (int i = 0; i < end_unsycned + 1; ++i) {
-      cudaEventRecord(events[i], streams_[i].view());
+      cudaEventRecord(events[i], streams_[i].view().get());
     }
     return events;
   }

--- a/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve_helpers.cuh
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_bounds_presolve_helpers.cuh
@@ -151,7 +151,7 @@ void calc_activity_heavy_cnst(managed_stream_pool& streams,
 {
   if (num_blocks_heavy_cnst != 0) {
     auto heavy_cnst_stream = streams.get_stream();
-    RAFT_CHECK_CUDA(heavy_cnst_stream);
+    RAFT_CHECK_CUDA(heavy_cnst_stream.get());
     // TODO : Check heavy_cnst_block_segments size for profiling
     if (!dry_run) {
       auto heavy_cnst_beg_id = get_id_offset(cnst_bin_offsets, heavy_degree_cutoff);
@@ -163,18 +163,18 @@ void calc_activity_heavy_cnst(managed_stream_pool& streams,
           heavy_degree_cutoff,
           view,
           tmp_cnst_act);
-      RAFT_CHECK_CUDA(heavy_cnst_stream);
+      RAFT_CHECK_CUDA(heavy_cnst_stream.get());
       auto num_heavy_cnst = cnst_bin_offsets.back() - heavy_cnst_beg_id;
       if (erase_inf_cnst) {
         finalize_calc_act_kernel<true, i_t, f_t, f_t2>
           <<<num_heavy_cnst, 32, 0, heavy_cnst_stream>>>(
             heavy_cnst_beg_id, make_span(heavy_cnst_block_segments), tmp_cnst_act, view);
-        RAFT_CHECK_CUDA(heavy_cnst_stream);
+        RAFT_CHECK_CUDA(heavy_cnst_stream.get());
       } else {
         finalize_calc_act_kernel<false, i_t, f_t, f_t2>
           <<<num_heavy_cnst, 32, 0, heavy_cnst_stream>>>(
             heavy_cnst_beg_id, make_span(heavy_cnst_block_segments), tmp_cnst_act, view);
-        RAFT_CHECK_CUDA(heavy_cnst_stream);
+        RAFT_CHECK_CUDA(heavy_cnst_stream.get());
       }
     }
   }
@@ -200,11 +200,11 @@ void calc_activity_per_block(managed_stream_pool& streams,
       if (erase_inf_cnst) {
         lb_calc_act_block_kernel<true, i_t, f_t, f_t2, block_dim>
           <<<block_count, block_dim, 0, block_stream>>>(cnst_id_beg, view);
-        RAFT_CHECK_CUDA(block_stream);
+        RAFT_CHECK_CUDA(block_stream.get());
       } else {
         lb_calc_act_block_kernel<false, i_t, f_t, f_t2, block_dim>
           <<<block_count, block_dim, 0, block_stream>>>(cnst_id_beg, view);
-        RAFT_CHECK_CUDA(block_stream);
+        RAFT_CHECK_CUDA(block_stream.get());
       }
     }
   }
@@ -261,11 +261,11 @@ void calc_activity_sub_warp(managed_stream_pool& streams,
       if (erase_inf_cnst) {
         lb_calc_act_sub_warp_kernel<true, i_t, f_t, f_t2, block_dim, threads_per_constraint>
           <<<block_count, block_dim, 0, sub_warp_thread>>>(cnst_id_beg, cnst_id_end, view);
-        RAFT_CHECK_CUDA(sub_warp_thread);
+        RAFT_CHECK_CUDA(sub_warp_thread.get());
       } else {
         lb_calc_act_sub_warp_kernel<false, i_t, f_t, f_t2, block_dim, threads_per_constraint>
           <<<block_count, block_dim, 0, sub_warp_thread>>>(cnst_id_beg, cnst_id_end, view);
-        RAFT_CHECK_CUDA(sub_warp_thread);
+        RAFT_CHECK_CUDA(sub_warp_thread.get());
       }
     }
   }
@@ -306,12 +306,12 @@ void calc_activity_sub_warp(managed_stream_pool& streams,
         lb_calc_act_sub_warp_kernel<true, i_t, f_t, f_t2, block_dim>
           <<<block_count, block_dim, 0, sub_warp_stream>>>(
             view, make_span(warp_cnst_offsets), make_span(warp_cnst_id_offsets));
-        RAFT_CHECK_CUDA(sub_warp_stream);
+        RAFT_CHECK_CUDA(sub_warp_stream.get());
       } else {
         lb_calc_act_sub_warp_kernel<false, i_t, f_t, f_t2, block_dim>
           <<<block_count, block_dim, 0, sub_warp_stream>>>(
             view, make_span(warp_cnst_offsets), make_span(warp_cnst_id_offsets));
-        RAFT_CHECK_CUDA(sub_warp_stream);
+        RAFT_CHECK_CUDA(sub_warp_stream.get());
       }
     }
   }

--- a/cpp/src/mip_heuristics/presolve/load_balanced_partition_helpers.cuh
+++ b/cpp/src/mip_heuristics/presolve/load_balanced_partition_helpers.cuh
@@ -271,7 +271,7 @@ log_dist_t<i_t> vertex_bin_t<i_t>::run(rmm::device_uvector<i_t>& reorganized_ver
                offsets_,
                vertex_begin_,
                vertex_end_,
-               handle_ptr->get_stream());
+               handle_ptr->get_stream().get());
 
   return log_dist_t<i_t>(reorganized_vertices, bin_offsets_);
 }

--- a/cpp/src/mip_heuristics/presolve/multi_probe.cu
+++ b/cpp/src/mip_heuristics/presolve/multi_probe.cu
@@ -115,11 +115,11 @@ void multi_probe_t<i_t, f_t>::calculate_activity(problem_t<i_t, f_t>& pb,
     auto& upd                = skip_0 ? upd_1 : upd_0;
     constexpr auto n_threads = 256;
     calc_activity_kernel<i_t, f_t, n_threads>
-      <<<pb.n_constraints, n_threads, 0, handle_ptr->get_stream()>>>(pb.view(), upd.view());
+      <<<pb.n_constraints, n_threads, 0, handle_ptr->get_stream().get()>>>(pb.view(), upd.view());
   } else {
     constexpr auto n_threads = 256;
     calc_activity_kernel<i_t, f_t, n_threads>
-      <<<pb.n_constraints, n_threads, 0, handle_ptr->get_stream()>>>(
+      <<<pb.n_constraints, n_threads, 0, handle_ptr->get_stream().get()>>>(
         pb.view(), upd_0.view(), upd_1.view());
   }
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
@@ -150,7 +150,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
   } else if (skip_0) {
     upd_1.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     update_bounds_kernel<i_t, f_t, n_threads>
-      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream()>>>(pb.view(), upd_1.view());
+      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(pb.view(), upd_1.view());
     RAFT_CHECK_CUDA(handle_ptr->get_stream());
     i_t h_bounds_changed_1 = upd_1.bounds_changed.value(handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Bounds changed upd 1 %d", h_bounds_changed_1);
@@ -158,7 +158,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
   } else if (skip_1) {
     upd_0.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     update_bounds_kernel<i_t, f_t, n_threads>
-      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream()>>>(pb.view(), upd_0.view());
+      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(pb.view(), upd_0.view());
     RAFT_CHECK_CUDA(handle_ptr->get_stream());
     i_t h_bounds_changed_0 = upd_0.bounds_changed.value(handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Bounds changed upd 0 %d", h_bounds_changed_0);
@@ -167,7 +167,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
     upd_0.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     upd_1.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     update_bounds_kernel<i_t, f_t, n_threads>
-      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream()>>>(
+      <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(
         pb.view(), upd_0.view(), upd_1.view());
     RAFT_CHECK_CUDA(handle_ptr->get_stream());
     i_t h_bounds_changed_0 = upd_0.bounds_changed.value(handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/presolve/multi_probe.cu
+++ b/cpp/src/mip_heuristics/presolve/multi_probe.cu
@@ -122,7 +122,7 @@ void multi_probe_t<i_t, f_t>::calculate_activity(problem_t<i_t, f_t>& pb,
       <<<pb.n_constraints, n_threads, 0, handle_ptr->get_stream().get()>>>(
         pb.view(), upd_0.view(), upd_1.view());
   }
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -151,7 +151,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
     upd_1.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     update_bounds_kernel<i_t, f_t, n_threads>
       <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(pb.view(), upd_1.view());
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     i_t h_bounds_changed_1 = upd_1.bounds_changed.value(handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Bounds changed upd 1 %d", h_bounds_changed_1);
     skip_1 = (h_bounds_changed_1 == zero);
@@ -159,7 +159,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
     upd_0.bounds_changed.set_value_async(zero, handle_ptr->get_stream());
     update_bounds_kernel<i_t, f_t, n_threads>
       <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(pb.view(), upd_0.view());
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     i_t h_bounds_changed_0 = upd_0.bounds_changed.value(handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Bounds changed upd 0 %d", h_bounds_changed_0);
     skip_0 = (h_bounds_changed_0 == zero);
@@ -169,7 +169,7 @@ bool multi_probe_t<i_t, f_t>::calculate_bounds_update(problem_t<i_t, f_t>& pb,
     update_bounds_kernel<i_t, f_t, n_threads>
       <<<pb.n_variables, n_threads, 0, handle_ptr->get_stream().get()>>>(
         pb.view(), upd_0.view(), upd_1.view());
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     i_t h_bounds_changed_0 = upd_0.bounds_changed.value(handle_ptr->get_stream());
     CUOPT_LOG_TRACE("Bounds changed upd 0 %d", h_bounds_changed_0);
     i_t h_bounds_changed_1 = upd_1.bounds_changed.value(handle_ptr->get_stream());
@@ -233,7 +233,7 @@ void multi_probe_t<i_t, f_t>::set_interval_bounds(
                    });
   init_changed_constraints = false;
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -262,7 +262,7 @@ void multi_probe_t<i_t, f_t>::set_bounds(
                      upd_1_v.ub[thrust::get<0>(t)] = thrust::get<2>(t);
                    });
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -465,7 +465,7 @@ void multi_probe_t<i_t, f_t>::constraint_stats(problem_t<i_t, f_t>& pb,
                    thrust::make_tuple<i_t, i_t, i_t, i_t>(0, 0, 0, 0),
                    tuple_plus_t<i_t>{});
 
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   if (redund_constraints_count_0 > 0) {
     CUOPT_LOG_TRACE("First probe: Redundant constraint count %d", redund_constraints_count_0);

--- a/cpp/src/mip_heuristics/presolve/probing_cache.cu
+++ b/cpp/src/mip_heuristics/presolve/probing_cache.cu
@@ -337,7 +337,7 @@ inline std::vector<i_t> compute_prioritized_integer_indices(
   CUOPT_LOG_DEBUG("prioritized integer_indices n_integer_vars %d", problem.n_integer_vars);
   // compute the min var slack
   compute_min_slack_per_var<i_t, f_t>
-    <<<problem.n_integer_vars, 128, 0, problem.handle_ptr->get_stream()>>>(
+    <<<problem.n_integer_vars, 128, 0, problem.handle_ptr->get_stream().get()>>>(
       problem.view(),
       make_span(bound_presolve.upd.min_activity),
       make_span(bound_presolve.upd.max_activity),
@@ -804,7 +804,7 @@ std::vector<i_t> compute_priority_indices_by_implied_integers(problem_t<i_t, f_t
                                      problem.offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      0,
-                                     problem.handle_ptr->get_stream());
+                                     problem.handle_ptr->get_stream().get());
 
   rmm::device_uvector<std::uint8_t> temp_storage(temp_storage_bytes,
                                                  problem.handle_ptr->get_stream());
@@ -820,7 +820,7 @@ std::vector<i_t> compute_priority_indices_by_implied_integers(problem_t<i_t, f_t
                                      problem.offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      0,
-                                     problem.handle_ptr->get_stream());
+                                     problem.handle_ptr->get_stream().get());
   // keeps the count of number of other integers that this variables shares a constraint with
   rmm::device_uvector<i_t> count_per_variable(problem.n_variables,
                                               problem.handle_ptr->get_stream());
@@ -842,7 +842,7 @@ std::vector<i_t> compute_priority_indices_by_implied_integers(problem_t<i_t, f_t
                                      problem.reverse_offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      0,
-                                     problem.handle_ptr->get_stream());
+                                     problem.handle_ptr->get_stream().get());
 
   temp_storage.resize(temp_storage_bytes, problem.handle_ptr->get_stream());
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
@@ -857,7 +857,7 @@ std::vector<i_t> compute_priority_indices_by_implied_integers(problem_t<i_t, f_t
                                      problem.reverse_offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      0,
-                                     problem.handle_ptr->get_stream());
+                                     problem.handle_ptr->get_stream().get());
   thrust::for_each(problem.handle_ptr->get_thrust_policy(),
                    thrust::make_counting_iterator(0),
                    thrust::make_counting_iterator(problem.n_variables),

--- a/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
+++ b/cpp/src/mip_heuristics/presolve/third_party_presolve.cpp
@@ -1215,7 +1215,7 @@ void third_party_presolve_t<i_t, f_t>::undo_from_device(rmm::device_uvector<f_t>
   raft::copy(h_primal.data(), primal_solution.data(), primal_solution.size(), stream_view);
   raft::copy(h_dual.data(), dual_solution.data(), dual_solution.size(), stream_view);
   raft::copy(h_rc.data(), reduced_costs.data(), reduced_costs.size(), stream_view);
-  stream_view.synchronize();
+  stream_view.sync();
 
   undo(h_primal, h_dual, h_rc, category, status_to_skip, dual_postsolve);
 
@@ -1225,7 +1225,7 @@ void third_party_presolve_t<i_t, f_t>::undo_from_device(rmm::device_uvector<f_t>
   raft::copy(primal_solution.data(), h_primal.data(), h_primal.size(), stream_view);
   raft::copy(dual_solution.data(), h_dual.data(), h_dual.size(), stream_view);
   raft::copy(reduced_costs.data(), h_rc.data(), h_rc.size(), stream_view);
-  stream_view.synchronize();
+  stream_view.sync();
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/presolve/trivial_presolve.cuh
+++ b/cpp/src/mip_heuristics/presolve/trivial_presolve.cuh
@@ -126,7 +126,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
                          cnst.end(),
                          cnst.begin(),
                          thrust::maximum<i_t>{});
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   //  partition coo - fixed variables reside in second partition
   i_t nnz_edge_count = pb.coefficients.size();
@@ -139,7 +139,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
                                coo_begin + cnst.size(),
                                is_variable_free_t<f_t, f_t2>{pb.tolerances.integrality_tolerance,
                                                              make_span(pb.variable_bounds)});
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     nnz_edge_count = partition_iter - coo_begin;
   }
 
@@ -154,13 +154,13 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
                   thrust::make_constant_iterator<i_t>(1) + nnz_edge_count,
                   cnst.begin(),
                   cnst_map.begin());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   thrust::scatter(handle_ptr->get_thrust_policy(),
                   thrust::make_constant_iterator<i_t>(1),
                   thrust::make_constant_iterator<i_t>(1) + nnz_edge_count,
                   pb.variables.begin(),
                   var_map.begin());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   auto unused_var_count =
     thrust::count(handle_ptr->get_thrust_policy(), var_map.begin(), var_map.end(), 0);
@@ -197,7 +197,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
         pb.reverse_original_ids[pb.original_ids[i]] = i;
       }
     }
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   }
 
   if (nnz_edge_count != static_cast<i_t>(pb.coefficients.size())) {
@@ -218,7 +218,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
       thrust::make_transform_iterator(thrust::make_counting_iterator<i_t>(nnz_edge_count), mul),
       unused_coo_cnst.begin(),
       unused_coo_cnst_bound_updates.begin());
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     auto unused_coo_cnst_count = iter.first - unused_coo_cnst.begin();
     unused_coo_cnst.resize(unused_coo_cnst_count, handle_ptr->get_stream());
     unused_coo_cnst_bound_updates.resize(unused_coo_cnst_count, handle_ptr->get_stream());
@@ -231,7 +231,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
                                                           make_span(unused_coo_cnst_bound_updates),
                                                           make_span(pb.constraint_lower_bounds),
                                                           make_span(pb.constraint_upper_bounds)});
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   }
 
   //  update objective_offset
@@ -243,7 +243,7 @@ void update_from_csr(problem_t<i_t, f_t>& pb, bool remap_cache_ids)
       make_span(var_map), make_span(pb.objective_coefficients), make_span(pb.variable_bounds)},
     0.,
     thrust::plus<f_t>{});
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   //  create renumbering maps
   rmm::device_uvector<i_t> cnst_renum_ids(pb.n_constraints, handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/problem/load_balanced_problem.cu
+++ b/cpp/src/mip_heuristics/problem/load_balanced_problem.cu
@@ -203,13 +203,13 @@ void create_constraint_graph(const raft::handle_t* handle_ptr,
     handle_ptr->get_thrust_policy(), offsets.begin(), offsets.end(), offsets.begin());
 
   // copy adjacency lists and vertex properties
-  constraint_data_copy<i_t, f_t><<<reorg_ids.size(), 256, 0, handle_ptr->get_stream()>>>(
+  constraint_data_copy<i_t, f_t><<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(
     make_span(reorg_ids), make_span(offsets), make_span(coeff), make_span(edge), bounds, pb.view());
 
   if (debug) {
     rmm::device_scalar<i_t> errors(zero_v<i_t>, handle_ptr->get_stream());
     check_constraint_data<i_t, f_t>
-      <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream()>>>(make_span(reorg_ids),
+      <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
                                                                make_span(offsets),
                                                                make_span(coeff),
                                                                make_span(edge),
@@ -245,7 +245,7 @@ void create_variable_graph(const raft::handle_t* handle_ptr,
 
   // copy adjacency lists and vertex properties
   variable_data_copy<i_t, f_t>
-    <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream()>>>(make_span(reorg_ids),
+    <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
                                                              make_span(offsets),
                                                              make_span(coeff),
                                                              make_span(edge),
@@ -256,7 +256,7 @@ void create_variable_graph(const raft::handle_t* handle_ptr,
   if (debug) {
     rmm::device_scalar<i_t> errors(zero_v<i_t>, handle_ptr->get_stream());
     check_variable_data<i_t, f_t>
-      <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream()>>>(make_span(reorg_ids),
+      <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
                                                                make_span(offsets),
                                                                make_span(coeff),
                                                                make_span(edge),

--- a/cpp/src/mip_heuristics/problem/load_balanced_problem.cu
+++ b/cpp/src/mip_heuristics/problem/load_balanced_problem.cu
@@ -210,12 +210,12 @@ void create_constraint_graph(const raft::handle_t* handle_ptr,
     rmm::device_scalar<i_t> errors(zero_v<i_t>, handle_ptr->get_stream());
     check_constraint_data<i_t, f_t>
       <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
-                                                               make_span(offsets),
-                                                               make_span(coeff),
-                                                               make_span(edge),
-                                                               bounds,
-                                                               pb.view(),
-                                                               errors.data());
+                                                                     make_span(offsets),
+                                                                     make_span(coeff),
+                                                                     make_span(edge),
+                                                                     bounds,
+                                                                     pb.view(),
+                                                                     errors.data());
     i_t error_count = errors.value(handle_ptr->get_stream());
     if (error_count != 0) { std::cerr << "adjacency list copy mismatch\n"; }
   }
@@ -246,24 +246,24 @@ void create_variable_graph(const raft::handle_t* handle_ptr,
   // copy adjacency lists and vertex properties
   variable_data_copy<i_t, f_t>
     <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
-                                                             make_span(offsets),
-                                                             make_span(coeff),
-                                                             make_span(edge),
-                                                             bounds,
-                                                             make_span(types),
-                                                             pb.view());
+                                                                   make_span(offsets),
+                                                                   make_span(coeff),
+                                                                   make_span(edge),
+                                                                   bounds,
+                                                                   make_span(types),
+                                                                   pb.view());
 
   if (debug) {
     rmm::device_scalar<i_t> errors(zero_v<i_t>, handle_ptr->get_stream());
     check_variable_data<i_t, f_t>
       <<<reorg_ids.size(), 256, 0, handle_ptr->get_stream().get()>>>(make_span(reorg_ids),
-                                                               make_span(offsets),
-                                                               make_span(coeff),
-                                                               make_span(edge),
-                                                               bounds,
-                                                               make_span(types),
-                                                               pb.view(),
-                                                               errors.data());
+                                                                     make_span(offsets),
+                                                                     make_span(coeff),
+                                                                     make_span(edge),
+                                                                     bounds,
+                                                                     make_span(types),
+                                                                     pb.view(),
+                                                                     errors.data());
     i_t error_count = errors.value(handle_ptr->get_stream());
     if (error_count != 0) { std::cerr << "adjacency list copy mismatch\n"; }
   }

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -454,7 +454,7 @@ void csr_to_csc_transpose(const i_t* csr_offsets,
   rmm::device_uvector<i_t> next_pos(n_cols, stream);
   raft::copy(next_pos.data(), csc_offsets, n_cols, stream);
 
-  csr_to_csc_scatter_kernel<i_t, f_t><<<n_rows, 256, 0, stream>>>(
+  csr_to_csc_scatter_kernel<i_t, f_t><<<n_rows, 256, 0, stream.get()>>>(
     n_rows, csr_offsets, csr_indices, csr_values, next_pos.data(), csc_indices, csc_values);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -473,7 +473,7 @@ void csr_to_csc_transpose(const i_t* csr_offsets,
                                       n_cols,
                                       csc_offsets,
                                       csc_offsets + 1,
-                                      stream);
+                                      stream.get());
 
   rmm::device_uvector<std::byte> temp_storage(temp_storage_bytes, stream);
   cub::DeviceSegmentedSort::SortPairs(temp_storage.data(),
@@ -486,12 +486,12 @@ void csr_to_csc_transpose(const i_t* csr_offsets,
                                       n_cols,
                                       csc_offsets,
                                       csc_offsets + 1,
-                                      stream);
+                                      stream.get());
 
   // Copy sorted results back
   raft::copy(csc_indices, row_ind_sorted.data(), nnz, stream);
   raft::copy(csc_values, val_sorted.data(), nnz, stream);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -500,9 +500,9 @@ void problem_t<i_t, f_t>::compute_transpose_of_problem()
   raft::common::nvtx::range fun_scope("compute_transpose_of_problem");
   csrsort_cusparse(coefficients, variables, offsets, n_constraints, n_variables, handle_ptr);
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   // Resize what is needed for LP
   reverse_offsets.resize(n_variables + 1, handle_ptr->get_stream());
   reverse_constraints.resize(nnz, handle_ptr->get_stream());
@@ -1018,7 +1018,7 @@ void problem_t<i_t, f_t>::compute_related_variables(double time_limit)
                     related_variables.size() / (f_t)1e6);
 
     thrust::fill(handle_ptr->get_thrust_policy(), varmap.begin(), varmap.end(), 0);
-    compute_related_vars_unique<i_t, f_t><<<1024, 128, 0, handle_ptr->get_stream()>>>(
+    compute_related_vars_unique<i_t, f_t><<<1024, 128, 0, handle_ptr->get_stream().get()>>>(
       pb_view, slice_begin, slice_end, make_span(varmap));
 
     // prefix sum to generate offsets
@@ -1508,7 +1508,7 @@ void problem_t<i_t, f_t>::substitute_variables(const std::vector<i_t>& var_indic
                                      offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      initial_value,
-                                     handle_ptr->get_stream());
+                                     handle_ptr->get_stream().get());
 
   rmm::device_uvector<std::uint8_t> temp_storage(temp_storage_bytes, handle_ptr->get_stream());
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
@@ -1523,7 +1523,7 @@ void problem_t<i_t, f_t>::substitute_variables(const std::vector<i_t>& var_indic
                                      offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      initial_value,
-                                     handle_ptr->get_stream());
+                                     handle_ptr->get_stream().get());
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
   thrust::for_each(
     handle_ptr->get_thrust_policy(),
@@ -1632,7 +1632,7 @@ void problem_t<i_t, f_t>::fix_given_variables(problem_t<i_t, f_t>& original_prob
                                      original_problem.offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      initial_value,
-                                     handle_ptr->get_stream());
+                                     handle_ptr->get_stream().get());
 
   rmm::device_uvector<std::uint8_t> temp_storage(temp_storage_bytes, handle_ptr->get_stream());
   d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
@@ -1647,7 +1647,7 @@ void problem_t<i_t, f_t>::fix_given_variables(problem_t<i_t, f_t>& original_prob
                                      original_problem.offsets.data() + 1,
                                      cuda::std::plus<>{},
                                      initial_value,
-                                     handle_ptr->get_stream());
+                                     handle_ptr->get_stream().get());
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
   thrust::for_each(
     handle_ptr->get_thrust_policy(),
@@ -1790,7 +1790,7 @@ void problem_t<i_t, f_t>::remove_given_variables(problem_t<i_t, f_t>& original_p
   presolve_data.var_flags.resize(variable_map.size(), handle_ptr->get_stream());
   const i_t TPB = 64;
   // compute new offsets
-  compute_new_offsets<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream()>>>(
+  compute_new_offsets<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream().get()>>>(
     original_problem.view(), view(), cuopt::make_span(variable_map));
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
   thrust::exclusive_scan(handle_ptr->get_thrust_policy(),
@@ -1800,7 +1800,7 @@ void problem_t<i_t, f_t>::remove_given_variables(problem_t<i_t, f_t>& original_p
   rmm::device_uvector<i_t> write_pos(n_constraints, handle_ptr->get_stream());
   thrust::fill(handle_ptr->get_thrust_policy(), write_pos.begin(), write_pos.end(), 0);
   // compute new csr
-  compute_new_csr<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream()>>>(
+  compute_new_csr<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream().get()>>>(
     original_problem.view(), view(), cuopt::make_span(variable_map), cuopt::make_span(write_pos));
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
   // assign nnz, number of variables etc.

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -501,8 +501,9 @@ void problem_t<i_t, f_t>::compute_transpose_of_problem()
   csrsort_cusparse(coefficients, variables, offsets, n_constraints, n_variables, handle_ptr);
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
   // Resize what is needed for LP
   reverse_offsets.resize(n_variables + 1, handle_ptr->get_stream());
   reverse_constraints.resize(nnz, handle_ptr->get_stream());

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -491,7 +491,7 @@ void csr_to_csc_transpose(const i_t* csr_offsets,
   // Copy sorted results back
   raft::copy(csc_indices, row_ind_sorted.data(), nnz, stream);
   raft::copy(csc_values, val_sorted.data(), nnz, stream);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+  stream.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -1524,7 +1524,7 @@ void problem_t<i_t, f_t>::substitute_variables(const std::vector<i_t>& var_indic
                                      cuda::std::plus<>{},
                                      initial_value,
                                      handle_ptr->get_stream().get());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   thrust::for_each(
     handle_ptr->get_thrust_policy(),
     thrust::make_counting_iterator(0),
@@ -1648,7 +1648,7 @@ void problem_t<i_t, f_t>::fix_given_variables(problem_t<i_t, f_t>& original_prob
                                      cuda::std::plus<>{},
                                      initial_value,
                                      handle_ptr->get_stream().get());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   thrust::for_each(
     handle_ptr->get_thrust_policy(),
     thrust::make_counting_iterator(0),
@@ -1687,7 +1687,7 @@ problem_t<i_t, f_t> problem_t<i_t, f_t>::get_problem_after_fixing_vars(
   variable_map.resize(assignment.size() - variables_to_fix.size(), handle_ptr->get_stream());
   // compute variable map to recover the assignment later
   // get the variable indices to gather
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   cuopt_assert(
     (thrust::is_sorted(
       handle_ptr->get_thrust_policy(), variables_to_fix.begin(), variables_to_fix.end())),
@@ -1699,14 +1699,14 @@ problem_t<i_t, f_t> problem_t<i_t, f_t>::get_problem_after_fixing_vars(
                                            variables_to_fix.begin(),
                                            variables_to_fix.end(),
                                            variable_map.begin());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   cuopt_assert(result_end - variable_map.data() == variable_map.size(),
                "Size issue in set_difference");
   CUOPT_LOG_DEBUG("Fixing assignment hash 0x%x, vars to fix: 0x%x",
                   mip::compute_hash(assignment, handle_ptr->get_stream()),
                   mip::compute_hash(variables_to_fix, handle_ptr->get_stream()));
   problem.fix_given_variables(*this, assignment, variables_to_fix, handle_ptr);
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   problem.remove_given_variables(*this, assignment, variable_map, handle_ptr);
   // if we are fixing on the original problem, the variable_map is what we want in
   // problem.original_ids but considering the case that we are fixing some variables multiple times,
@@ -1721,7 +1721,7 @@ problem_t<i_t, f_t> problem_t<i_t, f_t>::get_problem_after_fixing_vars(
                  "Variable index out of bounds");
     problem.reverse_original_ids[original_ids[h_variable_map[i]]] = i;
   }
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   auto end_time = std::chrono::high_resolution_clock::now();
   double time_taken =
     std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
@@ -1792,7 +1792,7 @@ void problem_t<i_t, f_t>::remove_given_variables(problem_t<i_t, f_t>& original_p
   // compute new offsets
   compute_new_offsets<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream().get()>>>(
     original_problem.view(), view(), cuopt::make_span(variable_map));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   thrust::exclusive_scan(handle_ptr->get_thrust_policy(),
                          offsets.data(),
                          offsets.data() + offsets.size(),
@@ -1802,7 +1802,7 @@ void problem_t<i_t, f_t>::remove_given_variables(problem_t<i_t, f_t>& original_p
   // compute new csr
   compute_new_csr<i_t, f_t><<<variable_map.size(), TPB, 0, handle_ptr->get_stream().get()>>>(
     original_problem.view(), view(), cuopt::make_span(variable_map), cuopt::make_span(write_pos));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   // assign nnz, number of variables etc.
   nnz         = offsets.back_element(handle_ptr->get_stream());
   n_variables = variable_map.size();
@@ -2150,7 +2150,7 @@ void problem_t<i_t, f_t>::set_constraints_from_host_csr(const std::vector<i_t>& 
   thrust::fill(
     handle_ptr->get_thrust_policy(), lp_state.prev_dual.begin(), lp_state.prev_dual.end(), f_t{0});
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 
   compute_transpose_of_problem();
   combined_bounds.resize(n_constraints, stream);
@@ -2409,7 +2409,7 @@ void problem_t<i_t, f_t>::update_variable_bounds(const std::vector<i_t>& var_ind
       variable_bounds[var_idx].y = ub_values[i];
     });
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 #if MIP_INSTANTIATE_FLOAT || PDLP_INSTANTIATE_FLOAT

--- a/cpp/src/mip_heuristics/problem/problem_helpers.cuh
+++ b/cpp/src/mip_heuristics/problem/problem_helpers.cuh
@@ -418,7 +418,7 @@ static void convert_greater_to_less(mip::problem_t<i_t, f_t>& problem)
                              problem.constraint_lower_bounds.size()),
       raft::device_span<f_t>(problem.constraint_upper_bounds.data(),
                              problem.constraint_upper_bounds.size()));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 
   problem.compute_transpose_of_problem();
 

--- a/cpp/src/mip_heuristics/problem/problem_helpers.cuh
+++ b/cpp/src/mip_heuristics/problem/problem_helpers.cuh
@@ -143,7 +143,7 @@ static void convert_to_maximization_problem(mip::problem_t<i_t, f_t>& op_problem
                           op_problem.objective_coefficients.data(),
                           op_problem.objective_coefficients.size(),
                           mip::negate<f_t>(),
-                          op_problem.handle_ptr->get_stream());
+                          op_problem.handle_ptr->get_stream().get());
   }
   // Negate objective scaling factor and objective offset so that primal / dual stay same sign after
   // negating objective coeffs
@@ -219,7 +219,7 @@ static bool check_transpose_validity(const rmm::device_uvector<f_t>& coefficient
 
   rmm::device_scalar<bool> failed(false_v, handle_ptr->get_stream());
   kernel_check_transpose_validity<i_t, f_t>
-    <<<offsets.size() - 1, 64, 0, handle_ptr->get_stream()>>>(
+    <<<offsets.size() - 1, 64, 0, handle_ptr->get_stream().get()>>>(
       raft::device_span<const f_t>(coefficients.data(), coefficients.size()),
       raft::device_span<const i_t>(offsets.data(), offsets.size()),
       raft::device_span<const i_t>(variables.data(), variables.size()),
@@ -366,7 +366,7 @@ static void csrsort_cusparse(rmm::device_uvector<f_t>& values,
   auto stream = offsets.stream();
   cusparseHandle_t handle;
   cusparseCreate(&handle);
-  cusparseSetStream(handle, stream);
+  cusparseSetStream(handle, stream.get());
 
   i_t nnz = values.size();
   i_t m   = rows;
@@ -411,7 +411,7 @@ static void convert_greater_to_less(mip::problem_t<i_t, f_t>& problem)
 
   constexpr i_t TPB = 256;
   kernel_convert_greater_to_less<i_t, f_t>
-    <<<problem.n_constraints, TPB, 0, handle_ptr->get_stream()>>>(
+    <<<problem.n_constraints, TPB, 0, handle_ptr->get_stream().get()>>>(
       raft::device_span<f_t>(problem.coefficients.data(), problem.coefficients.size()),
       raft::device_span<const i_t>(problem.offsets.data(), problem.offsets.size()),
       raft::device_span<f_t>(problem.constraint_lower_bounds.data(),

--- a/cpp/src/mip_heuristics/solution/feasibility_test.cuh
+++ b/cpp/src/mip_heuristics/solution/feasibility_test.cuh
@@ -86,7 +86,7 @@ void solution_t<i_t, f_t>::test_absolute_feasibility()
 {
   i_t TPB      = 64;
   i_t n_blocks = (problem_ptr->n_constraints + TPB - 1) / TPB;
-  test_feasibility_kernel<i_t, f_t><<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(view());
+  test_feasibility_kernel<i_t, f_t><<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(view());
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
 }
 
@@ -96,7 +96,7 @@ void solution_t<i_t, f_t>::test_variable_bounds(bool check_integer, i_t* is_feas
   i_t TPB      = 64;
   i_t n_blocks = (problem_ptr->n_variables + TPB - 1) / TPB;
   test_variable_bounds_kernel<i_t, f_t>
-    <<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(view(), check_integer, is_feasible);
+    <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(view(), check_integer, is_feasible);
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
 }
 

--- a/cpp/src/mip_heuristics/solution/feasibility_test.cuh
+++ b/cpp/src/mip_heuristics/solution/feasibility_test.cuh
@@ -77,7 +77,7 @@ void solution_t<i_t, f_t>::test_feasibility(bool check_integer)
   cuopt_assert(compute_feasibility(), "Solution is not feasible!");
   test_variable_bounds(check_integer);
   handle_ptr->sync_stream();
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 // test feasibility on
@@ -87,7 +87,7 @@ void solution_t<i_t, f_t>::test_absolute_feasibility()
   i_t TPB      = 64;
   i_t n_blocks = (problem_ptr->n_constraints + TPB - 1) / TPB;
   test_feasibility_kernel<i_t, f_t><<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(view());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>
@@ -97,7 +97,7 @@ void solution_t<i_t, f_t>::test_variable_bounds(bool check_integer, i_t* is_feas
   i_t n_blocks = (problem_ptr->n_variables + TPB - 1) / TPB;
   test_variable_bounds_kernel<i_t, f_t>
     <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(view(), check_integer, is_feasible);
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 }  // namespace cuopt::mathematical_optimization::mip

--- a/cpp/src/mip_heuristics/solution/solution.cu
+++ b/cpp/src/mip_heuristics/solution/solution.cu
@@ -296,7 +296,7 @@ void solution_t<i_t, f_t>::compute_constraints()
 
   i_t TPB = 64;
   compute_constraint_values<i_t, f_t>
-    <<<problem_ptr->n_constraints, TPB, 0, handle_ptr->get_stream()>>>(view());
+    <<<problem_ptr->n_constraints, TPB, 0, handle_ptr->get_stream().get()>>>(view());
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
 }
 
@@ -313,11 +313,11 @@ f_t solution_t<i_t, f_t>::compute_l2_residual()
     upper_excess.data(),
     problem_ptr->n_constraints,
     [] __device__(f_t lower, f_t upper) -> f_t { return max(abs(lower), abs(upper)); },
-    handle_ptr->get_stream());
+    handle_ptr->get_stream().get());
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   pdlp::my_l2_norm<i_t, f_t>(combined_excess, l2_residual, handle_ptr);
   return l2_residual.value(handle_ptr->get_stream());
 }

--- a/cpp/src/mip_heuristics/solution/solution.cu
+++ b/cpp/src/mip_heuristics/solution/solution.cu
@@ -316,8 +316,9 @@ f_t solution_t<i_t, f_t>::compute_l2_residual()
     handle_ptr->get_stream().get());
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
   pdlp::my_l2_norm<i_t, f_t>(combined_excess, l2_residual, handle_ptr);
   return l2_residual.value(handle_ptr->get_stream());
 }

--- a/cpp/src/mip_heuristics/solution/solution.cu
+++ b/cpp/src/mip_heuristics/solution/solution.cu
@@ -297,7 +297,7 @@ void solution_t<i_t, f_t>::compute_constraints()
   i_t TPB = 64;
   compute_constraint_values<i_t, f_t>
     <<<problem_ptr->n_constraints, TPB, 0, handle_ptr->get_stream().get()>>>(view());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -78,9 +78,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 template <typename f_t>

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -948,7 +948,7 @@ std::unique_ptr<mip_solution_interface_t<i_t, f_t>> solve_mip(
   auto gpu_solution = solve_mip<i_t, f_t>(*gpu_problem, settings);
 
   // Ensure all GPU work from the solve is complete before D2H copies in to_cpu_solution(),
-  // which uses rmm::cuda_stream_per_thread (a different stream than the solver used).
+  // which uses the per-thread default stream (a different stream than the solver used).
   stream.synchronize();
 
   // Convert GPU solution back to CPU

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -79,8 +79,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 template <typename f_t>

--- a/cpp/src/mip_heuristics/solver.cu
+++ b/cpp/src/mip_heuristics/solver.cu
@@ -46,8 +46,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/solver.cu
+++ b/cpp/src/mip_heuristics/solver.cu
@@ -45,9 +45,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/solver_solution.cu
+++ b/cpp/src/mip_heuristics/solver_solution.cu
@@ -215,8 +215,8 @@ void mip_solution_t<i_t, f_t>::write_to_sol_file(std::string_view filename,
   auto& var_names     = get_variable_names();
   std::vector<f_t> solution;
   solution.resize(solution_.size());
-  raft::copy(solution.data(), solution_.data(), solution_.size(), stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  raft::copy(solution.data(), solution_.data(), solution_.size(), stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 
   solution_writer_t::write_solution_to_sol_file(
     std::string(filename), status, objective_value, var_names, solution);

--- a/cpp/src/mip_heuristics/solver_solution.cu
+++ b/cpp/src/mip_heuristics/solver_solution.cu
@@ -216,7 +216,7 @@ void mip_solution_t<i_t, f_t>::write_to_sol_file(std::string_view filename,
   std::vector<f_t> solution;
   solution.resize(solution_.size());
   raft::copy(solution.data(), solution_.data(), solution_.size(), stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 
   solution_writer_t::write_solution_to_sol_file(
     std::string(filename), status, objective_value, var_names, solution);

--- a/cpp/src/mip_heuristics/utils.cuh
+++ b/cpp/src/mip_heuristics/utils.cuh
@@ -333,7 +333,7 @@ static __global__ void run_lambda_kernel(F f)
 template <typename Func>
 static void inline run_device_lambda(const rmm::cuda_stream_view& stream, Func f)
 {
-  run_lambda_kernel<<<1, 1, 0, stream.value()>>>(f);
+  run_lambda_kernel<<<1, 1, 0, stream.get()>>>(f);
 }
 
 template <typename f_t>

--- a/cpp/src/mip_heuristics/utils.cuh
+++ b/cpp/src/mip_heuristics/utils.cuh
@@ -34,7 +34,7 @@ template <typename i_t>
 inline uint32_t compute_hash(raft::device_span<i_t> values, rmm::cuda_stream_view stream)
 {
   auto h_contents = cuopt::host_copy(values, stream);
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   return cuopt::compute_hash(h_contents);
 }
 
@@ -42,7 +42,7 @@ template <typename i_t>
 inline uint32_t compute_hash(const rmm::device_uvector<i_t>& values, rmm::cuda_stream_view stream)
 {
   auto h_contents = cuopt::host_copy(values, stream);
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   return cuopt::compute_hash(h_contents);
 }
 

--- a/cpp/src/pdlp/cpu_pdlp_warm_start_data.cu
+++ b/cpp/src/pdlp/cpu_pdlp_warm_start_data.cu
@@ -22,7 +22,7 @@ std::vector<T> device_to_host_vector(const rmm::device_uvector<T>& device_vec,
 
   std::vector<T> host_vec(device_vec.size());
   raft::copy(host_vec.data(), device_vec.data(), device_vec.size(), stream);
-  stream.synchronize();
+  stream.sync();
   return host_vec;
 }
 
@@ -35,7 +35,7 @@ rmm::device_uvector<T> host_to_device_vector(const std::vector<T>& host_vec,
 
   rmm::device_uvector<T> device_vec(host_vec.size(), stream);
   raft::copy(device_vec.data(), host_vec.data(), host_vec.size(), stream);
-  stream.synchronize();
+  stream.sync();
   return device_vec;
 }
 

--- a/cpp/src/pdlp/cuopt_c_internal.hpp
+++ b/cpp/src/pdlp/cuopt_c_internal.hpp
@@ -15,6 +15,8 @@
 #include <cuopt/mathematical_optimization/optimization_problem_solution_interface.hpp>
 #include <cuopt/mathematical_optimization/pdlp/solver_solution.hpp>
 
+#include <cuda/stream>
+
 #include <raft/core/handle.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -30,7 +32,7 @@ struct problem_and_stream_view_t {
     if (mem_backend == memory_backend_t::GPU) {
       // Use RAII locals so partial allocations are cleaned up if a later new throws
       std::unique_ptr<rmm::cuda_stream_view> sv(
-        new rmm::cuda_stream_view(rmm::cuda_stream_per_thread));
+        new rmm::cuda_stream_view(cuda::stream_ref{cudaStreamPerThread}));
       std::unique_ptr<raft::handle_t> h(new raft::handle_t(*sv));
       std::unique_ptr<optimization_problem_t<cuopt_int_t, cuopt_float_t>> gp(
         new optimization_problem_t<cuopt_int_t, cuopt_float_t>(h.get()));

--- a/cpp/src/pdlp/cusparse_view.cu
+++ b/cpp/src/pdlp/cusparse_view.cu
@@ -439,7 +439,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   dual_solution.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_non_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
   buffer_non_transpose.resize(buffer_size_non_transpose, handle_ptr->get_stream());
 
   size_t buffer_size_transpose = 0;
@@ -453,7 +453,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   c.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
 
   buffer_transpose.resize(buffer_size_transpose, handle_ptr->get_stream());
 
@@ -470,7 +470,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   batch_tmp_primals.get(),
                                                   CUSPARSE_SPMM_CSR_ALG3,
                                                   &buffer_size_transpose_batch,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
 
   buffer_transpose_batch.resize(buffer_size_transpose_batch, handle_ptr->get_stream());
   size_t buffer_size_non_transpose_batch = 0;
@@ -485,7 +485,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   batch_tmp_duals.get(),
                                                   CUSPARSE_SPMM_CSR_ALG3,
                                                   &buffer_size_non_transpose_batch,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
   buffer_non_transpose_batch.resize(buffer_size_non_transpose_batch, handle_ptr->get_stream());
 
   // In row row the buffer size may be different
@@ -502,7 +502,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
       batch_current_AtYs.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &buffer_size_transpose_batch_row_row,
-      handle_ptr->get_stream()));
+      handle_ptr->get_stream().get()));
     buffer_transpose_batch_row_row_.resize(buffer_size_transpose_batch_row_row,
                                            handle_ptr->get_stream());
     size_t buffer_size_non_transpose_batch_row_row = 0;
@@ -517,7 +517,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
       batch_dual_gradients.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &buffer_size_non_transpose_batch_row_row,
-      handle_ptr->get_stream()));
+      handle_ptr->get_stream().get()));
     buffer_non_transpose_batch_row_row_.resize(buffer_size_non_transpose_batch_row_row,
                                                handle_ptr->get_stream());
   }
@@ -532,7 +532,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              dual_solution.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_non_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 
   my_cusparsespmv_preprocess(handle_ptr_->get_cusparse_handle(),
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -543,7 +543,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              c.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
   my_cusparsespmm_preprocess(handle_ptr_->get_cusparse_handle(),
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -554,7 +554,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              batch_tmp_primals.get(),
                              CUSPARSE_SPMM_CSR_ALG3,
                              buffer_transpose_batch.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 
   my_cusparsespmm_preprocess(handle_ptr_->get_cusparse_handle(),
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -566,7 +566,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              batch_tmp_duals.get(),
                              CUSPARSE_SPMM_CSR_ALG3,
                              buffer_non_transpose_batch.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
   if (batch_mode_) {
     my_cusparsespmm_preprocess(
       handle_ptr_->get_cusparse_handle(),
@@ -579,7 +579,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
       batch_current_AtYs.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       buffer_transpose_batch_row_row_.data(),
-      handle_ptr->get_stream());
+      handle_ptr->get_stream().get());
     my_cusparsespmm_preprocess(
       handle_ptr_->get_cusparse_handle(),
       CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -591,7 +591,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
       batch_dual_gradients.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       buffer_non_transpose_batch_row_row_.data(),
-      handle_ptr->get_stream());
+      handle_ptr->get_stream().get());
   }
 #endif
 
@@ -639,7 +639,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                         beta_d.data(),
                                         dual_solution.get(),
                                         CUSPARSE_SPMV_CSR_ALG2,
-                                        handle_ptr->get_stream());
+                                        handle_ptr->get_stream().get());
       buffer_non_transpose_mixed_.resize(buffer_size_non_transpose_mixed, handle_ptr->get_stream());
 
       size_t buffer_size_transpose_mixed =
@@ -651,7 +651,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                         beta_d.data(),
                                         c.get(),
                                         CUSPARSE_SPMV_CSR_ALG2,
-                                        handle_ptr->get_stream());
+                                        handle_ptr->get_stream().get());
       buffer_transpose_mixed_.resize(buffer_size_transpose_mixed, handle_ptr->get_stream());
 
 #if CUDA_VER_12_4_UP
@@ -664,7 +664,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                       dual_solution.get(),
                                       CUSPARSE_SPMV_CSR_ALG2,
                                       buffer_non_transpose_mixed_.data(),
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
 
       mixed_precision_spmv_preprocess(handle_ptr_->get_cusparse_handle(),
                                       CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -675,7 +675,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                       c.get(),
                                       CUSPARSE_SPMV_CSR_ALG2,
                                       buffer_transpose_mixed_.data(),
-                                      handle_ptr->get_stream());
+                                      handle_ptr->get_stream().get());
 #endif
     }
   }
@@ -727,7 +727,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
 #endif
 
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 
   // setup cusparse view
   A = make_csr<i_t, f_t>(op_problem.n_constraints,
@@ -796,7 +796,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   dual_solution.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_non_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
   buffer_non_transpose.resize(buffer_size_non_transpose, handle_ptr->get_stream());
 
   size_t buffer_size_transpose = 0;
@@ -810,7 +810,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   c.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
 
   buffer_transpose.resize(buffer_size_transpose, handle_ptr->get_stream());
 
@@ -827,7 +827,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                     batch_tmp_primals.get(),
                                                     CUSPARSE_SPMM_CSR_ALG3,
                                                     &buffer_size_transpose_batch,
-                                                    handle_ptr->get_stream()));
+                                                    handle_ptr->get_stream().get()));
     buffer_transpose_batch.resize(buffer_size_transpose_batch, handle_ptr->get_stream());
     size_t buffer_size_non_transpose_batch = 0;
     RAFT_CUSPARSE_TRY(
@@ -841,7 +841,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                     batch_tmp_duals.get(),
                                                     CUSPARSE_SPMM_CSR_ALG3,
                                                     &buffer_size_non_transpose_batch,
-                                                    handle_ptr->get_stream()));
+                                                    handle_ptr->get_stream().get()));
     buffer_non_transpose_batch.resize(buffer_size_non_transpose_batch, handle_ptr->get_stream());
   }
 
@@ -855,7 +855,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              dual_solution.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_non_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 
   my_cusparsespmv_preprocess(handle_ptr_->get_cusparse_handle(),
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -866,7 +866,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              c.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 
   if (batch_mode_) {
     my_cusparsespmm_preprocess(handle_ptr_->get_cusparse_handle(),
@@ -879,7 +879,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                batch_tmp_duals.get(),
                                CUSPARSE_SPMM_CSR_ALG3,
                                buffer_non_transpose_batch.data(),
-                               handle_ptr->get_stream());
+                               handle_ptr->get_stream().get());
 
     my_cusparsespmm_preprocess(handle_ptr_->get_cusparse_handle(),
                                CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -891,7 +891,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                batch_tmp_primals.get(),
                                CUSPARSE_SPMM_CSR_ALG3,
                                buffer_transpose_batch.data(),
-                               handle_ptr->get_stream());
+                               handle_ptr->get_stream().get());
   }
 #endif
 }
@@ -935,7 +935,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
 #endif
 
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 
   // Need to reinstanciate the cuSparse views
   // Copying them from the existing cuSparse view is a bad practice and creates segfault post
@@ -987,7 +987,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   dual_solution.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_non_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
   buffer_non_transpose.resize(buffer_size_non_transpose, handle_ptr->get_stream());
 
   size_t buffer_size_transpose = 0;
@@ -1001,7 +1001,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                   c.get(),
                                                   CUSPARSE_SPMV_CSR_ALG2,
                                                   &buffer_size_transpose,
-                                                  handle_ptr->get_stream()));
+                                                  handle_ptr->get_stream().get()));
 
   buffer_transpose.resize(buffer_size_transpose, handle_ptr->get_stream());
 
@@ -1015,7 +1015,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              dual_solution.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_non_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 
   my_cusparsespmv_preprocess(handle_ptr_->get_cusparse_handle(),
                              CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -1026,7 +1026,7 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                              c.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              buffer_transpose.data(),
-                             handle_ptr->get_stream());
+                             handle_ptr->get_stream().get());
 #endif
 }
 
@@ -1202,7 +1202,7 @@ void cusparse_view_t<i_t, f_t>::create_spmv_op_plans(bool is_reflected)
 #if CUOPT_CUSPARSE_VER_12_8_UP
   if (!is_cusparse_runtime_spmvop_supported() || !(std::is_same_v<f_t, double>)) { return; }
   RAFT_CUSPARSE_TRY(
-    cusparseSetStream(handle_ptr_->get_cusparse_handle(), handle_ptr_->get_stream()));
+    cusparseSetStream(handle_ptr_->get_cusparse_handle(), handle_ptr_->get_stream().get()));
   // Prepare buffers for At_y SpMVOp
   size_t buffer_size_transpose = 0;
   RAFT_CUSPARSE_TRY(cusparse_spmvop_buffer_size(handle_ptr_->get_cusparse_handle(),

--- a/cpp/src/pdlp/cusparse_view.cu
+++ b/cpp/src/pdlp/cusparse_view.cu
@@ -606,13 +606,13 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
                                                     A_float_.data(),
                                                     op_problem_scaled.nnz,
                                                     double_to_float_functor{},
-                                                    handle_ptr->get_stream().value()));
+                                                    handle_ptr->get_stream().get()));
 
       RAFT_CUDA_TRY(cub::DeviceTransform::Transform(A_T_.data(),
                                                     A_T_float_.data(),
                                                     op_problem_scaled.nnz,
                                                     double_to_float_functor{},
-                                                    handle_ptr->get_stream().value()));
+                                                    handle_ptr->get_stream().get()));
 
       A_mixed_   = make_csr<i_t, float>(op_problem_scaled.n_constraints,
                                       op_problem_scaled.n_variables,
@@ -1072,15 +1072,15 @@ void cusparse_view_t<i_t, f_t>::update_mixed_precision_matrices()
                                                   A_float_.data(),
                                                   A_.size(),
                                                   double_to_float_functor{},
-                                                  handle_ptr_->get_stream().value()));
+                                                  handle_ptr_->get_stream().get()));
 
     RAFT_CUDA_TRY(cub::DeviceTransform::Transform(A_T_.data(),
                                                   A_T_float_.data(),
                                                   A_T_.size(),
                                                   double_to_float_functor{},
-                                                  handle_ptr_->get_stream().value()));
+                                                  handle_ptr_->get_stream().get()));
 
-    handle_ptr_->get_stream().synchronize();
+    handle_ptr_->get_stream().sync();
   }
 }
 

--- a/cpp/src/pdlp/cusparse_view.cu
+++ b/cpp/src/pdlp/cusparse_view.cu
@@ -726,8 +726,9 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
   std::cout << "PDLP cusparse view init" << std::endl;
 #endif
 
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr_->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 
   // setup cusparse view
   A = make_csr<i_t, f_t>(op_problem.n_constraints,
@@ -934,8 +935,9 @@ cusparse_view_t<i_t, f_t>::cusparse_view_t(
   std::cout << "Restart Strategy cusparse view init" << std::endl;
 #endif
 
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr_->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr_->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 
   // Need to reinstanciate the cuSparse views
   // Copying them from the existing cuSparse view is a bad practice and creates segfault post

--- a/cpp/src/pdlp/cusparse_view.hpp
+++ b/cpp/src/pdlp/cusparse_view.hpp
@@ -12,7 +12,6 @@
 
 #include <mip_heuristics/problem/problem.cuh>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/detail/cusparse_wrappers.h>

--- a/cpp/src/pdlp/distributed_pdlp/distributed_algorithms.cu
+++ b/cpp/src/pdlp/distributed_pdlp/distributed_algorithms.cu
@@ -300,7 +300,7 @@ f_t multi_gpu_engine_t<i_t, f_t>::distributed_max_singular_value_squared(i_t n_g
                                       q[r].data(),
                                       n_owned,
                                       divide_by_device_scalar_t<f_t>{norm_q[r].data()},
-                                      s.stream.view().value());
+                                      s.stream.view().get());
     });
 
     // atq = A^T q  (fused halo-refresh of q + per-shard local SpMV).
@@ -320,7 +320,7 @@ f_t multi_gpu_engine_t<i_t, f_t>::distributed_max_singular_value_squared(i_t n_g
                                       q[r].data(),
                                       n_owned,
                                       residual_fma_neg_scalar_t<f_t>{sigma_sq[r].data()},
-                                      s.stream.view().value());
+                                      s.stream.view().get());
     });
 
     // Convergence check via global residual norm.

--- a/cpp/src/pdlp/distributed_pdlp/multi_gpu_engine.cu
+++ b/cpp/src/pdlp/distributed_pdlp/multi_gpu_engine.cu
@@ -185,7 +185,7 @@ void multi_gpu_engine_t<i_t, f_t>::halo_exchange_bufs_impl(
                               nccl_data_type<f_t>(),
                               peer,
                               s.comm.get(),
-                              s.stream.view().value()));
+                              s.stream.view().get()));
     }
   });
   for_each_shard([&](auto& s, int r) {
@@ -199,7 +199,7 @@ void multi_gpu_engine_t<i_t, f_t>::halo_exchange_bufs_impl(
                               nccl_data_type<f_t>(),
                               peer,
                               s.comm.get(),
-                              s.stream.view().value()));
+                              s.stream.view().get()));
     }
   });
   CUOPT_NCCL_TRY(ncclGroupEnd());
@@ -317,7 +317,7 @@ void multi_gpu_engine_t<i_t, f_t>::allreduce_sum_inplace_bufs(
                                  nccl_data_type<f_t>(),
                                  ncclSum,
                                  s.comm.get(),
-                                 s.stream.view().value()));
+                                 s.stream.view().get()));
   });
   CUOPT_NCCL_TRY(ncclGroupEnd());
 }
@@ -363,7 +363,7 @@ void multi_gpu_engine_t<i_t, f_t>::distributed_dot_bufs(
                                                     b_bufs[r].data(),
                                                     1,
                                                     out_scalars[r].data_handle(),
-                                                    s.stream.view().value()));
+                                                    s.stream.view().get()));
   });
 
   allreduce_sum_inplace_bufs(out_scalars);
@@ -394,7 +394,7 @@ void multi_gpu_engine_t<i_t, f_t>::distributed_l2_norm_bufs(
       out_scalars[r].data_handle(),
       1,
       [] __device__(f_t x) { return cuda::std::sqrt(x); },
-      s.stream.view().value());
+      s.stream.view().get());
   });
 }
 

--- a/cpp/src/pdlp/distributed_pdlp/multi_gpu_engine.hpp
+++ b/cpp/src/pdlp/distributed_pdlp/multi_gpu_engine.hpp
@@ -140,7 +140,7 @@ struct multi_gpu_engine_t {
                   "distributed_transform_bufs: in_tuples / outs / sizes must "
                   "all have size == shards.size()");
     for_each_shard([&](auto& s, int r) {
-      cub::DeviceTransform::Transform(in_tuples[r], outs[r], sizes[r], op, s.stream.view());
+      cub::DeviceTransform::Transform(in_tuples[r], outs[r], sizes[r], op, s.stream.view().get());
     });
   }
 

--- a/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
+++ b/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
@@ -102,9 +102,9 @@ pdlp_initial_scaling_strategy_t<i_t, f_t>::pdlp_initial_scaling_strategy_t(
 
   // start with all one for scaling vectors
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_));
+    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_));
+    iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
   thrust::fill(handle_ptr_->get_thrust_policy(),
                cummulative_constraint_matrix_scaling_.begin(),
                cummulative_constraint_matrix_scaling_.end(),
@@ -232,9 +232,9 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::ruiz_iter_local()
 {
   // Reset the iteration_scaling vectors to all 0
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0, sizeof(f_t) * dual_size_h_, stream_view_));
+    iteration_constraint_matrix_scaling_.data(), 0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_variable_scaling_.data(), 0, sizeof(f_t) * primal_size_h_, stream_view_));
+    iteration_variable_scaling_.data(), 0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
 
   // Inf-norm over rows and columns. Split into two kernels so the distributed path can
   // touch only owned entries.
@@ -243,14 +243,14 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::ruiz_iter_local()
   i_t number_of_blocks = op_problem_scaled_.n_constraints / block_size;
   if (op_problem_scaled_.n_constraints % block_size) number_of_blocks++;
   i_t number_of_threads = std::min(op_problem_scaled_.n_variables, (i_t)block_size);
-  inf_norm_row_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_>>>(
+  inf_norm_row_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_.get()>>>(
     op_problem_scaled_.view(), this->view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   i_t number_of_blocks_col = op_problem_scaled_.n_variables / block_size;
   if (op_problem_scaled_.n_variables % block_size) number_of_blocks_col++;
   i_t number_of_threads_col = std::min(op_problem_scaled_.n_constraints, (i_t)block_size);
-  inf_norm_col_kernel<i_t, f_t><<<number_of_blocks_col, number_of_threads_col, 0, stream_view_>>>(
+  inf_norm_col_kernel<i_t, f_t><<<number_of_blocks_col, number_of_threads_col, 0, stream_view_.get()>>>(
     op_problem_scaled_.view(), this->view(), A_T_.data(), A_T_offsets_.data(), A_T_indices_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -263,14 +263,14 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::ruiz_iter_local()
                          iteration_constraint_matrix_scaling_.data(),
                          dual_size_h_,
                          a_divides_sqrt_b_bounded<f_t>(),
-                         stream_view_);
+                         stream_view_.get());
 
   raft::linalg::binaryOp(cummulative_variable_scaling_.data(),
                          cummulative_variable_scaling_.data(),
                          iteration_variable_scaling_.data(),
                          primal_size_h_,
                          a_divides_sqrt_b_bounded<f_t>(),
-                         stream_view_);
+                         stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -379,9 +379,9 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::pock_chambolle_scaling(f_t alpha
 {
   // Reset the iteration_scaling vectors to all 0
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_));
+    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_));
+    iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
 
   EXE_CUOPT_EXPECTS(
     alpha >= 0.0 && alpha <= 2.0,
@@ -396,13 +396,13 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::pock_chambolle_scaling(f_t alpha
 
   constexpr i_t number_of_threads = 128;
   pock_chambolle_scaling_kernel_row<i_t, f_t, number_of_threads>
-    <<<op_problem_scaled_.n_constraints, number_of_threads, 0, stream_view_>>>(
+    <<<op_problem_scaled_.n_constraints, number_of_threads, 0, stream_view_.get()>>>(
       op_problem_scaled_.view(), alpha, this->view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Use transposed matrix instead to compute column-wise more easily
   pock_chambolle_scaling_kernel_col<i_t, f_t, number_of_threads>
-    <<<op_problem_scaled_.n_variables, number_of_threads, 0, stream_view_>>>(
+    <<<op_problem_scaled_.n_variables, number_of_threads, 0, stream_view_.get()>>>(
       op_problem_scaled_.view(),
       alpha,
       this->view(),
@@ -420,13 +420,13 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::pock_chambolle_scaling(f_t alpha
                          iteration_constraint_matrix_scaling_.data(),
                          dual_size_h_,
                          a_divides_sqrt_b_bounded<f_t>(),
-                         stream_view_);
+                         stream_view_.get());
   raft::linalg::binaryOp(cummulative_variable_scaling_.data(),
                          cummulative_variable_scaling_.data(),
                          iteration_variable_scaling_.data(),
                          primal_size_h_,
                          a_divides_sqrt_b_bounded<f_t>(),
-                         stream_view_);
+                         stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -516,7 +516,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::swap_context(
   const auto [grid_size, block_size] =
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   scaling_swap_rescaling_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(thrust::raw_pointer_cast(swap_pairs.data()),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
                                                  static_cast<i_t>(swap_pairs.size()),
                                                  make_span(bound_rescaling_),
                                                  make_span(objective_rescaling_));
@@ -553,7 +553,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
   i_t number_of_blocks = op_problem_scaled_.n_constraints / block_size;
   if (op_problem_scaled_.n_constraints % block_size) number_of_blocks++;
   i_t number_of_threads = std::min(op_problem_scaled_.n_variables, block_size);
-  scale_problem_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_>>>(
+  scale_problem_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_.get()>>>(
     this->view(), op_problem_scaled_.view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -563,7 +563,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
   i_t number_of_threads_transposed = std::min(op_problem_scaled_.n_constraints, block_size);
 
   scale_transposed_problem_kernel<i_t, f_t>
-    <<<number_of_blocks_transposed, number_of_threads_transposed, 0, stream_view_>>>(
+    <<<number_of_blocks_transposed, number_of_threads_transposed, 0, stream_view_.get()>>>(
       this->view(), A_T_.data(), A_T_offsets_.data(), A_T_indices_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 

--- a/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
+++ b/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
@@ -574,7 +574,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
     op_problem_scaled_.objective_coefficients.data(),
     op_problem_scaled_.objective_coefficients.size(),
     cuda::std::multiplies<f_t>{},
-    stream_view_);
+    stream_view_.get());
 
   using f_t2 = typename type_2<f_t>::type;
   cub::DeviceTransform::Transform(
@@ -599,7 +599,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
         if (s != f_t(0)) { return {lower / s, upper / s}; }
         return {lower, upper};
       },
-      stream_view_);
+      stream_view_.get());
   }
 
   cub::DeviceTransform::Transform(
@@ -608,14 +608,14 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
     op_problem_scaled_.constraint_lower_bounds.data(),
     op_problem_scaled_.constraint_lower_bounds.size(),
     cuda::std::multiplies<f_t>{},
-    stream_view_);
+    stream_view_.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(op_problem_scaled_.constraint_upper_bounds.data(),
                           problem_wrap_container(cummulative_constraint_matrix_scaling_)),
     op_problem_scaled_.constraint_upper_bounds.data(),
     op_problem_scaled_.constraint_upper_bounds.size(),
     cuda::std::multiplies<f_t>{},
-    stream_view_);
+    stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
   print("constraint_lower_bound", op_problem_scaled_.constraint_lower_bounds);
@@ -679,7 +679,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_bound_objective_rescaling_
       [bound_rescaling = bound_rescaling_.data()] __device__(f_t2 variable_bounds) -> f_t2 {
         return {variable_bounds.x * *bound_rescaling, variable_bounds.y * *bound_rescaling};
       },
-      stream_view_);
+      stream_view_.get());
   }
 
   cub::DeviceTransform::Transform(
@@ -735,7 +735,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
       primal_solution.data(),
       primal_solution.size(),
       batch_safe_div<f_t>(),
-      stream_view_);
+      stream_view_.get());
 
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
@@ -744,7 +744,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
         primal_solution.data(),
         primal_solution.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 
@@ -762,7 +762,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
       dual_solution.data(),
       dual_solution.size(),
       batch_safe_div<f_t>(),
-      stream_view_);
+      stream_view_.get());
 
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
@@ -771,7 +771,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
         dual_solution.data(),
         dual_solution.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 
@@ -789,7 +789,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
       dual_slack.data(),
       dual_slack.size(),
       cuda::std::multiplies<>{},
-      stream_view_);
+      stream_view_.get());
 
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
@@ -798,7 +798,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::scale_solutions(
         dual_slack.data(),
         dual_slack.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 }
@@ -857,7 +857,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
       primal_solution.data(),
       primal_solution.size(),
       cuda::std::multiplies<>{},
-      stream_view_);
+      stream_view_.get());
 
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
@@ -868,7 +868,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
         primal_solution.data(),
         primal_solution.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 
@@ -887,7 +887,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
       dual_solution.data(),
       dual_solution.size(),
       cuda::std::multiplies<>{},
-      stream_view_);
+      stream_view_.get());
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
         cuda::std::make_tuple(dual_solution.data(),
@@ -897,7 +897,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
         dual_solution.data(),
         dual_solution.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 
@@ -914,7 +914,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
       dual_slack.data(),
       dual_slack.size(),
       batch_safe_div<f_t>(),
-      stream_view_);
+      stream_view_.get());
     if (hyper_params_.bound_objective_rescaling && !running_mip_) {
       cub::DeviceTransform::Transform(
         cuda::std::make_tuple(dual_slack.data(),
@@ -924,7 +924,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::unscale_solutions(
         dual_slack.data(),
         dual_slack.size(),
         cuda::std::multiplies<f_t>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 }

--- a/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
+++ b/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
@@ -101,8 +101,10 @@ pdlp_initial_scaling_strategy_t<i_t, f_t>::pdlp_initial_scaling_strategy_t(
   cuopt_assert(original_batch_size_ > 0, "Original batch size must be positive");
 
   // start with all one for scaling vectors
-  RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(iteration_constraint_matrix_scaling_.data(),
+                                0.0,
+                                sizeof(f_t) * dual_size_h_,
+                                stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
   thrust::fill(handle_ptr_->get_thrust_policy(),
@@ -231,8 +233,10 @@ template <typename i_t, typename f_t>
 void pdlp_initial_scaling_strategy_t<i_t, f_t>::ruiz_iter_local()
 {
   // Reset the iteration_scaling vectors to all 0
-  RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(iteration_constraint_matrix_scaling_.data(),
+                                0,
+                                sizeof(f_t) * dual_size_h_,
+                                stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     iteration_variable_scaling_.data(), 0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
 
@@ -250,8 +254,13 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::ruiz_iter_local()
   i_t number_of_blocks_col = op_problem_scaled_.n_variables / block_size;
   if (op_problem_scaled_.n_variables % block_size) number_of_blocks_col++;
   i_t number_of_threads_col = std::min(op_problem_scaled_.n_constraints, (i_t)block_size);
-  inf_norm_col_kernel<i_t, f_t><<<number_of_blocks_col, number_of_threads_col, 0, stream_view_.get()>>>(
-    op_problem_scaled_.view(), this->view(), A_T_.data(), A_T_offsets_.data(), A_T_indices_.data());
+  inf_norm_col_kernel<i_t, f_t>
+    <<<number_of_blocks_col, number_of_threads_col, 0, stream_view_.get()>>>(
+      op_problem_scaled_.view(),
+      this->view(),
+      A_T_.data(),
+      A_T_offsets_.data(),
+      A_T_indices_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   if (running_mip_) { reset_integer_variables(); }
@@ -378,8 +387,10 @@ template <typename i_t, typename f_t>
 void pdlp_initial_scaling_strategy_t<i_t, f_t>::pock_chambolle_scaling(f_t alpha)
 {
   // Reset the iteration_scaling vectors to all 0
-  RAFT_CUDA_TRY(cudaMemsetAsync(
-    iteration_constraint_matrix_scaling_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(iteration_constraint_matrix_scaling_.data(),
+                                0.0,
+                                sizeof(f_t) * dual_size_h_,
+                                stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     iteration_variable_scaling_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
 
@@ -517,9 +528,9 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::swap_context(
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   scaling_swap_rescaling_kernel<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
-                                                 static_cast<i_t>(swap_pairs.size()),
-                                                 make_span(bound_rescaling_),
-                                                 make_span(objective_rescaling_));
+                                                       static_cast<i_t>(swap_pairs.size()),
+                                                       make_span(bound_rescaling_),
+                                                       make_span(objective_rescaling_));
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   for (const auto& pair : swap_pairs) {

--- a/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
+++ b/cpp/src/pdlp/initial_scaling_strategy/initial_scaling.cu
@@ -583,7 +583,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_cummulative_scaling_to_pro
     op_problem_scaled_.variable_bounds.data(),
     op_problem_scaled_.variable_bounds.size(),
     divide_check_zero<f_t, f_t2>(),
-    stream_view_.value());
+    stream_view_.get());
 
   if (pdhg_solver_ptr_ && pdhg_solver_ptr_->get_new_bounds_idx().size() != 0) {
     cub::DeviceTransform::Transform(
@@ -662,7 +662,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_bound_objective_rescaling_
                   f_t bound_rescaling) -> thrust::tuple<f_t, f_t> {
       return {constraint_lower_bound * bound_rescaling, constraint_upper_bound * bound_rescaling};
     },
-    stream_view_.value());
+    stream_view_.get());
 
   // In batch mode we don't scale the variable bounds (here) because they are shared across
   // climbers. While the variable bounds are the same across climbers, there can be different
@@ -688,7 +688,7 @@ void pdlp_initial_scaling_strategy_t<i_t, f_t>::apply_bound_objective_rescaling_
     op_problem_scaled_.objective_coefficients.data(),
     op_problem_scaled_.objective_coefficients.size(),
     cuda::std::multiplies<f_t>{},
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/optimal_batch_size_handler/optimal_batch_size_handler.cu
+++ b/cpp/src/pdlp/optimal_batch_size_handler/optimal_batch_size_handler.cu
@@ -240,7 +240,7 @@ int optimal_batch_size_handler(const optimization_problem_t<i_t, f_t>& op_proble
   i_t dual_size            = problem.n_constraints;
 
   // Sync before starting anything to make sure everything is done
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 
   // Evaluate current, left and right nodes to pick a direction
 

--- a/cpp/src/pdlp/optimal_batch_size_handler/optimal_batch_size_handler.cu
+++ b/cpp/src/pdlp/optimal_batch_size_handler/optimal_batch_size_handler.cu
@@ -62,7 +62,7 @@ struct SpMM_benchmarks_context_t {
       y_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &buffer_size_non_transpose_batch,
-      stream_view));
+      stream_view.get()));
 
     size_t buffer_size_transpose_batch = 0;
     RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm_bufferSize(
@@ -76,7 +76,7 @@ struct SpMM_benchmarks_context_t {
       x_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &buffer_size_transpose_batch,
-      stream_view));
+      stream_view.get()));
 
     buffer_transpose_batch     = rmm::device_buffer(buffer_size_transpose_batch, stream_view);
     buffer_non_transpose_batch = rmm::device_buffer(buffer_size_non_transpose_batch, stream_view);
@@ -94,7 +94,7 @@ struct SpMM_benchmarks_context_t {
       x_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       buffer_transpose_batch.data(),
-      stream_view);
+      stream_view.get());
 
     my_cusparsespmm_preprocess<f_t>(
       handle_ptr->get_cusparse_handle(),
@@ -107,7 +107,7 @@ struct SpMM_benchmarks_context_t {
       y_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       buffer_non_transpose_batch.data(),
-      stream_view);
+      stream_view.get());
 #endif
 
     // First empty run for warm up
@@ -129,7 +129,7 @@ struct SpMM_benchmarks_context_t {
       y_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       (f_t*)buffer_non_transpose_batch.data(),
-      stream_view));
+      stream_view.get()));
 
     RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm(
       handle_ptr->get_cusparse_handle(),
@@ -142,7 +142,7 @@ struct SpMM_benchmarks_context_t {
       x_descr.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       (f_t*)buffer_transpose_batch.data(),
-      stream_view));
+      stream_view.get()));
   }
 
   cusparse_dn_mat_uptr x_descr;
@@ -240,7 +240,7 @@ int optimal_batch_size_handler(const optimization_problem_t<i_t, f_t>& op_proble
   i_t dual_size            = problem.n_constraints;
 
   // Sync before starting anything to make sure everything is done
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 
   // Evaluate current, left and right nodes to pick a direction
 

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -1577,43 +1577,43 @@ optimization_problem_t<i_t, other_f_t> optimization_problem_t<i_t, f_t>::convert
                                     static_cast<i_t>(A_indices_.size()),
                                     A_offsets_.data(),
                                     static_cast<i_t>(A_offsets_.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (c_.size() > 0) {
     auto other_c = gpu_cast<f_t, other_f_t>(c_, stream);
     other.set_objective_coefficients(other_c.data(), static_cast<i_t>(other_c.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (b_.size() > 0) {
     auto other_b = gpu_cast<f_t, other_f_t>(b_, stream);
     other.set_constraint_bounds(other_b.data(), static_cast<i_t>(other_b.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (constraint_lower_bounds_.size() > 0) {
     auto other_clb = gpu_cast<f_t, other_f_t>(constraint_lower_bounds_, stream);
     other.set_constraint_lower_bounds(other_clb.data(), static_cast<i_t>(other_clb.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (constraint_upper_bounds_.size() > 0) {
     auto other_cub = gpu_cast<f_t, other_f_t>(constraint_upper_bounds_, stream);
     other.set_constraint_upper_bounds(other_cub.data(), static_cast<i_t>(other_cub.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (variable_lower_bounds_.size() > 0) {
     auto other_vlb = gpu_cast<f_t, other_f_t>(variable_lower_bounds_, stream);
     other.set_variable_lower_bounds(other_vlb.data(), static_cast<i_t>(other_vlb.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (variable_upper_bounds_.size() > 0) {
     auto other_vub = gpu_cast<f_t, other_f_t>(variable_upper_bounds_, stream);
     other.set_variable_upper_bounds(other_vub.data(), static_cast<i_t>(other_vub.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   }
 
   if (variable_types_.size() > 0) {

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -1577,43 +1577,43 @@ optimization_problem_t<i_t, other_f_t> optimization_problem_t<i_t, f_t>::convert
                                     static_cast<i_t>(A_indices_.size()),
                                     A_offsets_.data(),
                                     static_cast<i_t>(A_offsets_.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (c_.size() > 0) {
     auto other_c = gpu_cast<f_t, other_f_t>(c_, stream);
     other.set_objective_coefficients(other_c.data(), static_cast<i_t>(other_c.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (b_.size() > 0) {
     auto other_b = gpu_cast<f_t, other_f_t>(b_, stream);
     other.set_constraint_bounds(other_b.data(), static_cast<i_t>(other_b.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (constraint_lower_bounds_.size() > 0) {
     auto other_clb = gpu_cast<f_t, other_f_t>(constraint_lower_bounds_, stream);
     other.set_constraint_lower_bounds(other_clb.data(), static_cast<i_t>(other_clb.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (constraint_upper_bounds_.size() > 0) {
     auto other_cub = gpu_cast<f_t, other_f_t>(constraint_upper_bounds_, stream);
     other.set_constraint_upper_bounds(other_cub.data(), static_cast<i_t>(other_cub.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (variable_lower_bounds_.size() > 0) {
     auto other_vlb = gpu_cast<f_t, other_f_t>(variable_lower_bounds_, stream);
     other.set_variable_lower_bounds(other_vlb.data(), static_cast<i_t>(other_vlb.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (variable_upper_bounds_.size() > 0) {
     auto other_vub = gpu_cast<f_t, other_f_t>(variable_upper_bounds_, stream);
     other.set_variable_upper_bounds(other_vub.data(), static_cast<i_t>(other_vub.size()));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   }
 
   if (variable_types_.size() > 0) {

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -1543,7 +1543,7 @@ rmm::device_uvector<To> gpu_cast(const rmm::device_uvector<From>& src, rmm::cuda
   rmm::device_uvector<To> dst(src.size(), stream);
   if (src.size() > 0) {
     RAFT_CUDA_TRY(cub::DeviceTransform::Transform(
-      src.data(), dst.data(), src.size(), cast_op<From, To>{}, stream.value()));
+      src.data(), dst.data(), src.size(), cast_op<From, To>{}, stream.get()));
   }
   return dst;
 }

--- a/cpp/src/pdlp/pdhg.cu
+++ b/cpp/src/pdlp/pdhg.cu
@@ -191,7 +191,7 @@ new_bounds_groups_t<i_t, f_t> copy_new_bounds_to_groups(
     raft::copy(h_idx.data(), new_bounds_idx.data(), n_entries, stream_view);
     raft::copy(h_lower.data(), new_bounds_lower.data(), n_entries, stream_view);
     raft::copy(h_upper.data(), new_bounds_upper.data(), n_entries, stream_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+    stream_view.sync();
   }
 
   new_bounds_groups_t<i_t, f_t> groups(batch_size);

--- a/cpp/src/pdlp/pdhg.cu
+++ b/cpp/src/pdlp/pdhg.cu
@@ -191,7 +191,7 @@ new_bounds_groups_t<i_t, f_t> copy_new_bounds_to_groups(
     raft::copy(h_idx.data(), new_bounds_idx.data(), n_entries, stream_view);
     raft::copy(h_lower.data(), new_bounds_lower.data(), n_entries, stream_view);
     raft::copy(h_upper.data(), new_bounds_upper.data(), n_entries, stream_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   }
 
   new_bounds_groups_t<i_t, f_t> groups(batch_size);
@@ -411,7 +411,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_dual_solution(rmm::device_uvector<f_t
                            cusparse_view_.dual_gradient.get(),
                            CUSPARSE_SPMV_CSR_ALG2,
                            cusparse_view_.buffer_non_transpose_mixed_.data(),
-                           stream_view_);
+                           stream_view_.get());
     }
   }
   if (!cusparse_view_.mixed_precision_enabled_) {
@@ -425,7 +425,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_dual_solution(rmm::device_uvector<f_t
                                          cusparse_view_.dual_gradient.get(),
                                          CUSPARSE_SPMV_CSR_ALG2,
                                          (f_t*)cusparse_view_.buffer_non_transpose.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
   }
 
   // y - (sigma*dual_gradient)
@@ -473,7 +473,7 @@ void pdhg_solver_t<i_t, f_t>::spmvop_At_y()
                                                        cusparse_view_.current_AtY.get(),
                                                        CUSPARSE_SPMV_CSR_ALG2,
                                                        (f_t*)cusparse_view_.buffer_transpose.data(),
-                                                       stream_view_));
+                                                       stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -502,7 +502,7 @@ void pdhg_solver_t<i_t, f_t>::spmvop_A_x()
                                        cusparse_view_.dual_gradient.get(),
                                        CUSPARSE_SPMV_CSR_ALG2,
                                        (f_t*)cusparse_view_.buffer_non_transpose.data(),
-                                       stream_view_));
+                                       stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -529,7 +529,7 @@ void pdhg_solver_t<i_t, f_t>::compute_At_y()
                              cusparse_view_.current_AtY.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              cusparse_view_.buffer_transpose_mixed_.data(),
-                             stream_view_);
+                             stream_view_.get());
       } else {
         spmvop_At_y();
       }
@@ -544,7 +544,7 @@ void pdhg_solver_t<i_t, f_t>::compute_At_y()
                                            cusparse_view_.current_AtY.get(),
                                            CUSPARSE_SPMV_CSR_ALG2,
                                            (f_t*)cusparse_view_.buffer_transpose.data(),
-                                           stream_view_));
+                                           stream_view_.get()));
     }
   } else {
     RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm(
@@ -558,7 +558,7 @@ void pdhg_solver_t<i_t, f_t>::compute_At_y()
       cusparse_view_.batch_current_AtYs.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       (f_t*)cusparse_view_.buffer_transpose_batch_row_row_.data(),
-      stream_view_));
+      stream_view_.get()));
   }
 }
 
@@ -587,7 +587,7 @@ void pdhg_solver_t<i_t, f_t>::compute_A_x()
                              cusparse_view_.dual_gradient.get(),
                              CUSPARSE_SPMV_CSR_ALG2,
                              cusparse_view_.buffer_non_transpose_mixed_.data(),
-                             stream_view_);
+                             stream_view_.get());
       } else {
         spmvop_A_x();
       }
@@ -602,7 +602,7 @@ void pdhg_solver_t<i_t, f_t>::compute_A_x()
                                            cusparse_view_.dual_gradient.get(),
                                            CUSPARSE_SPMV_CSR_ALG2,
                                            (f_t*)cusparse_view_.buffer_non_transpose.data(),
-                                           stream_view_));
+                                           stream_view_.get()));
     }
   } else {
     RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm(
@@ -616,7 +616,7 @@ void pdhg_solver_t<i_t, f_t>::compute_A_x()
       cusparse_view_.batch_dual_gradients.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       (f_t*)cusparse_view_.buffer_non_transpose_batch_row_row_.data(),
-      stream_view_));
+      stream_view_.get()));
   }
 }
 
@@ -636,7 +636,7 @@ void pdhg_solver_t<i_t, f_t>::spmv_At_into(cusparseDnVecDescr_t in_desc,
                                                        out_desc,
                                                        CUSPARSE_SPMV_CSR_ALG2,
                                                        (f_t*)cusparse_view_.buffer_transpose.data(),
-                                                       stream_view_));
+                                                       stream_view_.get()));
 }
 
 // out_desc = A @ in_desc, the counterpart of spmv_At_into on this shard's local A.
@@ -654,7 +654,7 @@ void pdhg_solver_t<i_t, f_t>::spmv_A_into(cusparseDnVecDescr_t in_desc,
                                        out_desc,
                                        CUSPARSE_SPMV_CSR_ALG2,
                                        (f_t*)cusparse_view_.buffer_non_transpose.data(),
-                                       stream_view_));
+                                       stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/pdhg.cu
+++ b/cpp/src/pdlp/pdhg.cu
@@ -445,7 +445,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_dual_solution(rmm::device_uvector<f_t
                               current_saddle_point_state_.get_delta_dual().data()),
     dual_size_h_,
     dual_projection<f_t>(dual_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -460,7 +460,7 @@ void pdhg_solver_t<i_t, f_t>::spmvop_At_y()
                         cusparse_view_.dual_solution.get(),
                         cusparse_view_.current_AtY.get(),
                         cusparse_view_.current_AtY.get(),
-                        stream_view_.value());
+                        stream_view_.get());
     return;
   }
 #endif
@@ -488,7 +488,7 @@ void pdhg_solver_t<i_t, f_t>::spmvop_A_x()
                         cusparse_view_.reflected_primal_solution.get(),
                         cusparse_view_.dual_gradient.get(),
                         cusparse_view_.dual_gradient.get(),
-                        stream_view_.value());
+                        stream_view_.get());
     return;
   }
 #endif
@@ -678,7 +678,7 @@ void pdhg_solver_t<i_t, f_t>::compute_primal_projection_with_gradient(
                               tmp_primal_.data()),
     primal_size_h_,
     primal_projection<f_t, f_t2>(primal_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -764,7 +764,7 @@ void pdhg_solver_t<i_t, f_t>::primal_reflected_major_projection_transform(
       potential_next_primal_solution_.data(), dual_slack_.data(), reflected_primal_.data()),
     primal_size_h_,
     primal_reflected_major_projection<f_t>(primal_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename f_t>
@@ -807,7 +807,7 @@ void pdhg_solver_t<i_t, f_t>::primal_reflected_projection_transform(
     reflected_primal_.data(),
     primal_size_h_,
     primal_reflected_projection<f_t>(primal_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename f_t>
@@ -851,7 +851,7 @@ void pdhg_solver_t<i_t, f_t>::dual_reflected_major_projection_transform(
     thrust::make_zip_iterator(potential_next_dual_solution_.data(), reflected_dual_.data()),
     dual_size_h_,
     dual_reflected_major_projection<f_t>(dual_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename f_t>
@@ -894,7 +894,7 @@ void pdhg_solver_t<i_t, f_t>::dual_reflected_projection_transform(
     reflected_dual_.data(),
     dual_size_h_,
     dual_reflected_projection<f_t>(dual_step_size.data()),
-    stream_view_.value());
+    stream_view_.get());
 }
 
 template <typename f_t>
@@ -1217,7 +1217,7 @@ void pdhg_solver_t<i_t, f_t>::refine_initial_primal_projection(
                          make_span(bound_rescaling),
                          make_span(current_saddle_point_state_.get_primal_solution()),
                          problem_ptr->n_variables},
-                       stream_view_.value());
+                       stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -1265,7 +1265,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             reflected_primal_.data(),
             batch_size_divisor_,
             problem_ptr->objective_coefficients.size() > static_cast<size_t>(primal_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
       if (new_bounds_idx_.size() != 0) {
 #ifdef CUPDLP_DEBUG_MODE
@@ -1297,7 +1297,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             make_span(reflected_primal_),
             (int)climber_strategies_.size(),
             problem_ptr->objective_coefficients.size() > static_cast<size_t>(primal_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
 #ifdef CUPDLP_DEBUG_MODE
       print("potential_next_primal_solution_", potential_next_primal_solution_);
@@ -1329,7 +1329,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             reflected_dual_.data(),
             batch_size_divisor_,
             problem_ptr->constraint_lower_bounds.size() > static_cast<size_t>(dual_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
 
 #ifdef CUPDLP_DEBUG_MODE
@@ -1380,7 +1380,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             reflected_primal_.data(),
             (int)climber_strategies_.size(),
             problem_ptr->objective_coefficients.size() > static_cast<size_t>(primal_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
       if (new_bounds_idx_.size() != 0) {
 #ifdef CUPDLP_DEBUG_MODE
@@ -1410,7 +1410,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             make_span(reflected_primal_),
             (int)climber_strategies_.size(),
             problem_ptr->objective_coefficients.size() > static_cast<size_t>(primal_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
 #ifdef CUPDLP_DEBUG_MODE
       print("reflected_primal_", reflected_primal_);
@@ -1445,7 +1445,7 @@ void pdhg_solver_t<i_t, f_t>::compute_next_primal_dual_solution_reflected(
             reflected_dual_.data(),
             (int)climber_strategies_.size(),
             problem_ptr->constraint_lower_bounds.size() > static_cast<size_t>(dual_size_h_)},
-          stream_view_.value());
+          stream_view_.get());
       }
 #ifdef CUPDLP_DEBUG_MODE
       print("reflected_dual_", reflected_dual_);

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -945,7 +945,7 @@ template <typename i_t, typename f_t>
 optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::finalize_batch_return()
 {
   current_termination_strategy_.fill_gpu_terms_stats(total_pdlp_iterations_);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   current_termination_strategy_.convert_gpu_terms_stats_to_host(
     batch_solution_to_return_.get_additional_termination_informations());
   return optimization_problem_solution_t<i_t, f_t>{
@@ -1086,7 +1086,7 @@ pdlp_solver_t<i_t, f_t>::check_batch_termination(const timer_t& timer)
         sb_view_.mark_solved(climber_strategies_[i].original_index);
       }
     }
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
     return current_termination_strategy_.fill_return_problem_solution(
       internal_solver_iterations_,
       pdhg_solver_,
@@ -1484,11 +1484,11 @@ static void compute_stats(const rmm::device_uvector<f_t>& vec,
                                           n,
                                           cuda::minimum<>{},
                                           std::numeric_limits<f_t>::max(),
-                                          stream));
+                                          stream.get()));
   RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    d_temp, bytes_2, abs_iter, d_largest.data(), n, cuda::maximum<>{}, f_t(0), stream));
+    d_temp, bytes_2, abs_iter, d_largest.data(), n, cuda::maximum<>{}, f_t(0), stream.get()));
   RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    d_temp, bytes_3, abs_iter, d_sum.data(), n, cuda::std::plus<>{}, f_t(0), stream));
+    d_temp, bytes_3, abs_iter, d_sum.data(), n, cuda::std::plus<>{}, f_t(0), stream.get()));
 
   size_t max_bytes = std::max({bytes_1, bytes_2, bytes_3});
   rmm::device_buffer temp_buf(max_bytes, stream);
@@ -1500,11 +1500,11 @@ static void compute_stats(const rmm::device_uvector<f_t>& vec,
                                           n,
                                           cuda::minimum<>{},
                                           std::numeric_limits<f_t>::max(),
-                                          stream));
+                                          stream.get()));
   RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    temp_buf.data(), bytes_2, abs_iter, d_largest.data(), n, cuda::maximum<>{}, f_t(0), stream));
+    temp_buf.data(), bytes_2, abs_iter, d_largest.data(), n, cuda::maximum<>{}, f_t(0), stream.get()));
   RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    temp_buf.data(), bytes_3, abs_iter, d_sum.data(), n, cuda::std::plus<>{}, f_t(0), stream));
+    temp_buf.data(), bytes_3, abs_iter, d_sum.data(), n, cuda::std::plus<>{}, f_t(0), stream.get()));
 
   smallest = d_smallest.value(stream);
   largest  = d_largest.value(stream);
@@ -1628,7 +1628,7 @@ void pdlp_solver_t<i_t, f_t>::update_primal_dual_solutions(
       RAFT_CUDA_TRY(cudaMemsetAsync(saddle.get_current_AtY().data(),
                                     f_t(0.0),
                                     sizeof(f_t) * saddle.get_current_AtY().size(),
-                                    stream_view_));
+                                    stream_view_.get()));
 
       // Scale if should compute initial step size after scaling
       if (!settings_.hyper_params.compute_initial_step_size_before_scaling) {
@@ -1797,7 +1797,7 @@ void pdlp_solver_t<i_t, f_t>::swap_context(
   const auto [grid_size, block_size] =
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   pdlp_swap_device_vectors_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(thrust::raw_pointer_cast(swap_pairs.data()),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
                                                  static_cast<i_t>(swap_pairs.size()),
                                                  make_span(primal_weight_),
                                                  make_span(best_primal_weight_),
@@ -1862,7 +1862,7 @@ void pdlp_solver_t<i_t, f_t>::swap_all_context(
     host_vector_swap(climber_strategies_, pair.left, pair.right);
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -1881,7 +1881,7 @@ void pdlp_solver_t<i_t, f_t>::resize_all_context(i_t new_size)
   // Resize PDLP own context
   resize_context(new_size);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -2025,7 +2025,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
       pdhg_cusparse_view.batch_current_AtYs.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &new_buf_size,
-      stream_view_));
+      stream_view_.get()));
     pdhg_cusparse_view.buffer_transpose_batch_row_row_.resize(new_buf_size, stream_view_);
 
     // PDHG row-row: A * batch_reflected_primal_solutions -> batch_dual_gradients
@@ -2040,7 +2040,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
       pdhg_cusparse_view.batch_dual_gradients.get(),
       (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
       &new_buf_size,
-      stream_view_));
+      stream_view_.get()));
     pdhg_cusparse_view.buffer_non_transpose_batch_row_row_.resize(new_buf_size, stream_view_);
 
     // Adaptive step size: A_T * batch_potential_next_dual_solution -> batch_next_AtYs
@@ -2055,7 +2055,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
       pdhg_cusparse_view.batch_next_AtYs.get(),
       CUSPARSE_SPMM_CSR_ALG3,
       &new_buf_size,
-      stream_view_));
+      stream_view_.get()));
     pdhg_cusparse_view.buffer_transpose_batch.resize(new_buf_size, stream_view_);
 
     // Convergence info: A_T * batch_dual_solutions -> batch_tmp_primals
@@ -2070,7 +2070,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
       current_op_problem_evaluation_cusparse_view_.batch_tmp_primals.get(),
       CUSPARSE_SPMM_CSR_ALG3,
       &new_buf_size,
-      stream_view_));
+      stream_view_.get()));
     current_op_problem_evaluation_cusparse_view_.buffer_transpose_batch.resize(new_buf_size,
                                                                                stream_view_);
 
@@ -2086,7 +2086,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
       current_op_problem_evaluation_cusparse_view_.batch_tmp_duals.get(),
       CUSPARSE_SPMM_CSR_ALG3,
       &new_buf_size,
-      stream_view_));
+      stream_view_.get()));
     current_op_problem_evaluation_cusparse_view_.buffer_non_transpose_batch.resize(new_buf_size,
                                                                                    stream_view_);
   }
@@ -2106,7 +2106,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
     pdhg_cusparse_view.batch_current_AtYs.get(),
     (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
     pdhg_cusparse_view.buffer_transpose_batch_row_row_.data(),
-    stream_view_);
+    stream_view_.get());
   my_cusparsespmm_preprocess(
     handle_ptr_->get_cusparse_handle(),
     CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -2118,7 +2118,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
     pdhg_cusparse_view.batch_dual_gradients.get(),
     (deterministic_batch_pdlp) ? CUSPARSE_SPMM_CSR_ALG3 : CUSPARSE_SPMM_CSR_ALG2,
     pdhg_cusparse_view.buffer_non_transpose_batch_row_row_.data(),
-    stream_view_);
+    stream_view_.get());
 
   // Adaptive step size strategy SpMM preprocess
   my_cusparsespmm_preprocess(handle_ptr_->get_cusparse_handle(),
@@ -2131,7 +2131,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
                              pdhg_cusparse_view.batch_next_AtYs.get(),
                              CUSPARSE_SPMM_CSR_ALG3,
                              (f_t*)pdhg_cusparse_view.buffer_transpose_batch.data(),
-                             stream_view_);
+                             stream_view_.get());
 
   // Convergence information SpMM preprocess
   my_cusparsespmm_preprocess(
@@ -2145,7 +2145,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
     current_op_problem_evaluation_cusparse_view_.batch_tmp_primals.get(),
     CUSPARSE_SPMM_CSR_ALG3,
     (f_t*)current_op_problem_evaluation_cusparse_view_.buffer_transpose_batch.data(),
-    stream_view_);
+    stream_view_.get());
 
   my_cusparsespmm_preprocess(
     handle_ptr_->get_cusparse_handle(),
@@ -2158,7 +2158,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
     current_op_problem_evaluation_cusparse_view_.batch_tmp_duals.get(),
     CUSPARSE_SPMM_CSR_ALG3,
     (f_t*)current_op_problem_evaluation_cusparse_view_.buffer_non_transpose_batch.data(),
-    stream_view_);
+    stream_view_.get());
 #endif
 
   // Set PDHG graphs to uninitialized so that next call can start a new graph.
@@ -2168,7 +2168,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
   // graph_all_non_major (reflected non-major).
   pdhg_solver_.get_graph_all() = ping_pong_graph_t<i_t>(stream_view_, true);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 // delta = reflected - current, for both primal and dual, written into the
@@ -2285,7 +2285,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
   } else {
     // Sync to make sure all previous cuSparse operations are finished before setting the
     // potential_next_dual_solution
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 
     // Make potential_next_dual_solution point towards reflected dual solution to reuse the code
     RAFT_CUSPARSE_TRY(cusparseDnVecSetValues(cusparse_view.potential_next_dual_solution.get(),
@@ -2302,7 +2302,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
 
   if (batch_mode_) {
     const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
-    kernel_compute_fixed_error<f_t><<<grid_size, block_size, 0, stream_view_>>>(
+    kernel_compute_fixed_error<f_t><<<grid_size, block_size, 0, stream_view_.get()>>>(
       make_span(step_size_strategy_.get_norm_squared_delta_primal()),
       make_span(step_size_strategy_.get_norm_squared_delta_dual()),
       make_span(primal_weight_),
@@ -2310,7 +2310,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
       make_span(step_size_strategy_.get_interaction()),
       make_span(restart_strategy_.fixed_point_error_));
     RAFT_CUDA_TRY(cudaStreamSynchronize(
-      stream_view_));  // To make sure all the data is written from device to host
+      stream_view_.get()));  // To make sure all the data is written from device to host
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
 #ifdef CUPDLP_DEBUG_MODE
@@ -2327,7 +2327,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
 
   // Sync to make sure all previous cuSparse operations are finished before setting the
   // potential_next_dual_solution
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 
   // Put back, already done in multi-gpu side
   if (!is_distributed_master()) {
@@ -2388,10 +2388,10 @@ void pdlp_solver_t<i_t, f_t>::transpose_problem_fields(bool to_row)
                                  transposed.data(),
                                  *output_ld));
     raft::copy(field.data(), transposed.data(), field.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   };
 
-  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_));
+  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_.get()));
   // We need to swap the scaled version because they can be dynamically resized and swapped.
   transpose_field(op_problem_scaled_.objective_coefficients, primal_size_h_);
   transpose_field(op_problem_scaled_.constraint_lower_bounds, dual_size_h_);
@@ -2413,7 +2413,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_to_row(
   rmm::device_uvector<f_t> dual_slack_transposed(
     is_dual_slack_empty ? 0 : primal_size_h_ * climber_strategies_.size(), stream_view_);
 
-  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_));
+  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_.get()));
   CUBLAS_CHECK(cublasGeam<f_t>(handle_ptr_->get_cublas_handle(),
                                CUBLAS_OP_T,
                                CUBLAS_OP_N,
@@ -2476,7 +2476,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_to_row(
              dual_size_h_ * climber_strategies_.size(),
              stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -2492,7 +2492,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_back_to_col(
   rmm::device_uvector<f_t> dual_slack_transposed(
     is_dual_slack_empty ? 0 : primal_size_h_ * climber_strategies_.size(), stream_view_);
 
-  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_));
+  RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_.get()));
   CUBLAS_CHECK(cublasGeam<f_t>(handle_ptr_->get_cublas_handle(),
                                CUBLAS_OP_T,
                                CUBLAS_OP_N,
@@ -2556,7 +2556,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_back_to_col(
              dual_size_h_ * climber_strategies_.size(),
              stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -3325,7 +3325,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                               op_problem_scaled_.nnz,
                               red_op,
                               0.0,
-                              stream_view_);
+                              stream_view_.get());
     // Allocate temporary storage
     rmm::device_buffer cub_tmp{temp_storage_bytes, stream_view_};
     // Run max-reduction
@@ -3336,12 +3336,12 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                               op_problem_scaled_.nnz,
                               red_op,
                               0.0,
-                              stream_view_);
+                              stream_view_.get());
     raft::linalg::eltwiseDivideCheckZero(
-      step_size_.data(), step_size_.data(), abs_max_element.data(), 1, stream_view_);
+      step_size_.data(), step_size_.data(), abs_max_element.data(), 1, stream_view_.get());
 
     // Sync since we are using local variable
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   } else {
     i_t m = op_problem_scaled_.n_constraints;
     i_t n = op_problem_scaled_.n_variables;
@@ -3441,7 +3441,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
       handle_ptr_->get_thrust_policy(), step_size_.begin(), step_size_.end(), step_size);
 
     // Sync since we are using local variable
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecZ));
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecQ));
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecATQ));
@@ -3536,7 +3536,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_primal_weight()
 
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
   compute_weights_initial_primal_weight_from_squared_norms<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(b_vec_norm.data(),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(b_vec_norm.data(),
                                                  c_vec_norm.data(),
                                                  make_span(primal_weight_),
                                                  make_span(best_primal_weight_),
@@ -3545,7 +3545,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_primal_weight()
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Sync since we are using local variable
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -2182,13 +2182,13 @@ static void compute_primal_dual_deltas(pdhg_solver_t<i_t, f_t>& pdhg, rmm::cuda_
     pdhg.get_saddle_point_state().get_delta_primal().data(),
     pdhg.get_primal_solution().size(),
     cuda::std::minus<f_t>{},
-    stream);
+    stream.get());
   cub::DeviceTransform::Transform(
     cuda::std::make_tuple(pdhg.get_reflected_dual().data(), pdhg.get_dual_solution().data()),
     pdhg.get_saddle_point_state().get_delta_dual().data(),
     pdhg.get_dual_solution().size(),
     cuda::std::minus<f_t>{},
-    stream);
+    stream.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -2747,7 +2747,7 @@ optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::run_solver(co
           pdhg_solver_.get_primal_solution().data(),
           pdhg_solver_.get_primal_solution().size(),
           clamp<f_t, f_t2>(),
-          stream_view_.value());
+          stream_view_.get());
       } else {
         cub::DeviceTransform::Transform(
           cuda::std::make_tuple(pdhg_solver_.get_primal_solution().data(),
@@ -2755,7 +2755,7 @@ optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::run_solver(co
           pdhg_solver_.get_primal_solution().data(),
           pdhg_solver_.get_primal_solution().size(),
           clamp<f_t, f_t2>(),
-          stream_view_.value());
+          stream_view_.get());
       }
 
       pdhg_solver_.refine_initial_primal_projection(
@@ -2771,7 +2771,7 @@ optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::run_solver(co
           unscaled_primal_avg_solution_.data(),
           primal_size_h_,
           clamp<f_t, f_t2>(),
-          stream_view_.value());
+          stream_view_.get());
       }
     }
 
@@ -3191,7 +3191,7 @@ void pdlp_solver_t<i_t, f_t>::halpern_update()
                             (f_t(1.0) - reflection_coefficient) * current_primal;
       return weight * reflected + (f_t(1.0) - weight) * initial_primal;
     },
-    stream_view_.value());
+    stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
   print("pdhg_solver_.get_reflected_dual()", pdhg_solver_.get_reflected_dual());
@@ -3215,7 +3215,7 @@ void pdlp_solver_t<i_t, f_t>::halpern_update()
                             (f_t(1.0) - reflection_coefficient) * current_dual;
       return weight * reflected + (f_t(1.0) - weight) * initial_dual;
     },
-    stream_view_.value());
+    stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
   print("halpen_update current primal",
@@ -3384,7 +3384,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                                       d_q.data(),
                                       d_q.size(),
                                       divide_by_device_scalar_t<f_t>{norm_q.data()},
-                                      stream_view_.value());
+                                      stream_view_.get());
 
       // A_t_q = A_t @ d_q
       RAFT_CUSPARSE_TRY(
@@ -3397,7 +3397,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                                            vecATQ,
                                            CUSPARSE_SPMV_CSR_ALG2,
                                            (f_t*)cusparse_view_.buffer_transpose.data(),
-                                           stream_view_.value()));
+                                           stream_view_.get()));
 
       // z = A @ A_t_q
       RAFT_CUSPARSE_TRY(
@@ -3410,7 +3410,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                                            vecZ,
                                            CUSPARSE_SPMV_CSR_ALG2,
                                            (f_t*)cusparse_view_.buffer_non_transpose.data(),
-                                           stream_view_.value()));
+                                           stream_view_.get()));
       // sigma_max_sq = dot(q, z)
       RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
                                                       m,
@@ -3419,14 +3419,14 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
                                                       d_z.data(),
                                                       primal_stride,
                                                       sigma_max_sq.data(),
-                                                      stream_view_.value()));
+                                                      stream_view_.get()));
 
       // d_q := -sigma_max_sq * d_q + d_z
       cub::DeviceTransform::Transform(cuda::std::make_tuple(d_q.data(), d_z.data()),
                                       d_q.data(),
                                       d_q.size(),
                                       residual_fma_neg_scalar_t<f_t>{sigma_max_sq.data()},
-                                      stream_view_.value());
+                                      stream_view_.get());
 
       my_l2_norm<i_t, f_t>(d_q, residual_norm, handle_ptr_);
 

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -592,7 +592,7 @@ void pdlp_solver_t<i_t, f_t>::set_initial_primal_solution(
                                   initial_primal_.data(),
                                   initial_primal_.size(),
                                   cuda::std::identity{},
-                                  stream_view_);
+                                  stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -606,7 +606,7 @@ void pdlp_solver_t<i_t, f_t>::set_initial_dual_solution(
                                   initial_dual_.data(),
                                   initial_dual_.size(),
                                   cuda::std::identity{},
-                                  stream_view_);
+                                  stream_view_.get());
 }
 
 static bool time_limit_reached(const timer_t& timer) { return timer.check_time_limit(); }

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -945,7 +945,7 @@ template <typename i_t, typename f_t>
 optimization_problem_solution_t<i_t, f_t> pdlp_solver_t<i_t, f_t>::finalize_batch_return()
 {
   current_termination_strategy_.fill_gpu_terms_stats(total_pdlp_iterations_);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
   current_termination_strategy_.convert_gpu_terms_stats_to_host(
     batch_solution_to_return_.get_additional_termination_informations());
   return optimization_problem_solution_t<i_t, f_t>{
@@ -1086,7 +1086,7 @@ pdlp_solver_t<i_t, f_t>::check_batch_termination(const timer_t& timer)
         sb_view_.mark_solved(climber_strategies_[i].original_index);
       }
     }
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
     return current_termination_strategy_.fill_return_problem_solution(
       internal_solver_iterations_,
       pdhg_solver_,
@@ -1862,7 +1862,7 @@ void pdlp_solver_t<i_t, f_t>::swap_all_context(
     host_vector_swap(climber_strategies_, pair.left, pair.right);
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -1881,7 +1881,7 @@ void pdlp_solver_t<i_t, f_t>::resize_all_context(i_t new_size)
   // Resize PDLP own context
   resize_context(new_size);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -2168,7 +2168,7 @@ void pdlp_solver_t<i_t, f_t>::resize_and_swap_all_context_loop(
   // graph_all_non_major (reflected non-major).
   pdhg_solver_.get_graph_all() = ping_pong_graph_t<i_t>(stream_view_, true);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 // delta = reflected - current, for both primal and dual, written into the
@@ -2285,7 +2285,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
   } else {
     // Sync to make sure all previous cuSparse operations are finished before setting the
     // potential_next_dual_solution
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
 
     // Make potential_next_dual_solution point towards reflected dual solution to reuse the code
     RAFT_CUSPARSE_TRY(cusparseDnVecSetValues(cusparse_view.potential_next_dual_solution.get(),
@@ -2327,7 +2327,7 @@ void pdlp_solver_t<i_t, f_t>::compute_fixed_error(std::vector<int>& has_restarte
 
   // Sync to make sure all previous cuSparse operations are finished before setting the
   // potential_next_dual_solution
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 
   // Put back, already done in multi-gpu side
   if (!is_distributed_master()) {
@@ -2388,7 +2388,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_problem_fields(bool to_row)
                                  transposed.data(),
                                  *output_ld));
     raft::copy(field.data(), transposed.data(), field.size(), stream_view_);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   };
 
   RAFT_CUBLAS_TRY(cublasSetStream(handle_ptr_->get_cublas_handle(), stream_view_.get()));
@@ -2476,7 +2476,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_to_row(
              dual_size_h_ * climber_strategies_.size(),
              stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -2556,7 +2556,7 @@ void pdlp_solver_t<i_t, f_t>::transpose_primal_dual_back_to_col(
              dual_size_h_ * climber_strategies_.size(),
              stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -3341,7 +3341,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
       step_size_.data(), step_size_.data(), abs_max_element.data(), 1, stream_view_.get());
 
     // Sync since we are using local variable
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
   } else {
     i_t m = op_problem_scaled_.n_constraints;
     i_t n = op_problem_scaled_.n_variables;
@@ -3441,7 +3441,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_step_size()
       handle_ptr_->get_thrust_policy(), step_size_.begin(), step_size_.end(), step_size);
 
     // Sync since we are using local variable
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+    stream_view_.sync();
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecZ));
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecQ));
     RAFT_CUSPARSE_TRY(cusparseDestroyDnVec(vecATQ));
@@ -3545,7 +3545,7 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_primal_weight()
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Sync since we are using local variable
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/pdlp.cu
+++ b/cpp/src/pdlp/pdlp.cu
@@ -1501,10 +1501,22 @@ static void compute_stats(const rmm::device_uvector<f_t>& vec,
                                           cuda::minimum<>{},
                                           std::numeric_limits<f_t>::max(),
                                           stream.get()));
-  RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    temp_buf.data(), bytes_2, abs_iter, d_largest.data(), n, cuda::maximum<>{}, f_t(0), stream.get()));
-  RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(
-    temp_buf.data(), bytes_3, abs_iter, d_sum.data(), n, cuda::std::plus<>{}, f_t(0), stream.get()));
+  RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(temp_buf.data(),
+                                          bytes_2,
+                                          abs_iter,
+                                          d_largest.data(),
+                                          n,
+                                          cuda::maximum<>{},
+                                          f_t(0),
+                                          stream.get()));
+  RAFT_CUDA_TRY(cub::DeviceReduce::Reduce(temp_buf.data(),
+                                          bytes_3,
+                                          abs_iter,
+                                          d_sum.data(),
+                                          n,
+                                          cuda::std::plus<>{},
+                                          f_t(0),
+                                          stream.get()));
 
   smallest = d_smallest.value(stream);
   largest  = d_largest.value(stream);
@@ -1798,12 +1810,12 @@ void pdlp_solver_t<i_t, f_t>::swap_context(
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   pdlp_swap_device_vectors_kernel<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
-                                                 static_cast<i_t>(swap_pairs.size()),
-                                                 make_span(primal_weight_),
-                                                 make_span(best_primal_weight_),
-                                                 make_span(step_size_),
-                                                 make_span(primal_step_size_),
-                                                 make_span(dual_step_size_));
+                                                       static_cast<i_t>(swap_pairs.size()),
+                                                       make_span(primal_weight_),
+                                                       make_span(best_primal_weight_),
+                                                       make_span(step_size_),
+                                                       make_span(primal_step_size_),
+                                                       make_span(dual_step_size_));
   RAFT_CUDA_TRY(cudaPeekAtLastError());
   // Swap unscaled problem's per-climber fields (COL-major blocks)
   if (problem_ptr->objective_coefficients.size() > static_cast<size_t>(primal_size_h_)) {
@@ -3537,11 +3549,11 @@ void pdlp_solver_t<i_t, f_t>::compute_initial_primal_weight()
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
   compute_weights_initial_primal_weight_from_squared_norms<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(b_vec_norm.data(),
-                                                 c_vec_norm.data(),
-                                                 make_span(primal_weight_),
-                                                 make_span(best_primal_weight_),
-                                                 climber_strategies_.size(),
-                                                 settings_.hyper_params);
+                                                       c_vec_norm.data(),
+                                                       make_span(primal_weight_),
+                                                       make_span(best_primal_weight_),
+                                                       climber_strategies_.size(),
+                                                       settings_.hyper_params);
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   // Sync since we are using local variable

--- a/cpp/src/pdlp/pdlp_warm_start_data.cu
+++ b/cpp/src/pdlp/pdlp_warm_start_data.cu
@@ -11,6 +11,8 @@
 
 #include <mip_heuristics/mip_constants.hpp>
 
+#include <cuda/stream>
+
 #include <rmm/device_uvector.hpp>
 
 #include <raft/util/cudart_utils.hpp>
@@ -64,16 +66,23 @@ pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t(
 
 template <typename i_t, typename f_t>
 pdlp_warm_start_data_t<i_t, f_t>::pdlp_warm_start_data_t()
-  : current_primal_solution_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    current_dual_solution_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    initial_primal_average_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    initial_dual_average_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    current_ATY_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    sum_primal_solutions_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    sum_dual_solutions_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
+  : current_primal_solution_{rmm::device_uvector<f_t>(
+      0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    current_dual_solution_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    initial_primal_average_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    initial_dual_average_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    current_ATY_{rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    sum_primal_solutions_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    sum_dual_solutions_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
     last_restart_duality_gap_primal_solution_{
-      rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)},
-    last_restart_duality_gap_dual_solution_{rmm::device_uvector<f_t>(0, rmm::cuda_stream_default)}
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})},
+    last_restart_duality_gap_dual_solution_{
+      rmm::device_uvector<f_t>(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}})}
 {
 }
 

--- a/cpp/src/pdlp/restart_strategy/localized_duality_gap_container.cu
+++ b/cpp/src/pdlp/restart_strategy/localized_duality_gap_container.cu
@@ -52,11 +52,11 @@ localized_duality_gap_container_t<i_t, f_t>::localized_duality_gap_container_t(
   RAFT_CUDA_TRY(cudaMemsetAsync(primal_solution_.data(),
                                 f_t(0.0),
                                 sizeof(f_t) * primal_solution_.size(),
-                                handle_ptr->get_stream()));
+                                handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(dual_solution_.data(),
                                 f_t(0.0),
                                 sizeof(f_t) * dual_solution_.size(),
-                                handle_ptr->get_stream()));
+                                handle_ptr->get_stream().get()));
 }
 
 template <typename i_t, typename f_t>
@@ -96,7 +96,7 @@ void localized_duality_gap_container_t<i_t, f_t>::swap_context(
   const auto [grid_size, block_size] =
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   localized_duality_gap_swap_device_vectors_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, primal_solution_.stream()>>>(
+    <<<grid_size, block_size, 0, primal_solution_.stream().get()>>>(
       thrust::raw_pointer_cast(swap_pairs.data()),
       static_cast<i_t>(swap_pairs.size()),
       make_span(primal_distance_traveled_),

--- a/cpp/src/pdlp/restart_strategy/localized_duality_gap_container.hpp
+++ b/cpp/src/pdlp/restart_strategy/localized_duality_gap_container.hpp
@@ -13,7 +13,6 @@
 #include <raft/core/device_span.hpp>
 #include <raft/core/handle.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -1975,9 +1975,9 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
     high_radius_squared_.set_value_async(zero_float, stream_view_);
     low_radius_squared_.set_value_async(zero_float, stream_view_);
     RAFT_CUDA_TRY(cudaMemsetAsync(
-      direction_full_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_));
+      direction_full_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(
-      threshold_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_));
+      threshold_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_.get()));
     /* ----- */
 
     // Determine the direction which each component has moved and the threshold for when the

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -216,11 +216,11 @@ pdlp_restart_strategy_t<i_t, f_t>::pdlp_restart_strategy_t(
   RAFT_CUDA_TRY(cudaMemsetAsync(last_restart_duality_gap_.primal_solution_.data(),
                                 0.0,
                                 sizeof(f_t) * last_restart_duality_gap_.primal_solution_.size(),
-                                stream_view_));
+                                stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(last_restart_duality_gap_.dual_solution_.data(),
                                 0.0,
                                 sizeof(f_t) * last_restart_duality_gap_.dual_solution_.size(),
-                                stream_view_));
+                                stream_view_.get()));
 
   // Trigger the costly (costly for ms instances) GetDeviceProperty only if need trust region
   // restart
@@ -231,13 +231,13 @@ pdlp_restart_strategy_t<i_t, f_t>::pdlp_restart_strategy_t(
                            problem_ptr->constraint_upper_bounds.data(),
                            dual_size_h_,
                            transform_constraint_lower_bounds<f_t>(),
-                           stream_view_);
+                           stream_view_.get());
     raft::linalg::binaryOp(transformed_constraint_upper_bounds_.data(),
                            problem_ptr->constraint_lower_bounds.data(),
                            problem_ptr->constraint_upper_bounds.data(),
                            dual_size_h_,
                            transform_constraint_upper_bounds<f_t>(),
-                           stream_view_);
+                           stream_view_.get());
 
     // Check that device support CooperativeLaunch
     int dev                = 0;
@@ -287,7 +287,7 @@ pdlp_restart_strategy_t<i_t, f_t>::pdlp_restart_strategy_t(
       reusable_device_scalar_1_.data(),
       climber_strategies_.size(),
       primal_size_h_,
-      stream_view_);
+      stream_view_.get());
     dot_product_bytes = std::max(dot_product_bytes, byte_needed);
 
     cub::DeviceSegmentedReduce::Sum(
@@ -297,7 +297,7 @@ pdlp_restart_strategy_t<i_t, f_t>::pdlp_restart_strategy_t(
       reusable_device_scalar_1_.data(),
       climber_strategies_.size(),
       dual_size_h_,
-      stream_view_);
+      stream_view_.get());
     dot_product_bytes = std::max(dot_product_bytes, byte_needed);
 
     dot_product_storage.resize(dot_product_bytes, stream_view_);
@@ -351,12 +351,12 @@ bool pdlp_restart_strategy_t<i_t, f_t>::run_trust_region_restart(
                                        reusable_device_scalar_value_1_.data(),
                                        primal_step_size.data(),
                                        1,
-                                       stream_view_);
+                                       stream_view_.get());
   raft::linalg::eltwiseDivideCheckZero(dual_norm_weight_.data(),
                                        reusable_device_scalar_value_1_.data(),
                                        dual_step_size.data(),
                                        1,
-                                       stream_view_);
+                                       stream_view_.get());
 
   i_t restart = should_do_artificial_restart(total_number_of_iterations);
 
@@ -447,7 +447,7 @@ f_t pdlp_restart_strategy_t<i_t, f_t>::compute_kkt_score(
   const rmm::device_uvector<f_t>& gap,
   const rmm::device_uvector<f_t>& primal_weight)
 {
-  kernel_compute_kkt_score<f_t><<<1, 1, 0, stream_view_>>>(l2_primal_residual.data(),
+  kernel_compute_kkt_score<f_t><<<1, 1, 0, stream_view_.get()>>>(l2_primal_residual.data(),
                                                            l2_dual_residual.data(),
                                                            gap.data(),
                                                            primal_weight.data(),
@@ -928,10 +928,10 @@ void pdlp_restart_strategy_t<i_t, f_t>::cupdlpx_restart(
   if (batch_mode_) {
     const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
     kernel_compute_next_cupdlpx_primal_weight<i_t, f_t>
-      <<<grid_size, block_size, 0, stream_view_>>>(view, climber_strategies_.size());
+      <<<grid_size, block_size, 0, stream_view_.get()>>>(view, climber_strategies_.size());
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     RAFT_CUDA_TRY(cudaStreamSynchronize(
-      stream_view_));  // To make sure all the data is written from device to host
+      stream_view_.get()));  // To make sure all the data is written from device to host
 #ifdef CUPDLP_DEBUG_MODE
     RAFT_CUDA_TRY(cudaDeviceSynchronize());
 #endif
@@ -1232,7 +1232,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_new_primal_weight(
 
   cuopt_assert(!batch_mode_, "compute_new_primal_weight  not supported in batch mode");
 
-  compute_new_primal_weight_kernel<i_t, f_t><<<1, 1, 0, stream_view_>>>(duality_gap.view(),
+  compute_new_primal_weight_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(duality_gap.view(),
                                                                         primal_weight.data(),
                                                                         step_size.data(),
                                                                         primal_step_size.data(),
@@ -1282,7 +1282,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::distance_squared_moved_from_last_restart
                          new_solution.data(),
                          new_solution.size(),
                          a_sub_scalar_times_b<f_t>(reusable_device_scalar_value_1_.data()),
-                         stream_view_);
+                         stream_view_.get());
 
   if (!batch_mode_) {
     RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
@@ -1292,7 +1292,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::distance_squared_moved_from_last_restart
                                                     tmp.data(),
                                                     stride,
                                                     distance_moved.data(),
-                                                    stream_view_));
+                                                    stream_view_.get()));
   } else {
     cub::DeviceSegmentedReduce::Sum(
       dot_product_storage.data(),
@@ -1301,7 +1301,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::distance_squared_moved_from_last_restart
       distance_moved.data(),
       climber_strategies_.size(),
       size_of_solutions_h,
-      stream_view_);
+      stream_view_.get());
   }
 }
 
@@ -1348,7 +1348,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::update_last_restart_information(
 {
   raft::common::nvtx::range fun_scope("update_last_restart_information");
 
-  compute_distance_traveled_last_restart_kernel<i_t, f_t><<<1, 1, 0, stream_view_>>>(
+  compute_distance_traveled_last_restart_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(
     duality_gap.view(), primal_weight.data(), last_restart_duality_gap_.distance_traveled_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -1384,7 +1384,7 @@ template <typename i_t, typename f_t>
 i_t pdlp_restart_strategy_t<i_t, f_t>::pick_restart_candidate()
 {
   pick_restart_candidate_kernel<i_t, f_t>
-    <<<1, 1, 0, stream_view_>>>(avg_duality_gap_.view(), current_duality_gap_.view(), this->view());
+    <<<1, 1, 0, stream_view_.get()>>>(avg_duality_gap_.view(), current_duality_gap_.view(), this->view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   i_t restart_to_average_h = candidate_is_avg_.value(stream_view_);
@@ -1394,7 +1394,7 @@ i_t pdlp_restart_strategy_t<i_t, f_t>::pick_restart_candidate()
     candidate_duality_gap_ = &current_duality_gap_;
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
   return restart_to_average_h;
 }
 
@@ -1447,7 +1447,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::should_do_adaptive_restart_normalized_du
   //   2 * primal_weight + lri.dual_distance_moved_last_restart_period ^ 2 / primal_weight,
 
   compute_distance_traveled_last_restart_kernel<i_t, f_t>
-    <<<1, 1, 0, stream_view_>>>(candidate_duality_gap.view(),
+    <<<1, 1, 0, stream_view_.get()>>>(candidate_duality_gap.view(),
                                 primal_weight.data(),
                                 last_restart_duality_gap_.distance_traveled_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
@@ -1455,7 +1455,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::should_do_adaptive_restart_normalized_du
   bound_optimal_objective(
     last_restart_duality_gap_cusparse_view_, last_restart_duality_gap_, tmp_primal, tmp_dual);
 
-  adaptive_restart_triggered<i_t, f_t><<<1, 1, 0, stream_view_>>>(
+  adaptive_restart_triggered<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(
     candidate_duality_gap.view(), last_restart_duality_gap_.view(), this->view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
@@ -1552,7 +1552,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_localized_duality_gaps(
     current_duality_gap_cusparse_view_, current_duality_gap_, tmp_primal, tmp_dual);
 
   compute_normalized_gaps_kernel<i_t, f_t>
-    <<<1, 1, 0, stream_view_>>>(avg_duality_gap_.view(), current_duality_gap_.view());
+    <<<1, 1, 0, stream_view_.get()>>>(avg_duality_gap_.view(), current_duality_gap_.view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1589,7 +1589,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_bound(const rmm::device_uvector<
 #ifdef PDLP_DEBUG_MODE
   std::cout << "Compute bound" << std::endl;
 #endif
-  raft::linalg::eltwiseSub(tmp.data(), solution_tr.data(), solution.data(), size, stream_view_);
+  raft::linalg::eltwiseSub(tmp.data(), solution_tr.data(), solution.data(), size, stream_view_.get());
 
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
                                                   size,
@@ -1598,9 +1598,9 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_bound(const rmm::device_uvector<
                                                   gradient.data(),
                                                   stride,
                                                   bound.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
-  raft::linalg::eltwiseAdd(bound.data(), bound.data(), lagrangian.data(), 1, stream_view_);
+  raft::linalg::eltwiseAdd(bound.data(), bound.data(), lagrangian.data(), 1, stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -1947,7 +1947,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
                         duality_gap.dual_gradient_.data(),
                         dual_size_h_,
                         negate_t<f_t>(),
-                        stream_view_);
+                        stream_view_.get());
 
   // Use high_radius_squared_ to store objective_vector l2_norm
   my_l2_norm<i_t, f_t>(objective_vector_, high_radius_squared_, handle_ptr_);
@@ -2131,7 +2131,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
       dimBlock,
       kernel_args,
       0,
-      stream_view_));
+      stream_view_.get()));
 
     // Find max threshold for the join problem
     const f_t* max_threshold =
@@ -2146,7 +2146,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
     //  target_threshold which was computed before the loop in the direction_and_threshold_kernel
     // Otherwise use the test_threshold determined in the loop
     // {
-    target_threshold_determination_kernel<i_t, f_t><<<1, 1, 0, stream_view_>>>(
+    target_threshold_determination_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(
       this->view(), duality_gap.distance_traveled_.data(), max_threshold, max_threshold);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     // }
@@ -2160,13 +2160,13 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
                            unsorted_direction_full_.data(),
                            primal_size_h_,
                            a_add_scalar_times_b<f_t>(target_threshold_.data()),
-                           stream_view_);
+                           stream_view_.get());
     raft::linalg::binaryOp(duality_gap.dual_solution_tr_.data(),
                            duality_gap.dual_solution_.data(),
                            unsorted_direction_full_.data() + primal_size_h_,
                            dual_size_h_,
                            a_add_scalar_times_b<f_t>(target_threshold_.data()),
-                           stream_view_);
+                           stream_view_.get());
     // project by max(min(x[i], upperbound[i]),lowerbound[i]) for primal part
     using f_t2 = typename type_2<f_t>::type;
     cub::DeviceTransform::Transform(cuda::std::make_tuple(duality_gap.primal_solution_tr_.data(),
@@ -2183,7 +2183,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
                             transformed_constraint_upper_bounds_.data(),
                             dual_size_h_,
                             constraint_clamp<f_t>(),
-                            stream_view_);
+                            stream_view_.get());
     // }
   }
 
@@ -2245,7 +2245,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_distance_traveled_from_last_rest
 
   // distance_traveled = primal_distance * 0.5 * primal_weight
   // + dual_distance * 0.5 / primal_weight
-  compute_distance_traveled_last_restart_kernel<i_t, f_t><<<1, 1, 0, stream_view_>>>(
+  compute_distance_traveled_last_restart_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(
     duality_gap.view(), primal_weight.data(), duality_gap.distance_traveled_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
@@ -2276,7 +2276,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_primal_gradient(
                                                        cusparse_view.primal_gradient.get(),
                                                        CUSPARSE_SPMV_CSR_ALG2,
                                                        (f_t*)cusparse_view.buffer_transpose.data(),
-                                                       stream_view_));
+                                                       stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -2344,13 +2344,13 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_dual_gradient(
                                        cusparse_view.dual_gradient.get(),
                                        CUSPARSE_SPMV_CSR_ALG2,
                                        (f_t*)cusparse_view.buffer_non_transpose.data(),
-                                       stream_view_));
+                                       stream_view_.get()));
 
   // tmp_dual will contain the subgradient
   i_t number_of_blocks = dual_size_h_ / block_size;
   if (dual_size_h_ % block_size) number_of_blocks++;
   i_t number_of_threads = std::min(dual_size_h_, block_size);
-  compute_subgradient_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_>>>(
+  compute_subgradient_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_.get()>>>(
     this->view(), problem_ptr->view(), duality_gap.view(), tmp_dual.data());
 
   // dual gradient = subgradient - primal_product (tmp_dual-dual_gradient)
@@ -2358,7 +2358,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_dual_gradient(
                            tmp_dual.data(),
                            duality_gap.dual_gradient_.data(),
                            dual_size_h_,
-                           stream_view_);
+                           stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -2389,7 +2389,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_lagrangian_value(
                                                   problem_ptr->objective_coefficients.data(),
                                                   primal_stride,
                                                   reusable_device_scalar_1_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
   // third term, let beta be 0 to not add what is in tmp_primal, compute it and compute dot
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmv(handle_ptr_->get_cusparse_handle(),
@@ -2401,7 +2401,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_lagrangian_value(
                                                        cusparse_view.tmp_primal.get(),
                                                        CUSPARSE_SPMV_CSR_ALG2,
                                                        (f_t*)cusparse_view.buffer_transpose.data(),
-                                                       stream_view_));
+                                                       stream_view_.get()));
 
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
                                                   primal_size_h_,
@@ -2410,7 +2410,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_lagrangian_value(
                                                   tmp_primal.data(),
                                                   primal_stride,
                                                   reusable_device_scalar_2_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
   // fourth term //tmp_dual still contains subgradient from the dual_gradient computation
   reusable_device_scalar_3_.set_value_to_zero_async(stream_view_);
@@ -2421,19 +2421,19 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_lagrangian_value(
                                                   tmp_dual.data(),
                                                   dual_stride,
                                                   reusable_device_scalar_3_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
   // subtract third term from second up
   raft::linalg::eltwiseSub(reusable_device_scalar_1_.data(),
                            reusable_device_scalar_1_.data(),
                            reusable_device_scalar_2_.data(),
                            1,
-                           stream_view_);
+                           stream_view_.get());
   raft::linalg::eltwiseAdd(duality_gap.lagrangian_value_.data(),
                            reusable_device_scalar_1_.data(),
                            reusable_device_scalar_3_.data(),
                            1,
-                           stream_view_);
+                           stream_view_.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -1394,7 +1394,7 @@ i_t pdlp_restart_strategy_t<i_t, f_t>::pick_restart_candidate()
     candidate_duality_gap_ = &current_duality_gap_;
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
   return restart_to_average_h;
 }
 

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -448,10 +448,10 @@ f_t pdlp_restart_strategy_t<i_t, f_t>::compute_kkt_score(
   const rmm::device_uvector<f_t>& primal_weight)
 {
   kernel_compute_kkt_score<f_t><<<1, 1, 0, stream_view_.get()>>>(l2_primal_residual.data(),
-                                                           l2_dual_residual.data(),
-                                                           gap.data(),
-                                                           primal_weight.data(),
-                                                           tmp_kkt_score_.data());
+                                                                 l2_dual_residual.data(),
+                                                                 gap.data(),
+                                                                 primal_weight.data(),
+                                                                 tmp_kkt_score_.data());
   return tmp_kkt_score_.value(stream_view_);
 }
 
@@ -1232,11 +1232,12 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_new_primal_weight(
 
   cuopt_assert(!batch_mode_, "compute_new_primal_weight  not supported in batch mode");
 
-  compute_new_primal_weight_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(duality_gap.view(),
-                                                                        primal_weight.data(),
-                                                                        step_size.data(),
-                                                                        primal_step_size.data(),
-                                                                        dual_step_size.data());
+  compute_new_primal_weight_kernel<i_t, f_t>
+    <<<1, 1, 0, stream_view_.get()>>>(duality_gap.view(),
+                                      primal_weight.data(),
+                                      step_size.data(),
+                                      primal_step_size.data(),
+                                      dual_step_size.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -1383,8 +1384,8 @@ __global__ void pick_restart_candidate_kernel(
 template <typename i_t, typename f_t>
 i_t pdlp_restart_strategy_t<i_t, f_t>::pick_restart_candidate()
 {
-  pick_restart_candidate_kernel<i_t, f_t>
-    <<<1, 1, 0, stream_view_.get()>>>(avg_duality_gap_.view(), current_duality_gap_.view(), this->view());
+  pick_restart_candidate_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(
+    avg_duality_gap_.view(), current_duality_gap_.view(), this->view());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   i_t restart_to_average_h = candidate_is_avg_.value(stream_view_);
@@ -1448,8 +1449,8 @@ void pdlp_restart_strategy_t<i_t, f_t>::should_do_adaptive_restart_normalized_du
 
   compute_distance_traveled_last_restart_kernel<i_t, f_t>
     <<<1, 1, 0, stream_view_.get()>>>(candidate_duality_gap.view(),
-                                primal_weight.data(),
-                                last_restart_duality_gap_.distance_traveled_.data());
+                                      primal_weight.data(),
+                                      last_restart_duality_gap_.distance_traveled_.data());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   bound_optimal_objective(
@@ -1589,7 +1590,8 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_bound(const rmm::device_uvector<
 #ifdef PDLP_DEBUG_MODE
   std::cout << "Compute bound" << std::endl;
 #endif
-  raft::linalg::eltwiseSub(tmp.data(), solution_tr.data(), solution.data(), size, stream_view_.get());
+  raft::linalg::eltwiseSub(
+    tmp.data(), solution_tr.data(), solution.data(), size, stream_view_.get());
 
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
                                                   size,
@@ -2352,8 +2354,9 @@ void pdlp_restart_strategy_t<i_t, f_t>::compute_dual_gradient(
   i_t number_of_blocks = dual_size_h_ / block_size;
   if (dual_size_h_ % block_size) number_of_blocks++;
   i_t number_of_threads = std::min(dual_size_h_, block_size);
-  compute_subgradient_kernel<i_t, f_t><<<number_of_blocks, number_of_threads, 0, stream_view_.get()>>>(
-    this->view(), problem_ptr->view(), duality_gap.view(), tmp_dual.data());
+  compute_subgradient_kernel<i_t, f_t>
+    <<<number_of_blocks, number_of_threads, 0, stream_view_.get()>>>(
+      this->view(), problem_ptr->view(), duality_gap.view(), tmp_dual.data());
 
   // dual gradient = subgradient - primal_product (tmp_dual-dual_gradient)
   raft::linalg::eltwiseSub(duality_gap.dual_gradient_.data(),

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -1262,7 +1262,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::distance_squared_moved_from_last_restart
                                                   old_solution.data(),
                                                   stride,
                                                   debuga.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
                                                   size_of_solutions_h,
                                                   new_solution.data(),
@@ -1270,7 +1270,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::distance_squared_moved_from_last_restart
                                                   new_solution.data(),
                                                   stride,
                                                   debugb.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
   std::cout << "Distance squared moved:\n"
             << "  Old location=" << debuga.value(stream_view_) << "\n"
             << "  New location=" << debugb.value(stream_view_) << std::endl;

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -1974,8 +1974,10 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
     const f_t zero_float = f_t(0.0);
     high_radius_squared_.set_value_async(zero_float, stream_view_);
     low_radius_squared_.set_value_async(zero_float, stream_view_);
-    RAFT_CUDA_TRY(cudaMemsetAsync(
-      direction_full_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_.get()));
+    RAFT_CUDA_TRY(cudaMemsetAsync(direction_full_.data(),
+                                  0,
+                                  sizeof(f_t) * (primal_size_h_ + dual_size_h_),
+                                  stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(
       threshold_.data(), 0, sizeof(f_t) * (primal_size_h_ + dual_size_h_), stream_view_.get()));
     /* ----- */

--- a/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
+++ b/cpp/src/pdlp/restart_strategy/pdlp_restart_strategy.cu
@@ -1990,7 +1990,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
       thrust::make_zip_iterator(thrust::make_tuple(lower_bound_.data(), upper_bound_.data())),
       primal_size_h_,
       extract_bounds_t<f_t, f_t2>(),
-      stream_view_.value());
+      stream_view_.get());
     raft::copy(lower_bound_.data() + primal_size_h_,
                transformed_constraint_lower_bounds_.data(),
                dual_size_h_,
@@ -2174,7 +2174,7 @@ void pdlp_restart_strategy_t<i_t, f_t>::solve_bound_constrained_trust_region(
                                     duality_gap.primal_solution_tr_.data(),
                                     primal_size_h_,
                                     clamp<f_t, f_t2>(),
-                                    stream_view_.value());
+                                    stream_view_.get());
 
     // project by max(min(y[i], upperbound[i]),lowerbound[i])
     raft::linalg::ternaryOp(duality_gap.dual_solution_tr_.data(),

--- a/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
+++ b/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
@@ -34,18 +34,18 @@ weighted_average_solution_t<i_t, f_t>::weighted_average_solution_t(raft::handle_
     graph(stream_view_, is_batch_mode)
 {
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_));
+    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_));
+    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
 void weighted_average_solution_t<i_t, f_t>::reset_weighted_average_solution()
 {
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_));
+    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_));
+    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
   sum_primal_solution_weights_.set_value_to_zero_async(stream_view_);
   sum_dual_solution_weights_.set_value_to_zero_async(stream_view_);
   iterations_since_last_restart_ = 0;
@@ -88,7 +88,7 @@ void weighted_average_solution_t<i_t, f_t>::add_current_solution_to_weighted_ave
       stream_view_.get());
 
     // update weight sums and count (add weight and +1 respectively)
-    add_weight_sums<<<1, 1, 0, stream_view_>>>(weight.data(),
+    add_weight_sums<<<1, 1, 0, stream_view_.get()>>>(weight.data(),
                                                weight.data(),
                                                sum_primal_solution_weights_.data(),
                                                sum_dual_solution_weights_.data());
@@ -104,9 +104,9 @@ void weighted_average_solution_t<i_t, f_t>::compute_averages(rmm::device_uvector
   // no iterations have added to the sum, so avg is all zero vector
   if (!iterations_since_last_restart_) {
     RAFT_CUDA_TRY(
-      cudaMemsetAsync(avg_primal.data(), f_t(0.0), sizeof(f_t) * primal_size_h_, stream_view_));
+      cudaMemsetAsync(avg_primal.data(), f_t(0.0), sizeof(f_t) * primal_size_h_, stream_view_.get()));
     RAFT_CUDA_TRY(
-      cudaMemsetAsync(avg_dual.data(), f_t(0.0), sizeof(f_t) * dual_size_h_, stream_view_));
+      cudaMemsetAsync(avg_dual.data(), f_t(0.0), sizeof(f_t) * dual_size_h_, stream_view_.get()));
     return;
   }
 
@@ -114,19 +114,19 @@ void weighted_average_solution_t<i_t, f_t>::compute_averages(rmm::device_uvector
   f_t sum_primal_solution_weights_h = sum_primal_solution_weights_.value(stream_view_);
   f_t sum_dual_solution_weights_h   = sum_dual_solution_weights_.value(stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 
   // compute sum_primal_solutions/primal_size
   raft::linalg::divideScalar(avg_primal.data(),
                              sum_primal_solutions_.data(),
                              sum_primal_solution_weights_h,
                              primal_size_h_,
-                             stream_view_);
+                             stream_view_.get());
   raft::linalg::divideScalar(avg_dual.data(),
                              sum_dual_solutions_.data(),
                              sum_dual_solution_weights_h,
                              dual_size_h_,
-                             stream_view_);
+                             stream_view_.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
+++ b/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
@@ -114,7 +114,7 @@ void weighted_average_solution_t<i_t, f_t>::compute_averages(rmm::device_uvector
   f_t sum_primal_solution_weights_h = sum_primal_solution_weights_.value(stream_view_);
   f_t sum_dual_solution_weights_h   = sum_dual_solution_weights_.value(stream_view_);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 
   // compute sum_primal_solutions/primal_size
   raft::linalg::divideScalar(avg_primal.data(),

--- a/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
+++ b/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
@@ -33,19 +33,19 @@ weighted_average_solution_t<i_t, f_t>::weighted_average_solution_t(raft::handle_
     iterations_since_last_restart_{0},
     graph(stream_view_, is_batch_mode)
 {
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
 void weighted_average_solution_t<i_t, f_t>::reset_weighted_average_solution()
 {
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    sum_primal_solutions_.data(), 0.0, sizeof(f_t) * primal_size_h_, stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    sum_dual_solutions_.data(), 0.0, sizeof(f_t) * dual_size_h_, stream_view_.get()));
   sum_primal_solution_weights_.set_value_to_zero_async(stream_view_);
   sum_dual_solution_weights_.set_value_to_zero_async(stream_view_);
   iterations_since_last_restart_ = 0;
@@ -89,9 +89,9 @@ void weighted_average_solution_t<i_t, f_t>::add_current_solution_to_weighted_ave
 
     // update weight sums and count (add weight and +1 respectively)
     add_weight_sums<<<1, 1, 0, stream_view_.get()>>>(weight.data(),
-                                               weight.data(),
-                                               sum_primal_solution_weights_.data(),
-                                               sum_dual_solution_weights_.data());
+                                                     weight.data(),
+                                                     sum_primal_solution_weights_.data(),
+                                                     sum_dual_solution_weights_.data());
   });
 
   iterations_since_last_restart_ += 1;
@@ -103,8 +103,8 @@ void weighted_average_solution_t<i_t, f_t>::compute_averages(rmm::device_uvector
 {
   // no iterations have added to the sum, so avg is all zero vector
   if (!iterations_since_last_restart_) {
-    RAFT_CUDA_TRY(
-      cudaMemsetAsync(avg_primal.data(), f_t(0.0), sizeof(f_t) * primal_size_h_, stream_view_.get()));
+    RAFT_CUDA_TRY(cudaMemsetAsync(
+      avg_primal.data(), f_t(0.0), sizeof(f_t) * primal_size_h_, stream_view_.get()));
     RAFT_CUDA_TRY(
       cudaMemsetAsync(avg_dual.data(), f_t(0.0), sizeof(f_t) * dual_size_h_, stream_view_.get()));
     return;

--- a/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
+++ b/cpp/src/pdlp/restart_strategy/weighted_average_solution.cu
@@ -78,14 +78,14 @@ void weighted_average_solution_t<i_t, f_t>::add_current_solution_to_weighted_ave
       sum_primal_solutions_.data(),
       primal_size_h_,
       a_add_scalar_times_b<f_t>(weight.data()),
-      stream_view_.value());
+      stream_view_.get());
 
     cub::DeviceTransform::Transform(
       cuda::std::make_tuple(sum_dual_solutions_.data(), dual_solution),
       sum_dual_solutions_.data(),
       dual_size_h_,
       a_add_scalar_times_b<f_t>(weight.data()),
-      stream_view_.value());
+      stream_view_.get());
 
     // update weight sums and count (add weight and +1 respectively)
     add_weight_sums<<<1, 1, 0, stream_view_>>>(weight.data(),

--- a/cpp/src/pdlp/saddle_point.cu
+++ b/cpp/src/pdlp/saddle_point.cu
@@ -47,13 +47,13 @@ saddle_point_state_t<i_t, f_t>::saddle_point_state_t(raft::handle_t const* handl
     handle_ptr->get_thrust_policy(), dual_solution_.data(), dual_solution_.end(), f_t(0));
 
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    delta_primal_.data(), 0, sizeof(f_t) * delta_primal_.size(), handle_ptr->get_stream()));
+    delta_primal_.data(), 0, sizeof(f_t) * delta_primal_.size(), handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    delta_dual_.data(), 0, sizeof(f_t) * delta_dual_.size(), handle_ptr->get_stream()));
+    delta_dual_.data(), 0, sizeof(f_t) * delta_dual_.size(), handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    primal_gradient_.data(), 0, sizeof(f_t) * primal_gradient_.size(), handle_ptr->get_stream()));
+    primal_gradient_.data(), 0, sizeof(f_t) * primal_gradient_.size(), handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    dual_gradient_.data(), 0, sizeof(f_t) * dual_gradient_.size(), handle_ptr->get_stream()));
+    dual_gradient_.data(), 0, sizeof(f_t) * dual_gradient_.size(), handle_ptr->get_stream().get()));
 
   // No need to 0 init current/next AtY, they are directlty written as result of SpMV
 }

--- a/cpp/src/pdlp/saddle_point.cu
+++ b/cpp/src/pdlp/saddle_point.cu
@@ -50,8 +50,10 @@ saddle_point_state_t<i_t, f_t>::saddle_point_state_t(raft::handle_t const* handl
     delta_primal_.data(), 0, sizeof(f_t) * delta_primal_.size(), handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     delta_dual_.data(), 0, sizeof(f_t) * delta_dual_.size(), handle_ptr->get_stream().get()));
-  RAFT_CUDA_TRY(cudaMemsetAsync(
-    primal_gradient_.data(), 0, sizeof(f_t) * primal_gradient_.size(), handle_ptr->get_stream().get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(primal_gradient_.data(),
+                                0,
+                                sizeof(f_t) * primal_gradient_.size(),
+                                handle_ptr->get_stream().get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     dual_gradient_.data(), 0, sizeof(f_t) * dual_gradient_.size(), handle_ptr->get_stream().get()));
 

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -81,9 +81,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 // Corresponds to the first good general settings we found

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -49,6 +49,8 @@
 #include <pdlp/utilities/problem_checking.cuh>
 
 #include <raft/sparse/detail/cusparse_wrappers.h>
+
+#include <cuda/stream>
 #include <raft/core/cusparse_macros.hpp>
 #include <raft/core/device_setter.hpp>
 #include <raft/core/handle.hpp>
@@ -1607,7 +1609,7 @@ optimization_problem_solution_t<i_t, f_t> run_concurrent(
         {
           try {
             auto call_barrier_thread = [&]() {
-              rmm::cuda_stream_view barrier_stream = rmm::cuda_stream_per_thread;
+              rmm::cuda_stream_view barrier_stream = cuda::stream_ref{cudaStreamPerThread};
               barrier_handle_ptr = std::make_unique<raft::handle_t>(barrier_stream);
               run_barrier_thread<i_t, f_t>(dual_simplex_problem,
                                            settings_pdlp,
@@ -2696,7 +2698,7 @@ std::unique_ptr<lp_solution_interface_t<i_t, f_t>> solve_lp(
     *gpu_problem, settings, problem_checking, use_pdlp_solver_mode, is_batch_mode);
 
   // Ensure all GPU work from the solve is complete before D2H copies in to_cpu_solution(),
-  // which uses rmm::cuda_stream_per_thread (a different stream than the solver used).
+  // which uses the per-thread default stream (a different stream than the solver used).
   stream.synchronize();
 
   // Convert GPU solution back to CPU

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -2358,7 +2358,7 @@ cuopt::mathematical_optimization::io::mps_data_model_t<i_t, f_t> op_problem_to_m
   raft::copy(h_constr_lb.data(), d_constr_lb.data(), d_constr_lb.size(), stream);
   raft::copy(h_constr_ub.data(), d_constr_ub.data(), d_constr_ub.size(), stream);
   raft::copy(h_var_types_enum.data(), d_var_types.data(), d_var_types.size(), stream);
-  stream.synchronize();
+  stream.sync();
 
   if (!h_offsets.empty()) {
     mps.set_csr_constraint_matrix(

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -84,8 +84,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 // Corresponds to the first good general settings we found

--- a/cpp/src/pdlp/solve.cu
+++ b/cpp/src/pdlp/solve.cu
@@ -343,7 +343,7 @@ void adjust_dual_solution_and_reduced_cost(rmm::device_uvector<f_t>& dual_soluti
     dual_solution.data(),
     dual_solution.size(),
     [] HD(f_t dual) { return -dual; },
-    stream_view);
+    stream_view.get());
 
   // z <- -z
   cub::DeviceTransform::Transform(
@@ -351,7 +351,7 @@ void adjust_dual_solution_and_reduced_cost(rmm::device_uvector<f_t>& dual_soluti
     reduced_cost.data(),
     reduced_cost.size(),
     [] HD(f_t reduced_cost) { return -reduced_cost; },
-    stream_view);
+    stream_view.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/solver_solution.cu
+++ b/cpp/src/pdlp/solver_solution.cu
@@ -238,7 +238,7 @@ void optimization_problem_solution_t<i_t, f_t>::write_to_file(std::string_view f
     primal_solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.get());
   raft::copy(dual_solution.data(), dual_solution_.data(), dual_solution_.size(), stream_view.get());
   raft::copy(reduced_cost.data(), reduced_cost_.data(), reduced_cost_.size(), stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 
   myfile << "{ " << std::endl;
   myfile << "\t\"Termination reason\" : \"" << get_termination_status_string() << "\","
@@ -446,7 +446,7 @@ void optimization_problem_solution_t<i_t, f_t>::write_to_sol_file(
   std::vector<f_t> solution;
   solution.resize(primal_solution_.size());
   raft::copy(solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
   solution_writer_t::write_solution_to_sol_file(
     std::string(filename), status, objective_value, var_names_, solution);
 }

--- a/cpp/src/pdlp/solver_solution.cu
+++ b/cpp/src/pdlp/solver_solution.cu
@@ -235,11 +235,10 @@ void optimization_problem_solution_t<i_t, f_t>::write_to_file(std::string_view f
   dual_solution.resize(dual_solution_.size());
   reduced_cost.resize(reduced_cost_.size());
   raft::copy(
-    primal_solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.value());
-  raft::copy(
-    dual_solution.data(), dual_solution_.data(), dual_solution_.size(), stream_view.value());
-  raft::copy(reduced_cost.data(), reduced_cost_.data(), reduced_cost_.size(), stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+    primal_solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.get());
+  raft::copy(dual_solution.data(), dual_solution_.data(), dual_solution_.size(), stream_view.get());
+  raft::copy(reduced_cost.data(), reduced_cost_.data(), reduced_cost_.size(), stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 
   myfile << "{ " << std::endl;
   myfile << "\t\"Termination reason\" : \"" << get_termination_status_string() << "\","
@@ -446,9 +445,8 @@ void optimization_problem_solution_t<i_t, f_t>::write_to_sol_file(
   auto objective_value = get_objective_value(0);
   std::vector<f_t> solution;
   solution.resize(primal_solution_.size());
-  raft::copy(
-    solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  raft::copy(solution.data(), primal_solution_.data(), primal_solution_.size(), stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   solution_writer_t::write_solution_to_sol_file(
     std::string(filename), status, objective_value, var_names_, solution);
 }

--- a/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
+++ b/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
@@ -562,9 +562,9 @@ void adaptive_step_size_strategy_t<i_t, f_t>::get_primal_and_dual_stepsizes(
                "step size must be the same size as the number of climber strategies");
   compute_actual_stepsizes<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(this->view(),
-                                                 make_span(primal_step_size),
-                                                 make_span(dual_step_size),
-                                                 climber_strategies_.size());
+                                                       make_span(primal_step_size),
+                                                       make_span(dual_step_size),
+                                                       climber_strategies_.size());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 

--- a/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
+++ b/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
@@ -561,7 +561,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::get_primal_and_dual_stepsizes(
   cuopt_assert(step_size_->size() == climber_strategies_.size(),
                "step size must be the same size as the number of climber strategies");
   compute_actual_stepsizes<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(this->view(),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(this->view(),
                                                  make_span(primal_step_size),
                                                  make_span(dual_step_size),
                                                  climber_strategies_.size());

--- a/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
+++ b/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
@@ -357,7 +357,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_step_sizes(
                                         pdhg_solver.get_d_total_pdhg_iterations().data());
   });
   // Steam sync so that next call can see modification made to host var valid_step_size
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
+++ b/cpp/src/pdlp/step_size_strategy/adaptive_step_size_strategy.cu
@@ -78,7 +78,7 @@ adaptive_step_size_strategy_t<i_t, f_t>::adaptive_step_size_strategy_t(
       interaction_.data(),
       climber_strategies_.size(),
       primal_size_,
-      stream_view_.value()));
+      stream_view_.get()));
     dot_product_bytes = std::max(dot_product_bytes, byte_needed);
 
     RAFT_CUDA_TRY(cub::DeviceSegmentedReduce::Sum(
@@ -88,7 +88,7 @@ adaptive_step_size_strategy_t<i_t, f_t>::adaptive_step_size_strategy_t(
       norm_squared_delta_primal_.data(),
       climber_strategies_.size(),
       primal_size_,
-      stream_view_.value()));
+      stream_view_.get()));
     dot_product_bytes = std::max(dot_product_bytes, byte_needed);
 
     RAFT_CUDA_TRY(cub::DeviceSegmentedReduce::Sum(
@@ -98,10 +98,10 @@ adaptive_step_size_strategy_t<i_t, f_t>::adaptive_step_size_strategy_t(
       norm_squared_delta_dual_.data(),
       climber_strategies_.size(),
       dual_size_,
-      stream_view_.value()));
+      stream_view_.get()));
     dot_product_bytes = std::max(dot_product_bytes, byte_needed);
 
-    dot_product_storage.resize(dot_product_bytes, stream_view_.value());
+    dot_product_storage.resize(dot_product_bytes, stream_view_.get());
   }
 }
 
@@ -141,12 +141,11 @@ void adaptive_step_size_strategy_t<i_t, f_t>::swap_context(
   const auto [grid_size, block_size] =
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   adaptive_step_size_swap_device_vectors_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_.value()>>>(
-      thrust::raw_pointer_cast(swap_pairs.data()),
-      static_cast<i_t>(swap_pairs.size()),
-      make_span(interaction_),
-      make_span(norm_squared_delta_primal_),
-      make_span(norm_squared_delta_dual_));
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
+                                                       static_cast<i_t>(swap_pairs.size()),
+                                                       make_span(interaction_),
+                                                       make_span(norm_squared_delta_primal_),
+                                                       make_span(norm_squared_delta_dual_));
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -158,9 +157,9 @@ void adaptive_step_size_strategy_t<i_t, f_t>::resize_context(i_t new_size)
   cuopt_assert(new_size > 0, "New size must be greater than 0");
   cuopt_assert(new_size < batch_size, "New size must be less than batch size");
 
-  interaction_.resize(new_size, stream_view_.value());
-  norm_squared_delta_primal_.resize(new_size, stream_view_.value());
-  norm_squared_delta_dual_.resize(new_size, stream_view_.value());
+  interaction_.resize(new_size, stream_view_.get());
+  norm_squared_delta_primal_.resize(new_size, stream_view_.get());
+  norm_squared_delta_dual_.resize(new_size, stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -275,19 +274,19 @@ i_t adaptive_step_size_strategy_t<i_t, f_t>::get_valid_step_size() const
 template <typename i_t, typename f_t>
 f_t adaptive_step_size_strategy_t<i_t, f_t>::get_interaction(i_t i) const
 {
-  return interaction_.element(i, stream_view_.value());
+  return interaction_.element(i, stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
 f_t adaptive_step_size_strategy_t<i_t, f_t>::get_norm_squared_delta_primal(i_t i) const
 {
-  return norm_squared_delta_primal_.element(i, stream_view_.value());
+  return norm_squared_delta_primal_.element(i, stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
 f_t adaptive_step_size_strategy_t<i_t, f_t>::get_norm_squared_delta_dual(i_t i) const
 {
-  return norm_squared_delta_dual_.element(i, stream_view_.value());
+  return norm_squared_delta_dual_.element(i, stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -352,13 +351,13 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_step_sizes(
                                      pdhg_solver.get_saddle_point_state());
     // Compute n_lim, n_next and decide if step size is valid
     compute_step_sizes_from_movement_and_interaction<i_t, f_t>
-      <<<1, 1, 0, stream_view_.value()>>>(this->view(),
-                                          primal_step_size.data(),
-                                          dual_step_size.data(),
-                                          pdhg_solver.get_d_total_pdhg_iterations().data());
+      <<<1, 1, 0, stream_view_.get()>>>(this->view(),
+                                        primal_step_size.data(),
+                                        dual_step_size.data(),
+                                        pdhg_solver.get_d_total_pdhg_iterations().data());
   });
   // Steam sync so that next call can see modification made to host var valid_step_size
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.value()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -421,7 +420,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
                                          cusparse_view.next_AtY.get(),
                                          CUSPARSE_SPMV_CSR_ALG2,
                                          (f_t*)cusparse_view.buffer_transpose.data(),
-                                         stream_view_.value()));
+                                         stream_view_.get()));
   } else {
     // TODO later batch mode: handle if not all restart
     RAFT_CUSPARSE_TRY(
@@ -435,7 +434,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
                                          cusparse_view.batch_next_AtYs.get(),
                                          CUSPARSE_SPMM_CSR_ALG3,
                                          (f_t*)cusparse_view.buffer_transpose_batch.data(),
-                                         stream_view_.value()));
+                                         stream_view_.get()));
   }
 
   // Compute Ay' - Ay = next_Aty - current_Aty
@@ -446,7 +445,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
     tmp_primal.data(),
     tmp_primal.size(),
     cuda::std::minus<>{},
-    stream_view_.value());
+    stream_view_.get());
 
   if (!batch_mode_) {
     // compute interaction (x'-x) . (A(y'-y))
@@ -458,7 +457,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
                                       current_saddle_point_state.get_delta_primal().data(),
                                       primal_stride,
                                       interaction_.data(),
-                                      stream_view_.value()));
+                                      stream_view_.get()));
 
     // Compute movement
     //  compute euclidean norm squared which is
@@ -476,7 +475,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
                                       current_saddle_point_state.get_delta_primal().data(),
                                       primal_stride,
                                       norm_squared_delta_primal_.data(),
-                                      stream_view_.value()));
+                                      stream_view_.get()));
 
     RAFT_CUBLAS_TRY(
       raft::linalg::detail::cublasdot(handle_ptr_->get_cublas_handle(),
@@ -486,7 +485,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
                                       current_saddle_point_state.get_delta_dual().data(),
                                       dual_stride,
                                       norm_squared_delta_dual_.data(),
-                                      stream_view_.value()));
+                                      stream_view_.get()));
   } else {
     // TODO later batch mode: remove this once you want to do per climber restart
     cub::DeviceSegmentedReduce::Sum(
@@ -499,7 +498,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
       interaction_.data(),
       climber_strategies_.size(),
       primal_size_,
-      stream_view_.value());
+      stream_view_.get());
 
     cub::DeviceSegmentedReduce::Sum(
       dot_product_storage.data(),
@@ -509,7 +508,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
       norm_squared_delta_primal_.data(),
       climber_strategies_.size(),
       primal_size_,
-      stream_view_.value());
+      stream_view_.get());
 
     cub::DeviceSegmentedReduce::Sum(
       dot_product_storage.data(),
@@ -519,7 +518,7 @@ void adaptive_step_size_strategy_t<i_t, f_t>::compute_interaction_and_movement(
       norm_squared_delta_dual_.data(),
       climber_strategies_.size(),
       dual_size_,
-      stream_view_.value());
+      stream_view_.get());
   }
 }
 

--- a/cpp/src/pdlp/swap_and_resize_helper.cuh
+++ b/cpp/src/pdlp/swap_and_resize_helper.cuh
@@ -83,7 +83,7 @@ void matrix_swap(rmm::device_uvector<f_t>& matrix,
     [] HD(thrust::tuple<f_t, f_t> values) -> thrust::tuple<f_t, f_t> {
       return thrust::make_tuple(thrust::get<1>(values), thrust::get<0>(values));
     },
-    matrix.stream().value());
+    matrix.stream().get());
 }
 
 template <typename host_vector_t>

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -111,9 +111,9 @@ convergence_information_t<i_t, f_t>::convergence_information_t(
 
   // Zero the residual workspace (reused each iteration by compute_convergence_information).
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_));
+    primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_));
+    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
 }
 
 // ---------------------------------------------------------------------------
@@ -285,7 +285,7 @@ void convergence_information_t<i_t, f_t>::init_reduction_storage()
                          bound_value_.begin(),
                          dual_objective_.data(),
                          dual_size_h_,
-                         stream_view_);
+                         stream_view_.get());
 
   size_t temp_storage_bytes_2 = 0;
   cub::DeviceReduce::Sum(d_temp_storage,
@@ -293,7 +293,7 @@ void convergence_information_t<i_t, f_t>::init_reduction_storage()
                          bound_value_.begin(),
                          reduced_cost_dual_objective_.data(),
                          primal_size_h_,
-                         stream_view_);
+                         stream_view_.get());
 
   size_of_buffer_       = std::max({temp_storage_bytes_1, temp_storage_bytes_2});
   this->rmm_tmp_buffer_ = rmm::device_buffer{size_of_buffer_, stream_view_};
@@ -359,7 +359,7 @@ void convergence_information_t<i_t, f_t>::swap_context(
   const auto [grid_size, block_size] =
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   convergence_information_swap_device_vectors_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(thrust::raw_pointer_cast(swap_pairs.data()),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
                                                  static_cast<i_t>(swap_pairs.size()),
                                                  make_span(primal_objective_),
                                                  make_span(dual_objective_),
@@ -690,14 +690,14 @@ void convergence_information_t<i_t, f_t>::compute_convergence_information(
   // behaviour
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
   compute_remaining_stats_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(this->view(), climber_strategies_.size());
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(this->view(), climber_strategies_.size());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 
   //  cleanup for next termination evaluation
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_));
+    primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_));
+    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
 }
 
 template <typename f_t>
@@ -726,7 +726,7 @@ void convergence_information_t<i_t, f_t>::compute_primal_residual(
                                          cusparse_view.tmp_dual.get(),
                                          CUSPARSE_SPMV_CSR_ALG2,
                                          (f_t*)cusparse_view.buffer_non_transpose.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
   } else {
     RAFT_CUSPARSE_TRY(
       raft::sparse::detail::cusparsespmm(handle_ptr_->get_cusparse_handle(),
@@ -739,7 +739,7 @@ void convergence_information_t<i_t, f_t>::compute_primal_residual(
                                          cusparse_view.batch_tmp_duals.get(),
                                          CUSPARSE_SPMM_CSR_ALG3,
                                          (f_t*)cusparse_view.buffer_non_transpose_batch.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
   }
 
   if (!hyper_params_.use_reflected_primal_dual) {
@@ -754,7 +754,7 @@ void convergence_information_t<i_t, f_t>::compute_primal_residual(
                                                  problem_ptr->constraint_upper_bounds.data(),
                                                  dual_size_h_,
                                                  violation<f_t>(),
-                                                 stream_view_);
+                                                 stream_view_.get());
   } else {
     cuopt_assert(primal_residual_.size() == primal_slack_.size(),
                  "Both vectors should had the same size");
@@ -811,7 +811,7 @@ void convergence_information_t<i_t, f_t>::compute_primal_objective_owned_partial
                                                   problem_ptr->objective_coefficients.data(),
                                                   primal_stride,
                                                   primal_objective_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -846,7 +846,7 @@ template <typename i_t, typename f_t>
 void convergence_information_t<i_t, f_t>::apply_primal_objective_scaling_and_offset()
 {
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
-  apply_objective_scaling_and_offset<i_t, f_t><<<grid_size, block_size, 0, stream_view_>>>(
+  apply_objective_scaling_and_offset<i_t, f_t><<<grid_size, block_size, 0, stream_view_.get()>>>(
     make_span(primal_objective_),
     problem_ptr->presolve_data.objective_scaling_factor,
     make_span(objective_offsets_),
@@ -888,7 +888,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_residual(
                                          cusparse_view.tmp_primal.get(),
                                          CUSPARSE_SPMV_CSR_ALG2,
                                          (f_t*)cusparse_view.buffer_transpose.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
   } else {
     RAFT_CUSPARSE_TRY(
       raft::sparse::detail::cusparsespmm(handle_ptr_->get_cusparse_handle(),
@@ -901,7 +901,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_residual(
                                          cusparse_view.batch_tmp_primals.get(),
                                          CUSPARSE_SPMM_CSR_ALG3,
                                          (f_t*)cusparse_view.buffer_transpose_batch.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
   }
 
   // Substract with the objective vector manually to avoid possible cusparse bug w/ nonzero beta and
@@ -935,7 +935,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_residual(
                              tmp_primal.data(),  // primal_gradient
                              reduced_cost_.data(),
                              primal_size_h_,
-                             stream_view_);
+                             stream_view_.get());
   }
 }
 
@@ -963,7 +963,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective_owned_partial(
                                                   primal_solution.data(),
                                                   primal_stride,
                                                   dual_dot_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
   // sum_primal_slack_ = Σ primal_slack_[0:n_owned_cstr]
   // primal_slack_ is assumed populated for owned cstrs by a prior
@@ -973,7 +973,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective_owned_partial(
                          primal_slack_.data(),
                          sum_primal_slack_.data(),
                          static_cast<int>(n_owned_cstr),
-                         stream_view_);
+                         stream_view_.get());
 
   // dual_objective_ = dual_dot_ + sum_primal_slack_ (still a partial sum).
   cub::DeviceTransform::Transform(cuda::std::make_tuple(dual_dot_.data(), sum_primal_slack_.data()),
@@ -1008,14 +1008,14 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective(
                             problem_ptr->constraint_upper_bounds.data(),
                             dual_size_h_,
                             constraint_bound_value_reduced_cost_product<f_t>(),
-                            stream_view_);
+                            stream_view_.get());
 
     cub::DeviceReduce::Sum(rmm_tmp_buffer_.data(),
                            size_of_buffer_,
                            bound_value_.begin(),
                            dual_objective_.data(),
                            dual_size_h_,
-                           stream_view_);
+                           stream_view_.get());
 
     compute_reduced_costs_dual_objective_contribution();
 
@@ -1023,7 +1023,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective(
                              dual_objective_.data(),
                              reduced_cost_dual_objective_.data(),
                              1,
-                             stream_view_);
+                             stream_view_.get());
   } else {
     // Reflected path.
     if (!batch_mode_) {
@@ -1064,7 +1064,7 @@ template <typename i_t, typename f_t>
 void convergence_information_t<i_t, f_t>::apply_dual_objective_scaling_and_offset()
 {
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
-  apply_objective_scaling_and_offset<i_t, f_t><<<grid_size, block_size, 0, stream_view_>>>(
+  apply_objective_scaling_and_offset<i_t, f_t><<<grid_size, block_size, 0, stream_view_.get()>>>(
     make_span(dual_objective_),
     problem_ptr->presolve_data.objective_scaling_factor,
     make_span(objective_offsets_),
@@ -1093,14 +1093,14 @@ void convergence_information_t<i_t, f_t>::compute_reduced_cost_from_primal_gradi
                             primal_gradient.data(),
                             primal_size_h_,
                             copy_gradient_if_should_be_reduced_cost<f_t>(),
-                            stream_view_);
+                            stream_view_.get());
   } else {
     raft::linalg::binaryOp(reduced_cost_.data(),
                            bound_value_.data(),
                            primal_gradient.data(),
                            primal_size_h_,
                            copy_gradient_if_finite_bounds<f_t>(),
-                           stream_view_);
+                           stream_view_.get());
   }
 }
 
@@ -1125,7 +1125,7 @@ void convergence_information_t<i_t, f_t>::compute_reduced_costs_dual_objective_c
                          bound_value_.begin(),
                          reduced_cost_dual_objective_.data(),
                          primal_size_h_,
-                         stream_view_);
+                         stream_view_.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -774,7 +774,7 @@ void convergence_information_t<i_t, f_t>::compute_primal_residual(
                 raft::max(dual, f_t(0.0)) * finite_or_zero(lower) +
                   raft::min(dual, f_t(0.0)) * finite_or_zero(upper)};
       },
-      stream_view_.value());
+      stream_view_.get());
   }
 
 #ifdef PDLP_DEBUG_MODE
@@ -922,7 +922,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_residual(
                                     dual_residual_.data(),
                                     dual_residual_.size(),
                                     cuda::std::minus<>{},
-                                    stream_view_.value());
+                                    stream_view_.get());
   } else {
     cuopt_expects(!batch_mode_,
                   error_type_t::ValidationError,
@@ -1084,7 +1084,7 @@ void convergence_information_t<i_t, f_t>::compute_reduced_cost_from_primal_gradi
     bound_value_.data(),
     primal_size_h_,
     bound_value_gradient<f_t, f_t2>(),
-    stream_view_.value());
+    stream_view_.get());
 
   if (hyper_params_.handle_some_primal_gradients_on_finite_bounds_as_residuals) {
     raft::linalg::ternaryOp(reduced_cost_.data(),
@@ -1117,7 +1117,7 @@ void convergence_information_t<i_t, f_t>::compute_reduced_costs_dual_objective_c
     bound_value_.data(),
     primal_size_h_,
     bound_value_reduced_cost_product<f_t, f_t2>(),
-    stream_view_.value());
+    stream_view_.get());
 
   // sum over bound_value*reduced_cost, but should be -inf if any element is -inf
   cub::DeviceReduce::Sum(rmm_tmp_buffer_.data(),

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -415,7 +415,7 @@ void convergence_information_t<i_t, f_t>::set_relative_primal_tolerance_factor(
                                   l2_norm_primal_right_hand_side_.data(),
                                   l2_norm_primal_right_hand_side_.size(),
                                   cuda::std::identity{},
-                                  stream_view_);
+                                  stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -599,7 +599,7 @@ void convergence_information_t<i_t, f_t>::compute_convergence_information(
       l2_primal_residual_.data(),
       l2_primal_residual_.size(),
       [] HD(f_t x) { return raft::sqrt(x); },
-      stream_view_);
+      stream_view_.get());
   }
 
 #ifdef CUPDLP_DEBUG_MODE
@@ -668,7 +668,7 @@ void convergence_information_t<i_t, f_t>::compute_convergence_information(
       l2_dual_residual_.data(),
       l2_dual_residual_.size(),
       [] HD(f_t x) { return raft::sqrt(x); },
-      stream_view_);
+      stream_view_.get());
   }
 #ifdef CUPDLP_DEBUG_MODE
   print("Absolute Dual Residual", l2_dual_residual_);
@@ -914,7 +914,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_residual(
     tmp_primal.data(),
     tmp_primal.size(),
     cuda::std::minus<>{},
-    stream_view_);
+    stream_view_.get());
 
   if (hyper_params_.use_reflected_primal_dual) {
     cuopt_assert(reduced_cost_.size() == dual_slack.size(),
@@ -982,7 +982,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective_owned_partial(
                                   dual_objective_.data(),
                                   1,
                                   cuda::std::plus<>{},
-                                  stream_view_);
+                                  stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -1050,7 +1050,7 @@ void convergence_information_t<i_t, f_t>::compute_dual_objective(
         dual_objective_.data(),
         dual_objective_.size(),
         cuda::std::plus<>{},
-        stream_view_);
+        stream_view_.get());
     }
   }
 

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -114,8 +114,8 @@ convergence_information_t<i_t, f_t>::convergence_information_t(
   // Zero the residual workspace (reused each iteration by compute_convergence_information).
   RAFT_CUDA_TRY(cudaMemsetAsync(
     primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
 }
 
 // ---------------------------------------------------------------------------
@@ -362,20 +362,20 @@ void convergence_information_t<i_t, f_t>::swap_context(
     kernel_config_from_batch_size(static_cast<i_t>(swap_pairs.size()));
   convergence_information_swap_device_vectors_kernel<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(thrust::raw_pointer_cast(swap_pairs.data()),
-                                                 static_cast<i_t>(swap_pairs.size()),
-                                                 make_span(primal_objective_),
-                                                 make_span(dual_objective_),
-                                                 make_span(l2_primal_residual_),
-                                                 make_span(l2_dual_residual_),
-                                                 make_span(linf_primal_residual_),
-                                                 make_span(linf_dual_residual_),
-                                                 make_span(gap_),
-                                                 make_span(abs_objective_),
-                                                 make_span(dual_dot_),
-                                                 make_span(sum_primal_slack_),
-                                                 make_span(objective_offsets_),
-                                                 make_span(l2_norm_primal_linear_objective_),
-                                                 make_span(l2_norm_primal_right_hand_side_));
+                                                       static_cast<i_t>(swap_pairs.size()),
+                                                       make_span(primal_objective_),
+                                                       make_span(dual_objective_),
+                                                       make_span(l2_primal_residual_),
+                                                       make_span(l2_dual_residual_),
+                                                       make_span(linf_primal_residual_),
+                                                       make_span(linf_dual_residual_),
+                                                       make_span(gap_),
+                                                       make_span(abs_objective_),
+                                                       make_span(dual_dot_),
+                                                       make_span(sum_primal_slack_),
+                                                       make_span(objective_offsets_),
+                                                       make_span(l2_norm_primal_linear_objective_),
+                                                       make_span(l2_norm_primal_right_hand_side_));
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 
@@ -698,8 +698,8 @@ void convergence_information_t<i_t, f_t>::compute_convergence_information(
   //  cleanup for next termination evaluation
   RAFT_CUDA_TRY(cudaMemsetAsync(
     primal_residual_.data(), 0.0, sizeof(f_t) * primal_residual_.size(), stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    dual_residual_.data(), 0.0, sizeof(f_t) * dual_residual_.size(), stream_view_.get()));
 }
 
 template <typename f_t>

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -91,17 +91,19 @@ convergence_information_t<i_t, f_t>::convergence_information_t(
   // Zero-init per-climber scalars
   RAFT_CUDA_TRY(cudaMemsetAsync(
     primal_objective_.data(), 0, sizeof(f_t) * primal_objective_.size(), stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_objective_.data(), 0, sizeof(f_t) * dual_objective_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    dual_objective_.data(), 0, sizeof(f_t) * dual_objective_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(gap_.data(), 0, sizeof(f_t) * gap_.size(), stream_view_.get()));
-  RAFT_CUDA_TRY(
-    cudaMemsetAsync(abs_objective_.data(), 0, sizeof(f_t) * abs_objective_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(
+    abs_objective_.data(), 0, sizeof(f_t) * abs_objective_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     l2_dual_residual_.data(), 0, sizeof(f_t) * l2_dual_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     l2_primal_residual_.data(), 0, sizeof(f_t) * l2_primal_residual_.size(), stream_view_.get()));
-  RAFT_CUDA_TRY(cudaMemsetAsync(
-    linf_primal_residual_.data(), 0, sizeof(f_t) * linf_primal_residual_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(linf_primal_residual_.data(),
+                                0,
+                                sizeof(f_t) * linf_primal_residual_.size(),
+                                stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
     linf_dual_residual_.data(), 0, sizeof(f_t) * linf_dual_residual_.size(), stream_view_.get()));
 

--- a/cpp/src/pdlp/termination_strategy/convergence_information.cu
+++ b/cpp/src/pdlp/termination_strategy/convergence_information.cu
@@ -90,20 +90,20 @@ convergence_information_t<i_t, f_t>::convergence_information_t(
 {
   // Zero-init per-climber scalars
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    primal_objective_.data(), 0, sizeof(f_t) * primal_objective_.size(), stream_view_));
+    primal_objective_.data(), 0, sizeof(f_t) * primal_objective_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(dual_objective_.data(), 0, sizeof(f_t) * dual_objective_.size(), stream_view_));
-  RAFT_CUDA_TRY(cudaMemsetAsync(gap_.data(), 0, sizeof(f_t) * gap_.size(), stream_view_));
+    cudaMemsetAsync(dual_objective_.data(), 0, sizeof(f_t) * dual_objective_.size(), stream_view_.get()));
+  RAFT_CUDA_TRY(cudaMemsetAsync(gap_.data(), 0, sizeof(f_t) * gap_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(
-    cudaMemsetAsync(abs_objective_.data(), 0, sizeof(f_t) * abs_objective_.size(), stream_view_));
+    cudaMemsetAsync(abs_objective_.data(), 0, sizeof(f_t) * abs_objective_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    l2_dual_residual_.data(), 0, sizeof(f_t) * l2_dual_residual_.size(), stream_view_));
+    l2_dual_residual_.data(), 0, sizeof(f_t) * l2_dual_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    l2_primal_residual_.data(), 0, sizeof(f_t) * l2_primal_residual_.size(), stream_view_));
+    l2_primal_residual_.data(), 0, sizeof(f_t) * l2_primal_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    linf_primal_residual_.data(), 0, sizeof(f_t) * linf_primal_residual_.size(), stream_view_));
+    linf_primal_residual_.data(), 0, sizeof(f_t) * linf_primal_residual_.size(), stream_view_.get()));
   RAFT_CUDA_TRY(cudaMemsetAsync(
-    linf_dual_residual_.data(), 0, sizeof(f_t) * linf_dual_residual_.size(), stream_view_));
+    linf_dual_residual_.data(), 0, sizeof(f_t) * linf_dual_residual_.size(), stream_view_.get()));
 
   init_objective_offsets();
   init_reduction_storage();

--- a/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
+++ b/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
@@ -690,7 +690,7 @@ void infeasibility_information_t<i_t, f_t>::compute_reduced_cost_from_primal_gra
     bound_value_.data(),
     primal_size_h_,
     bound_value_gradient<f_t, f_t2>(),
-    stream_view_.value());
+    stream_view_.get());
 
   if (hyper_params_.handle_some_primal_gradients_on_finite_bounds_as_residuals) {
     raft::linalg::ternaryOp(reduced_cost_.data(),

--- a/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
+++ b/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
@@ -104,11 +104,11 @@ infeasibility_information_t<i_t, f_t>::infeasibility_information_t(
     RAFT_CUDA_TRY(cudaMemsetAsync(homogenous_primal_residual_.data(),
                                   0.0,
                                   sizeof(f_t) * homogenous_primal_residual_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(homogenous_dual_residual_.data(),
                                   0.0,
                                   sizeof(f_t) * homogenous_dual_residual_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
 
     // variable bounds in the homogenous primal are 0.0 if the original bound was finite, and
     // otherwise it is -inf for lower bounds and inf for upper bounds
@@ -116,12 +116,12 @@ infeasibility_information_t<i_t, f_t>::infeasibility_information_t(
                           problem_ptr->constraint_lower_bounds.data(),
                           dual_size_h_,
                           zero_if_is_finite<f_t>(),
-                          stream_view_);
+                          stream_view_.get());
     raft::linalg::unaryOp(homogenous_dual_upper_bounds_.data(),
                           problem_ptr->constraint_upper_bounds.data(),
                           dual_size_h_,
                           zero_if_is_finite<f_t>(),
-                          stream_view_);
+                          stream_view_.get());
 
     void* d_temp_storage        = NULL;
     size_t temp_storage_bytes_1 = 0;
@@ -130,7 +130,7 @@ infeasibility_information_t<i_t, f_t>::infeasibility_information_t(
                            bound_value_.begin(),
                            dual_ray_linear_objective_.data(),
                            dual_size_h_,
-                           stream_view_);
+                           stream_view_.get());
 
     size_t temp_storage_bytes_2 = 0;
     cub::DeviceReduce::Sum(d_temp_storage,
@@ -138,7 +138,7 @@ infeasibility_information_t<i_t, f_t>::infeasibility_information_t(
                            bound_value_.begin(),
                            reduced_cost_dual_objective_.data(),
                            primal_size_h_,
-                           stream_view_);
+                           stream_view_.get());
 
     size_of_buffer_       = std::max({temp_storage_bytes_1, temp_storage_bytes_2});
     this->rmm_tmp_buffer_ = rmm::device_buffer{size_of_buffer_, stream_view_};
@@ -146,20 +146,20 @@ infeasibility_information_t<i_t, f_t>::infeasibility_information_t(
     RAFT_CUDA_TRY(cudaMemsetAsync(dual_ray_linear_objective_.data(),
                                   0,
                                   sizeof(f_t) * dual_ray_linear_objective_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(max_dual_ray_infeasibility_.data(),
                                   0,
                                   sizeof(f_t) * max_dual_ray_infeasibility_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
 
     RAFT_CUDA_TRY(cudaMemsetAsync(primal_ray_linear_objective_.data(),
                                   0,
                                   sizeof(f_t) * primal_ray_linear_objective_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(max_primal_ray_infeasibility_.data(),
                                   0,
                                   sizeof(f_t) * max_primal_ray_infeasibility_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
   }
 }
 
@@ -327,7 +327,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
       scaled_cusparse_view_.batch_tmp_duals.get(),
       CUSPARSE_SPMM_CSR_ALG3,
       (f_t*)scaled_cusparse_view_.buffer_non_transpose_batch.data(),
-      stream_view_));
+      stream_view_.get()));
     RAFT_CUSPARSE_TRY(
       raft::sparse::detail::cusparsespmm(handle_ptr_->get_cusparse_handle(),
                                          CUSPARSE_OPERATION_NON_TRANSPOSE,
@@ -339,7 +339,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
                                          scaled_cusparse_view_.batch_tmp_primals.get(),
                                          CUSPARSE_SPMM_CSR_ALG3,
                                          (f_t*)scaled_cusparse_view_.buffer_transpose_batch.data(),
-                                         stream_view_));
+                                         stream_view_.get()));
 
 #ifdef CUPDLP_DEBUG_MODE
     print("primal_product", current_pdhg_solver.get_dual_tmp_resource());
@@ -507,12 +507,12 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
                                          reusable_device_scalar_value_1_.data(),
                                          primal_ray_inf_norm_.data(),
                                          1,
-                                         stream_view_);
+                                         stream_view_.get());
     raft::linalg::eltwiseMultiply(neg_primal_ray_inf_norm_inverse_.data(),
                                   primal_ray_inf_norm_inverse_.data(),
                                   reusable_device_scalar_value_neg_1_.data(),
                                   1,
-                                  stream_view_);
+                                  stream_view_.get());
 
     compute_homogenous_primal_residual(op_problem_cusparse_view_,
                                        current_pdhg_solver.get_dual_tmp_resource());
@@ -531,14 +531,14 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
     my_inf_norm(dual_ray, dual_ray_inf_norm_, handle_ptr_);
     my_inf_norm(reduced_cost_, reduced_cost_inf_norm_, handle_ptr_);
 
-    compute_remaining_stats_kernel<i_t, f_t><<<1, 1, 0, stream_view_>>>(this->view());
+    compute_remaining_stats_kernel<i_t, f_t><<<1, 1, 0, stream_view_.get()>>>(this->view());
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
     // reset for next round
     RAFT_CUDA_TRY(cudaMemsetAsync(homogenous_primal_residual_.data(),
                                   0.0,
                                   sizeof(f_t) * homogenous_primal_residual_.size(),
-                                  stream_view_));
+                                  stream_view_.get()));
     RAFT_CUDA_TRY(cudaMemsetAsync(
       homogenous_dual_residual_.data(), 0.0, sizeof(f_t) * homogenous_dual_residual_.size()));
   }
@@ -558,7 +558,7 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_primal_residual(
                                        cusparse_view.tmp_dual.get(),
                                        CUSPARSE_SPMV_CSR_ALG2,
                                        (f_t*)cusparse_view.buffer_non_transpose.data(),
-                                       stream_view_));
+                                       stream_view_.get()));
 
   raft::linalg::ternaryOp(homogenous_primal_residual_.data(),
                           tmp_dual.data(),
@@ -566,7 +566,7 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_primal_residual(
                           homogenous_dual_upper_bounds_.data(),
                           dual_size_h_,
                           violation<f_t>(),
-                          stream_view_);
+                          stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -599,14 +599,14 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_primal_objective(
                                                   problem_ptr->objective_coefficients.data(),
                                                   primal_stride,
                                                   primal_ray_linear_objective_.data(),
-                                                  stream_view_));
+                                                  stream_view_.get()));
 
   // just to scale from the primal ray scaling
   raft::linalg::eltwiseMultiply(primal_ray_linear_objective_.data(),
                                 primal_ray_linear_objective_.data(),
                                 primal_ray_inf_norm_inverse_.data(),
                                 1,
-                                stream_view_);
+                                stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -628,7 +628,7 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_dual_residual(
                                                        cusparse_view.tmp_primal.get(),
                                                        CUSPARSE_SPMV_CSR_ALG2,
                                                        (f_t*)cusparse_view.buffer_transpose.data(),
-                                                       stream_view_));
+                                                       stream_view_.get()));
 
   compute_reduced_cost_from_primal_gradient(tmp_primal,
                                             primal_ray);  // primal gradient is now in temp
@@ -637,7 +637,7 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_dual_residual(
                            tmp_primal.data(),  // primal_gradient
                            reduced_cost_.data(),
                            primal_size_h_,
-                           stream_view_);
+                           stream_view_.get());
 }
 
 template <typename i_t, typename f_t>
@@ -650,14 +650,14 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_dual_objective(
                           problem_ptr->constraint_upper_bounds.data(),
                           dual_size_h_,
                           constraint_bound_value_reduced_cost_product<f_t>(),
-                          stream_view_);
+                          stream_view_.get());
 
   cub::DeviceReduce::Sum(rmm_tmp_buffer_.data(),
                          size_of_buffer_,
                          bound_value_.begin(),
                          dual_ray_linear_objective_.data(),
                          dual_size_h_,
-                         stream_view_);
+                         stream_view_.get());
 
 #ifdef PDLP_DEBUG_MODE
   std::cout << "-compute_homogenous_dual_objective:\n"
@@ -671,7 +671,7 @@ void infeasibility_information_t<i_t, f_t>::compute_homogenous_dual_objective(
                            dual_ray_linear_objective_.data(),
                            reduced_cost_dual_objective_.data(),
                            1,
-                           stream_view_);
+                           stream_view_.get());
 #ifdef PDLP_DEBUG_MODE
   std::cout << "  reduced_cost_dual_objective_=" << reduced_cost_dual_objective_.value(stream_view_)
             << std::endl;
@@ -699,14 +699,14 @@ void infeasibility_information_t<i_t, f_t>::compute_reduced_cost_from_primal_gra
                             primal_gradient.data(),
                             primal_size_h_,
                             copy_gradient_if_should_be_reduced_cost<f_t>(),
-                            stream_view_);
+                            stream_view_.get());
   } else {
     raft::linalg::binaryOp(reduced_cost_.data(),
                            bound_value_.data(),
                            primal_gradient.data(),
                            primal_size_h_,
                            copy_gradient_if_finite_bounds<f_t>(),
-                           stream_view_);
+                           stream_view_.get());
   }
 }
 
@@ -730,7 +730,7 @@ void infeasibility_information_t<i_t, f_t>::compute_reduced_costs_dual_objective
                          bound_value_.begin(),
                          reduced_cost_dual_objective_.data(),
                          primal_size_h_,
-                         stream_view_);
+                         stream_view_.get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
+++ b/cpp/src/pdlp/termination_strategy/infeasibility_information.cu
@@ -263,7 +263,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         if (isfinite(upper)) primal_to_return = cuda::std::min(primal_to_return, f_t(0.0));
         return primal_to_return;
       },
-      stream_view_);
+      stream_view_.get());
 
     // Inf norm of primal ray
     segmented_sum_handler_.segmented_reduce_helper(primal_ray.data(),
@@ -285,7 +285,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         if (!isfinite(upper)) dual_to_return = cuda::std::max(dual_to_return, f_t(0.0));
         return dual_to_return;
       },
-      stream_view_);
+      stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
     print("delta_primal_solution after", primal_ray);
@@ -308,7 +308,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         if (primal_ray_inf_norm_value > f_t(0.0))
           primal_ray_data[id] = primal_ray_data[id] / primal_ray_inf_norm_value;
       },
-      stream_view_);
+      stream_view_.get());
 #ifdef CUPDLP_DEBUG_MODE
     print("delta_primal_solution after scale", primal_ray);
     print("delta_dual_solution after scale", dual_ray);
@@ -375,7 +375,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         return cuda::std::max(dual, f_t(0.0)) * finite_or_zero(lower) +
                cuda::std::min(dual, f_t(0.0)) * finite_or_zero(upper);
       },
-      stream_view_);
+      stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
     print("primal_slack", primal_slack_);
@@ -393,7 +393,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         return cuda::std::max(-dual, f_t(0.0)) * finite_or_zero(lower) +
                cuda::std::min(-dual, f_t(0.0)) * finite_or_zero(upper);
       },
-      stream_view_);
+      stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
     print("dual_slack", dual_slack_);
@@ -426,7 +426,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
                 cuda::std::max(primal, f_t(0.0)) * isfinite(upper)) *
                scale;
       },
-      stream_view_);
+      stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
     print("primal_slack", primal_slack_);
@@ -447,7 +447,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
                 cuda::std::min(-dual, f_t(0.0)) * !isfinite(upper)) *
                scale;
       },
-      stream_view_);
+      stream_view_.get());
 #ifdef CUPDLP_DEBUG_MODE
     print("dual_slack", dual_slack_);
 #endif
@@ -493,7 +493,7 @@ void infeasibility_information_t<i_t, f_t>::compute_infeasibility_information(
         else
           return {f_t(0.0), f_t(0.0)};
       },
-      stream_view_);
+      stream_view_.get());
 
 #ifdef CUPDLP_DEBUG_MODE
     printf("max_dual_ray_infeasibility=%lf\n",
@@ -722,7 +722,7 @@ void infeasibility_information_t<i_t, f_t>::compute_reduced_costs_dual_objective
     bound_value_.data(),
     primal_size_h_,
     bound_value_reduced_cost_product<f_t, f_t2>(),
-    stream_view_);
+    stream_view_.get());
 
   // sum over bound_value*reduced_cost
   cub::DeviceReduce::Sum(rmm_tmp_buffer_.data(),

--- a/cpp/src/pdlp/termination_strategy/termination_strategy.cu
+++ b/cpp/src/pdlp/termination_strategy/termination_strategy.cu
@@ -421,12 +421,12 @@ void pdlp_termination_strategy_t<i_t, f_t>::check_termination_criteria()
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
   check_termination_criteria_kernel<i_t, f_t>
     <<<grid_size, block_size, 0, stream_view_.get()>>>(convergence_information_.view(),
-                                                 infeasibility_information_.view(),
-                                                 make_span(termination_status_),
-                                                 settings_.tolerances,
-                                                 settings_.detect_infeasibility,
-                                                 settings_.per_constraint_residual,
-                                                 climber_strategies_.size());
+                                                       infeasibility_information_.view(),
+                                                       make_span(termination_status_),
+                                                       settings_.tolerances,
+                                                       settings_.detect_infeasibility,
+                                                       settings_.per_constraint_residual,
+                                                       climber_strategies_.size());
   RAFT_CUDA_TRY(cudaPeekAtLastError());
 }
 

--- a/cpp/src/pdlp/termination_strategy/termination_strategy.cu
+++ b/cpp/src/pdlp/termination_strategy/termination_strategy.cu
@@ -188,7 +188,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::evaluate_termination_criteria(
   check_termination_criteria();
 
   // Sync to make sure the termination status is updated
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -509,7 +509,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::fill_gpu_terms_stats(i_t number_of_i
     settings_.per_constraint_residual,
     force_all);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 }
 
 template <typename i_t, typename f_t>
@@ -641,7 +641,7 @@ pdlp_termination_strategy_t<i_t, f_t>::fill_return_problem_solution(
     }
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
+  stream_view_.sync();
 
   if (deep_copy) {
     cuopt_assert(

--- a/cpp/src/pdlp/termination_strategy/termination_strategy.cu
+++ b/cpp/src/pdlp/termination_strategy/termination_strategy.cu
@@ -188,7 +188,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::evaluate_termination_criteria(
   check_termination_criteria();
 
   // Sync to make sure the termination status is updated
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -420,7 +420,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::check_termination_criteria()
 #endif
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
   check_termination_criteria_kernel<i_t, f_t>
-    <<<grid_size, block_size, 0, stream_view_>>>(convergence_information_.view(),
+    <<<grid_size, block_size, 0, stream_view_.get()>>>(convergence_information_.view(),
                                                  infeasibility_information_.view(),
                                                  make_span(termination_status_),
                                                  settings_.tolerances,
@@ -499,7 +499,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::fill_gpu_terms_stats(i_t number_of_i
   const bool accept_primal_feasible =
     settings_.first_primal_feasible || settings_.all_primal_feasible;
   const auto [grid_size, block_size] = kernel_config_from_batch_size(climber_strategies_.size());
-  fill_gpu_terms_stats_kernel<i_t, f_t><<<grid_size, block_size, 0, stream_view_>>>(
+  fill_gpu_terms_stats_kernel<i_t, f_t><<<grid_size, block_size, 0, stream_view_.get()>>>(
     make_span(termination_status_),
     make_span(original_index_),
     gpu_batch_additional_termination_information_.view(),
@@ -509,7 +509,7 @@ void pdlp_termination_strategy_t<i_t, f_t>::fill_gpu_terms_stats(i_t number_of_i
     settings_.per_constraint_residual,
     force_all);
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 }
 
 template <typename i_t, typename f_t>
@@ -641,7 +641,7 @@ pdlp_termination_strategy_t<i_t, f_t>::fill_return_problem_solution(
     }
   }
 
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view_.get()));
 
   if (deep_copy) {
     cuopt_assert(

--- a/cpp/src/pdlp/translate.hpp
+++ b/cpp/src/pdlp/translate.hpp
@@ -354,14 +354,14 @@ void translate_to_crossover_problem(const mip::problem_t<i_t, f_t>& problem,
   csr_A.j         = std::vector<i_t>(cuopt::host_copy(problem.variables, stream));
   csr_A.row_start = std::vector<i_t>(cuopt::host_copy(problem.offsets, stream));
 
-  stream.synchronize();
+  stream.sync();
   CUOPT_LOG_DEBUG("Converting to compressed column");
   csr_A.to_compressed_col(lp.A);
   CUOPT_LOG_DEBUG("Converted to compressed column");
 
   std::vector<f_t> slack(problem.n_constraints);
   std::vector<f_t> tmp_x = cuopt::host_copy(sol.get_primal_solution(), stream);
-  stream.synchronize();
+  stream.sync();
   matrix_vector_multiply(lp.A, f_t(1.0), tmp_x, f_t(0.0), slack);
   CUOPT_LOG_DEBUG("Multiplied A and x");
 
@@ -400,7 +400,7 @@ void translate_to_crossover_problem(const mip::problem_t<i_t, f_t>& problem,
   std::copy(lower.begin(), lower.begin() + problem.n_variables, lp.lower.begin());
   std::copy(upper.begin(), upper.begin() + problem.n_variables, lp.upper.begin());
 
-  problem.handle_ptr->get_stream().synchronize();
+  problem.handle_ptr->get_stream().sync();
   for (i_t i = 0; i < m; ++i) {
     lp.lower[problem.n_variables + i] = constraint_lower[i];
     lp.upper[problem.n_variables + i] = constraint_upper[i];
@@ -420,7 +420,7 @@ void translate_to_crossover_problem(const mip::problem_t<i_t, f_t>& problem,
   initial_solution.y = cuopt::host_copy(sol.get_dual_solution(), stream);
 
   std::vector<f_t> tmp_z = cuopt::host_copy(sol.get_reduced_cost(), stream);
-  stream.synchronize();
+  stream.sync();
   std::copy(tmp_z.begin(), tmp_z.begin() + problem.n_variables, initial_solution.z.begin());
   for (i_t j = problem.n_variables; j < n; ++j) {
     initial_solution.z[j] = initial_solution.y[j - problem.n_variables];

--- a/cpp/src/pdlp/utilities/cython_solve.cu
+++ b/cpp/src/pdlp/utilities/cython_solve.cu
@@ -22,6 +22,8 @@
 #include <utilities/copy_helpers.hpp>
 #include <utilities/logger.hpp>
 
+#include <cuda/stream>
+
 #include <raft/core/handle.hpp>
 #include <raft/core/nvtx.hpp>
 
@@ -129,18 +131,20 @@ std::unique_ptr<solver_ret_t> call_solve(
       // all returned device_buffers with a long-lived stream for safe deallocation later.
       auto& gpu_sols =
         std::get<linear_programming_ret_t::gpu_solutions_t>(response.lp_ret.solutions_);
-      gpu_sols.primal_solution_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.dual_solution_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.reduced_cost_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.current_primal_solution_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.current_dual_solution_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.initial_primal_average_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.initial_dual_average_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.current_ATY_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.sum_primal_solutions_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.sum_dual_solutions_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.last_restart_duality_gap_primal_solution_->set_stream(rmm::cuda_stream_per_thread);
-      gpu_sols.last_restart_duality_gap_dual_solution_->set_stream(rmm::cuda_stream_per_thread);
+      gpu_sols.primal_solution_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.dual_solution_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.reduced_cost_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.current_primal_solution_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.current_dual_solution_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.initial_primal_average_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.initial_dual_average_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.current_ATY_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.sum_primal_solutions_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.sum_dual_solutions_->set_stream(cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.last_restart_duality_gap_primal_solution_->set_stream(
+        cuda::stream_ref{cudaStreamPerThread});
+      gpu_sols.last_restart_duality_gap_dual_solution_->set_stream(
+        cuda::stream_ref{cudaStreamPerThread});
 
     } else {
       // MIP solve
@@ -153,7 +157,7 @@ std::unique_ptr<solver_ret_t> call_solve(
 
       // Same stream reassociation as the LP path above.
       auto& gpu_sol = std::get<gpu_buffer>(response.mip_ret.solution_);
-      gpu_sol->set_stream(rmm::cuda_stream_per_thread);
+      gpu_sol->set_stream(cuda::stream_ref{cudaStreamPerThread});
     }
 
     // Reset warmstart data streams in solver_settings (skip in batch mode to avoid data race
@@ -161,17 +165,17 @@ std::unique_ptr<solver_ret_t> call_solve(
     if (!is_batch_mode) {
       auto& warmstart_data = solver_settings->get_pdlp_settings().get_pdlp_warm_start_data();
       if (warmstart_data.current_primal_solution_.size() > 0) {
-        warmstart_data.current_primal_solution_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.current_dual_solution_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.initial_primal_average_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.initial_dual_average_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.current_ATY_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.sum_primal_solutions_.set_stream(rmm::cuda_stream_per_thread);
-        warmstart_data.sum_dual_solutions_.set_stream(rmm::cuda_stream_per_thread);
+        warmstart_data.current_primal_solution_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.current_dual_solution_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.initial_primal_average_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.initial_dual_average_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.current_ATY_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.sum_primal_solutions_.set_stream(cuda::stream_ref{cudaStreamPerThread});
+        warmstart_data.sum_dual_solutions_.set_stream(cuda::stream_ref{cudaStreamPerThread});
         warmstart_data.last_restart_duality_gap_primal_solution_.set_stream(
-          rmm::cuda_stream_per_thread);
+          cuda::stream_ref{cudaStreamPerThread});
         warmstart_data.last_restart_duality_gap_dual_solution_.set_stream(
-          rmm::cuda_stream_per_thread);
+          cuda::stream_ref{cudaStreamPerThread});
       }
     }
 

--- a/cpp/src/pdlp/utils.cuh
+++ b/cpp/src/pdlp/utils.cuh
@@ -356,7 +356,7 @@ void inline compute_sum_bounds_squared(const rmm::device_uvector<f_t>& constrain
     cuda::std::plus<>{},
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
-    stream_view);
+    stream_view.get());
 
   d_temp_storage.resize(bytes, stream_view);
 
@@ -369,8 +369,8 @@ void inline compute_sum_bounds_squared(const rmm::device_uvector<f_t>& constrain
     cuda::std::plus<>{},
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
-    stream_view);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+    stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 }
 
 // Weighted sum of squares of the first n entries of `values` (no fused sqrt).
@@ -394,7 +394,7 @@ void inline compute_sum_weighted_squares(const rmm::device_uvector<f_t>& values,
                                      cuda::std::plus<>{},
                                      weighted_square_op<f_t>{weight},
                                      f_t(0),
-                                     stream_view);
+                                     stream_view.get());
 
   d_temp_storage.resize(bytes, stream_view);
 
@@ -406,8 +406,8 @@ void inline compute_sum_weighted_squares(const rmm::device_uvector<f_t>& values,
                                      cuda::std::plus<>{},
                                      weighted_square_op<f_t>{weight},
                                      f_t(0),
-                                     stream_view);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+                                     stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 }
 
 // Like compute_sum_bounds_squared, but writes sqrt(sum of squares) (the L2 norm).
@@ -428,7 +428,7 @@ void inline compute_sum_bounds(const rmm::device_uvector<f_t>& constraint_lower_
     cuda::std::plus<>{},
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
-    stream_view);
+    stream_view.get());
 
   d_temp_storage.resize(bytes, stream_view);
 
@@ -441,8 +441,8 @@ void inline compute_sum_bounds(const rmm::device_uvector<f_t>& constraint_lower_
     cuda::std::plus<>{},
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
-    stream_view);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view));
+    stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 }
 
 template <typename f_t>
@@ -688,7 +688,7 @@ void inline my_l2_norm(const f_t* in, f_t* out, size_t size, raft::handle_t cons
 {
   constexpr int stride = 1;
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublasnrm2(
-    handle_ptr->get_cublas_handle(), size, in, stride, out, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), size, in, stride, out, handle_ptr->get_stream().get()));
 }
 
 template <typename i_t, typename f_t>
@@ -721,7 +721,7 @@ void inline my_l2_weighted_norm(const f_t* input_vector,
                                                   (i_t)size,
                                                   1,
                                                   f_t(0.0),
-                                                  stream,
+                                                  stream.get(),
                                                   false,
                                                   main_op,
                                                   raft::Sum<f_t>(),
@@ -779,10 +779,10 @@ void inline my_inf_norm(const rmm::device_uvector<f_t>& input_vector,
 
   void* d_temp      = nullptr;
   size_t temp_bytes = 0;
-  cub::DeviceReduce::Max(d_temp, temp_bytes, abs_iter, result, n, stream);
+  cub::DeviceReduce::Max(d_temp, temp_bytes, abs_iter, result, n, stream.get());
   rmm::device_buffer temp_buf(temp_bytes, stream);
-  cub::DeviceReduce::Max(temp_buf.data(), temp_bytes, abs_iter, result, n, stream);
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+  cub::DeviceReduce::Max(temp_buf.data(), temp_bytes, abs_iter, result, n, stream.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 }
 
 template <typename f_t>

--- a/cpp/src/pdlp/utils.cuh
+++ b/cpp/src/pdlp/utils.cuh
@@ -370,7 +370,7 @@ void inline compute_sum_bounds_squared(const rmm::device_uvector<f_t>& constrain
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
     stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 }
 
 // Weighted sum of squares of the first n entries of `values` (no fused sqrt).
@@ -407,7 +407,7 @@ void inline compute_sum_weighted_squares(const rmm::device_uvector<f_t>& values,
                                      weighted_square_op<f_t>{weight},
                                      f_t(0),
                                      stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 }
 
 // Like compute_sum_bounds_squared, but writes sqrt(sum of squares) (the L2 norm).
@@ -442,7 +442,7 @@ void inline compute_sum_bounds(const rmm::device_uvector<f_t>& constraint_lower_
     rhs_sum_of_squares_t<f_t>{},
     f_t(0),
     stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 }
 
 template <typename f_t>
@@ -782,7 +782,7 @@ void inline my_inf_norm(const rmm::device_uvector<f_t>& input_vector,
   cub::DeviceReduce::Max(d_temp, temp_bytes, abs_iter, result, n, stream.get());
   rmm::device_buffer temp_buf(temp_bytes, stream);
   cub::DeviceReduce::Max(temp_buf.data(), temp_bytes, abs_iter, result, n, stream.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+  stream.sync();
 }
 
 template <typename f_t>

--- a/cpp/src/pdlp/utils.cuh
+++ b/cpp/src/pdlp/utils.cuh
@@ -329,7 +329,7 @@ void inline combine_constraint_bounds(const mip::problem_t<i_t, f_t>& op_problem
                                   combined_bounds.data(),
                                   combined_bounds.size(),
                                   combine_finite_abs_bounds<f_t>(),
-                                  op_problem.handle_ptr->get_stream());
+                                  op_problem.handle_ptr->get_stream().get());
 }
 
 // Same as compute_sum_bounds, but without the fused sqrt.

--- a/cpp/src/routing/adapters/adapted_sol.cuh
+++ b/cpp/src/routing/adapters/adapted_sol.cuh
@@ -351,7 +351,7 @@ struct adapted_sol_t {
       i_t id_to_remove = routes_to_remove[i] - i;
       remove_host_route(id_to_remove);
     }
-    RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
     populate_host_data(false, true);
     check_device_host_coherence();
   }

--- a/cpp/src/routing/adapters/assignment_adapter.cuh
+++ b/cpp/src/routing/adapters/assignment_adapter.cuh
@@ -27,7 +27,7 @@ assignment_t<i_t> ges_solver_t<i_t, f_t, REQUEST>::get_ges_assignment(
   // the stream should be the initial handle stream and not the sol_handle stream as this data will
   // be exported
   auto stream = problem.handle_ptr->get_stream();
-  stream.synchronize();
+  stream.sync();
 
   const auto& problem = *sol.problem_ptr;
   i_t n_output_nodes  = sol.get_n_routes() * 2 + sol.get_num_depot_excluded_orders() +
@@ -39,7 +39,7 @@ assignment_t<i_t> ges_solver_t<i_t, f_t, REQUEST>::get_ges_assignment(
   rmm::device_uvector<i_t> route_locations_out(0, stream);
   rmm::device_uvector<i_t> node_types_out(0, stream);
   auto accepted_out = cuopt::device_copy(accepted, stream);
-  stream.synchronize();
+  stream.sync();
   std::vector<i_t> node_types_out_h(n_output_nodes);
   std::vector<i_t> route_out_h(n_output_nodes);
   std::vector<i_t> truck_id_out_h(n_output_nodes);
@@ -150,7 +150,7 @@ assignment_t<i_t> ges_solver_t<i_t, f_t, REQUEST>::get_ges_assignment(
 
   auto unserviced_nodes_h = sol.get_unserviced_nodes();
   auto unserviced_nodes   = cuopt::device_copy(unserviced_nodes_h, stream);
-  stream.synchronize();
+  stream.sync();
 
   std::map<objective_t, double> objective_values;
   for (int i = 0; i < (int)objective_t::SIZE; ++i) {

--- a/cpp/src/routing/adapters/solution_adapter.cuh
+++ b/cpp/src/routing/adapters/solution_adapter.cuh
@@ -32,7 +32,7 @@ void fill_routes_data(solution_t<i_t, f_t, REQUEST>& sol,
   auto h_node_types      = cuopt::host_copy(assignment.get_node_types(), stream);
 
   sol.sol_handle->sync_stream();
-  assignment.get_truck_id().stream().synchronize();
+  assignment.get_truck_id().stream().sync();
   i_t route_id = -1;
   NodeInfo<i_t> curr_node;
   // depot is counter only once

--- a/cpp/src/routing/assignment.cu
+++ b/cpp/src/routing/assignment.cu
@@ -196,10 +196,9 @@ void assignment_t<i_t>::to_csv(std::string_view filename, rmm::cuda_stream_view 
   route.resize(route_.size());
   arrival_stamp.resize(arrival_stamp_.size());
   truck_id.resize(truck_id_.size());
-  raft::copy(route.data(), route_.data(), route_.size(), stream_view.value());
-  raft::copy(
-    arrival_stamp.data(), arrival_stamp_.data(), arrival_stamp_.size(), stream_view.value());
-  raft::copy(truck_id.data(), truck_id_.data(), truck_id_.size(), stream_view.value());
+  raft::copy(route.data(), route_.data(), route_.size(), stream_view.get());
+  raft::copy(arrival_stamp.data(), arrival_stamp_.data(), arrival_stamp_.size(), stream_view.get());
+  raft::copy(truck_id.data(), truck_id_.data(), truck_id_.size(), stream_view.get());
   std::ofstream myfile(filename.data());
   std::cout << "truck_id,\troute,\tarrival_time\n";
   for (size_t i = 0; i < route.size(); i++)

--- a/cpp/src/routing/cpu_routing_problem.cu
+++ b/cpp/src/routing/cpu_routing_problem.cu
@@ -87,7 +87,7 @@ std::unique_ptr<rmm::device_uvector<bool>> copy_u8_as_bool(std::vector<uint8_t> 
   // as_bool is a local temporary and the H2D copy above is async; drain the
   // stream before it goes out of scope so the copy does not read freed host
   // memory.
-  stream.synchronize();
+  stream.sync();
   return d;
 }
 
@@ -302,7 +302,7 @@ cpu_routing_problem_t::to_device(raft::handle_t* handle) const
     data->init_types = copy_vector(types, stream);
     // types is a local temporary feeding an async H2D copy; drain before it
     // goes out of scope.
-    stream.synchronize();
+    stream.sync();
 
     int32_t n_nodes = static_cast<int32_t>(initial_solutions.routes.size());
     int32_t n_sols  = static_cast<int32_t>(initial_solutions.sol_offsets.size());

--- a/cpp/src/routing/crossovers/optimal_eax_cycles.cu
+++ b/cpp/src/routing/crossovers/optimal_eax_cycles.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -179,8 +179,9 @@ bool optimal_cycles_t<i_t, f_t, REQUEST>::insert_cycle_to_found_position(
     return false;
   }
   // prepare the rotations once and copy them to respective device arrays
-  insert_optimal_rotation_kernel<i_t, f_t><<<1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(
-    solution.view(), index_delta_pair.data(), eax_fragment.view(), n_rotations);
+  insert_optimal_rotation_kernel<i_t, f_t>
+    <<<1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(
+      solution.view(), index_delta_pair.data(), eax_fragment.view(), n_rotations);
   solution.compute_route_id_per_node();
   solution.compute_cost();
   return true;
@@ -223,12 +224,13 @@ bool optimal_cycles_t<i_t, f_t, REQUEST>::add_cycles_request(
       n_rotations);
 
     i_t n_blocks = (n_rotations * n_positions + TPB - 1) / TPB;
-    find_optimal_position_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.sol_handle->get_stream().get()>>>(
-      solution.view(),
-      resource.ls.move_candidates.view(),
-      eax_fragment.view(),
-      n_rotations,
-      raft::device_span<double>(eax_cycle_delta.data(), eax_cycle_delta.size()));
+    find_optimal_position_kernel<i_t, f_t>
+      <<<n_blocks, TPB, 0, solution.sol_handle->get_stream().get()>>>(
+        solution.view(),
+        resource.ls.move_candidates.view(),
+        eax_fragment.view(),
+        n_rotations,
+        raft::device_span<double>(eax_cycle_delta.data(), eax_cycle_delta.size()));
     get_min_delta_and_index(sol, n_rotations * n_positions);
     bool success = insert_cycle_to_found_position(sol, n_rotations);
 

--- a/cpp/src/routing/crossovers/optimal_eax_cycles.cu
+++ b/cpp/src/routing/crossovers/optimal_eax_cycles.cu
@@ -151,7 +151,7 @@ void optimal_cycles_t<i_t, f_t, REQUEST>::get_min_delta_and_index(
                             eax_cycle_delta.data(),
                             index_delta_pair.data(),
                             num_items,
-                            sol.sol.sol_handle->get_stream());
+                            sol.sol.sol_handle->get_stream().get());
   // Allocate temporary storage
   if (d_cub_storage_bytes.size() < temp_storage_bytes) {
     d_cub_storage_bytes.resize(temp_storage_bytes, sol.sol.sol_handle->get_stream());
@@ -162,7 +162,7 @@ void optimal_cycles_t<i_t, f_t, REQUEST>::get_min_delta_and_index(
                             eax_cycle_delta.data(),
                             index_delta_pair.data(),
                             num_items,
-                            sol.sol.sol_handle->get_stream());
+                            sol.sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -179,7 +179,7 @@ bool optimal_cycles_t<i_t, f_t, REQUEST>::insert_cycle_to_found_position(
     return false;
   }
   // prepare the rotations once and copy them to respective device arrays
-  insert_optimal_rotation_kernel<i_t, f_t><<<1, TPB, sh_size, solution.sol_handle->get_stream()>>>(
+  insert_optimal_rotation_kernel<i_t, f_t><<<1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(
     solution.view(), index_delta_pair.data(), eax_fragment.view(), n_rotations);
   solution.compute_route_id_per_node();
   solution.compute_cost();
@@ -216,14 +216,14 @@ bool optimal_cycles_t<i_t, f_t, REQUEST>::add_cycles_request(
 
     constexpr i_t TPB = 128;
     // prepare the rotations once and copy them to respective device arrays
-    create_rotations_kernel<i_t, f_t><<<1, TPB, 0, solution.sol_handle->get_stream()>>>(
+    create_rotations_kernel<i_t, f_t><<<1, TPB, 0, solution.sol_handle->get_stream().get()>>>(
       solution.view(),
       raft::device_span<NodeInfo<>>(d_cycle.data(), d_cycle.size()),
       eax_fragment.view(),
       n_rotations);
 
     i_t n_blocks = (n_rotations * n_positions + TPB - 1) / TPB;
-    find_optimal_position_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.sol_handle->get_stream()>>>(
+    find_optimal_position_kernel<i_t, f_t><<<n_blocks, TPB, 0, solution.sol_handle->get_stream().get()>>>(
       solution.view(),
       resource.ls.move_candidates.view(),
       eax_fragment.view(),

--- a/cpp/src/routing/crossovers/ox_recombiner.cuh
+++ b/cpp/src/routing/crossovers/ox_recombiner.cuh
@@ -592,7 +592,7 @@ struct OX {
                                         num_segments,
                                         row_offsets.data(),
                                         row_offsets.data() + 1,
-                                        stream_view);
+                                        stream_view.get());
     d_tmp_storage_bytes.resize(tmp_storage_bytes, stream_view);
     cub::DeviceSegmentedSort::SortPairs(d_tmp_storage_bytes.data(),
                                         tmp_storage_bytes,
@@ -604,7 +604,7 @@ struct OX {
                                         num_segments,
                                         row_offsets.data(),
                                         row_offsets.data() + 1,
-                                        stream_view);
+                                        stream_view.get());
     RAFT_CHECK_CUDA(stream_view);
 
     thrust::gather(policy, val_map.begin(), val_map.end(), graph.buckets.data(), gather_int.data());
@@ -622,7 +622,7 @@ struct OX {
     auto const n_blocks      = n_buckets * d_graph.get_num_vertices();
 
     transpose_graph.reset(A.sol.sol_handle);
-    transpose_graph_kernel<int, float><<<n_blocks, TPB, 0, A.sol.sol_handle->get_stream()>>>(
+    transpose_graph_kernel<int, float><<<n_blocks, TPB, 0, A.sol.sol_handle->get_stream().get()>>>(
       d_graph.view(), transpose_graph.view(), max_route_len);
     RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream());
     sort_graph_edges<int, float>(A, transpose_graph);
@@ -646,7 +646,7 @@ struct OX {
     async_fill(d_path_cost, std::numeric_limits<double>::max(), A.sol.sol_handle->get_stream());
     async_fill(d_predecessor, -1, A.sol.sol_handle->get_stream());
     async_fill(d_predecessor_vehicle, -1, A.sol.sol_handle->get_stream());
-    bellman_ford_init<int, double><<<1, 1, 0, A.sol.sol_handle->get_stream()>>>(
+    bellman_ford_init<int, double><<<1, 1, 0, A.sol.sol_handle->get_stream().get()>>>(
       raft::device_span<double>(d_path_cost.data(), d_path_cost.size()),
       raft::device_span<int>(d_predecessor.data(), d_predecessor.size()),
       raft::device_span<int>(d_predecessor_vehicle.data(), d_predecessor_vehicle.size()));
@@ -665,7 +665,7 @@ struct OX {
       // routes number exceeds num nodes. Stop the search here
       if (n_blocks == 0) { break; }
       bellman_ford_kernel<int, float, Solution::request_type>
-        <<<n_blocks, TPB, 0, A.sol.sol_handle->get_stream()>>>(
+        <<<n_blocks, TPB, 0, A.sol.sol_handle->get_stream().get()>>>(
           A.sol.view(),
           transpose_graph.view(),
           raft::device_span<double>(d_path_cost.data(), d_path_cost.size()),
@@ -971,7 +971,7 @@ struct OX {
       return;
     }
     calculate_edge_costs_kernel<int, float, Solution::request_type>
-      <<<n_blocks, 128, shmem, A.sol.sol_handle->get_stream()>>>(
+      <<<n_blocks, 128, shmem, A.sol.sol_handle->get_stream().get()>>>(
         A.sol.view(),
         d_graph.view(),
         raft::device_span<int>(d_offspring.data(), d_offspring.size()),

--- a/cpp/src/routing/crossovers/ox_recombiner.cuh
+++ b/cpp/src/routing/crossovers/ox_recombiner.cuh
@@ -605,7 +605,7 @@ struct OX {
                                         row_offsets.data(),
                                         row_offsets.data() + 1,
                                         stream_view.get());
-    RAFT_CHECK_CUDA(stream_view);
+    RAFT_CHECK_CUDA(stream_view.get());
 
     thrust::gather(policy, val_map.begin(), val_map.end(), graph.buckets.data(), gather_int.data());
     thrust::gather(
@@ -624,7 +624,7 @@ struct OX {
     transpose_graph.reset(A.sol.sol_handle);
     transpose_graph_kernel<int, float><<<n_blocks, TPB, 0, A.sol.sol_handle->get_stream().get()>>>(
       d_graph.view(), transpose_graph.view(), max_route_len);
-    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream().get());
     sort_graph_edges<int, float>(A, transpose_graph);
   }
 
@@ -650,7 +650,7 @@ struct OX {
       raft::device_span<double>(d_path_cost.data(), d_path_cost.size()),
       raft::device_span<int>(d_predecessor.data(), d_predecessor.size()),
       raft::device_span<int>(d_predecessor_vehicle.data(), d_predecessor_vehicle.size()));
-    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream().get());
 
     constexpr auto const TPB     = 128;
     auto min_cost_of_last_column = std::numeric_limits<double>::max();
@@ -675,7 +675,7 @@ struct OX {
           row_size,
           i,
           run_heuristic);
-      RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream());
+      RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream().get());
 
       if (optimal_routes_search) {
         raft::copy(&cost_of_last_column,
@@ -978,7 +978,7 @@ struct OX {
         raft::device_span<int>(d_vehicle_id_per_bucket.data(), d_vehicle_id_per_bucket.size()),
         max_route_len,
         gpu_weight);
-    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(A.sol.sol_handle->get_stream().get());
     A.sol.sol_handle->sync_stream();
 
     if (A.problem->data_view_ptr->get_vehicle_locations().first == nullptr) {

--- a/cpp/src/routing/cuda_graph.cuh
+++ b/cpp/src/routing/cuda_graph.cuh
@@ -22,7 +22,7 @@ struct cuda_graph_t {
   {
     // Use ThreadLocal mode to allow multi-threaded batch execution
     // Global mode blocks other streams from performing operations during capture
-    cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal);
+    cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeThreadLocal);
     capture_started = true;
   }
 
@@ -30,7 +30,7 @@ struct cuda_graph_t {
   {
     cuopt_assert(capture_started, "start_capture was not called before end_capture!");
     cuopt_expects(capture_started, error_type_t::RuntimeError, "A runtime error occurred!");
-    cudaStreamEndCapture(stream, &graph);
+    cudaStreamEndCapture(stream.get(), &graph);
     capture_started = false;
     if (graph_created) {
       // If the graph fails to update, errorNode will be set to the
@@ -52,7 +52,7 @@ struct cuda_graph_t {
     cudaGraphDestroy(graph);
   }
 
-  void launch_graph(rmm::cuda_stream_view stream) { cudaGraphLaunch(instance, stream); }
+  void launch_graph(rmm::cuda_stream_view stream) { cudaGraphLaunch(instance, stream.get()); }
 
   bool graph_created   = false;
   bool capture_started = false;

--- a/cpp/src/routing/distance_engine/waypoint_matrix.cpp
+++ b/cpp/src/routing/distance_engine/waypoint_matrix.cpp
@@ -248,7 +248,7 @@ void waypoint_matrix_t<i_t, f_t>::compute_cost_matrix(f_t* d_cost_matrix,
   std::vector<f_t> cost_matrix = mpsp(target_locations, n_target_locations);
 
   raft::copy(d_cost_matrix, cost_matrix.data(), cost_matrix.size(), stream_view_);
-  stream_view_.synchronize();
+  stream_view_.sync();
 }
 
 // Location values are greater or equal to n_target_locations
@@ -293,7 +293,7 @@ waypoint_matrix_t<i_t, f_t>::compute_waypoint_sequence(i_t const* target_locatio
 
   std::vector<i_t> h_locations(n_locations);
   raft::copy(h_locations.data(), locations, n_locations, stream_view_);
-  stream_view_.synchronize();
+  stream_view_.sync();
 
   // Locations validity checks
   check_locations(h_locations.data(), n_locations, n_target_locations);
@@ -321,7 +321,7 @@ waypoint_matrix_t<i_t, f_t>::compute_waypoint_sequence(i_t const* target_locatio
 
   raft::copy(paths_offsets_out.data(), paths_offsets.data(), paths_offsets.size(), stream_view_);
   raft::copy(paths_list_out.data(), paths_list.data(), paths_list.size(), stream_view_);
-  stream_view_.synchronize();
+  stream_view_.sync();
 
   return {std::make_unique<rmm::device_buffer>(paths_offsets_out.release()),
           std::make_unique<rmm::device_buffer>(paths_list_out.release())};
@@ -406,7 +406,7 @@ void waypoint_matrix_t<i_t, f_t>::compute_shortest_path_costs(f_t* d_custom_matr
 
   raft::copy(
     d_custom_matrix, shortest_path_matrix.data(), shortest_path_matrix.size(), stream_view_);
-  stream_view_.synchronize();
+  stream_view_.sync();
 }
 
 template class CUOPT_EXPORT waypoint_matrix_t<int, float>;

--- a/cpp/src/routing/fleet_info.cu
+++ b/cpp/src/routing/fleet_info.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -153,9 +153,9 @@ void populate_fleet_info(data_model_view_t<i_t, f_t> const& data_model,
   if (auto [start_locations, return_locations] = data_model.get_vehicle_locations();
       start_locations != nullptr) {
     raft::copy(
-      fleet_info_.v_start_locations_.data(), start_locations, fleet_size, stream_view.value());
+      fleet_info_.v_start_locations_.data(), start_locations, fleet_size, stream_view.get());
     raft::copy(
-      fleet_info_.v_return_locations_.data(), return_locations, fleet_size, stream_view.value());
+      fleet_info_.v_return_locations_.data(), return_locations, fleet_size, stream_view.get());
     is_homogenous =
       is_homogenous &&
       all_entries_are_equal(handle_ptr_, fleet_info_.v_start_locations_.data(), fleet_size);
@@ -176,7 +176,7 @@ void populate_fleet_info(data_model_view_t<i_t, f_t> const& data_model,
 
   if (auto drop_return_trip = data_model.get_drop_return_trips(); drop_return_trip) {
     raft::copy(
-      fleet_info_.v_drop_return_trip_.data(), drop_return_trip, fleet_size, stream_view.value());
+      fleet_info_.v_drop_return_trip_.data(), drop_return_trip, fleet_size, stream_view.get());
     is_homogenous =
       is_homogenous &&
       all_entries_are_equal(handle_ptr_, fleet_info_.v_drop_return_trip_.data(), fleet_size);
@@ -189,7 +189,7 @@ void populate_fleet_info(data_model_view_t<i_t, f_t> const& data_model,
 
   if (auto skip_first_trip = data_model.get_skip_first_trips(); skip_first_trip) {
     raft::copy(
-      fleet_info_.v_skip_first_trip_.data(), skip_first_trip, fleet_size, stream_view.value());
+      fleet_info_.v_skip_first_trip_.data(), skip_first_trip, fleet_size, stream_view.get());
     is_homogenous =
       is_homogenous &&
       all_entries_are_equal(handle_ptr_, fleet_info_.v_skip_first_trip_.data(), fleet_size);

--- a/cpp/src/routing/generator/generator.cu
+++ b/cpp/src/routing/generator/generator.cu
@@ -234,7 +234,7 @@ d_mdarray_t<f_t> generate_matrices(raft::handle_t& handle,
                                                       params.n_locations,
                                                       params.asymmetric,
                                                       asymmetry_scalar);
-  RAFT_CHECK_CUDA(handle.get_stream());
+  RAFT_CHECK_CUDA(handle.get_stream().get());
 
   auto seed     = params.seed;
   auto matrices = detail::create_device_mdarray<f_t>(
@@ -494,7 +494,7 @@ time_window_t<i_t> generate_time_windows(raft::handle_t& handle,
                                                          params.tw_tightness,
                                                          params.n_locations);
   handle.sync_stream();
-  RAFT_CHECK_CUDA(handle.get_stream());
+  RAFT_CHECK_CUDA(handle.get_stream().get());
 
   return std::make_tuple(
     std::move(v_earliest_time), std::move(v_latest_time), std::move(v_service_time));

--- a/cpp/src/routing/generator/generator.cu
+++ b/cpp/src/routing/generator/generator.cu
@@ -119,7 +119,7 @@ detail::fleet_order_constraints_t<i_t> generate_fleet_order_constraints(
       n_orders - 1,
       params.min_service_time,
       params.max_service_time + 1,
-      handle.get_stream());
+      handle.get_stream().get());
   }
   return fleet_order_constraints;
 }
@@ -188,7 +188,7 @@ coordinates_t<f_t> generate_coordinates(raft::handle_t& handle,
                            params.n_locations,
                            n_cols,
                            n_clusters,
-                           handle.get_stream(),
+                           handle.get_stream().get(),
                            false,
                            (f_t*)nullptr,
                            (f_t*)nullptr,
@@ -228,7 +228,7 @@ d_mdarray_t<f_t> generate_matrices(raft::handle_t& handle,
   rmm::device_uvector<f_t> v_rands(params.n_locations * params.n_locations, handle.get_stream());
 
   detail::build_cost_matrix<i_t, f_t>
-    <<<n_blocks, n_threads, 0, handle.get_stream()>>>(cost_matrix.data(),
+    <<<n_blocks, n_threads, 0, handle.get_stream().get()>>>(cost_matrix.data(),
                                                       std::get<0>(coordinates).data(),
                                                       std::get<1>(coordinates).data(),
                                                       params.n_locations,
@@ -248,7 +248,7 @@ d_mdarray_t<f_t> generate_matrices(raft::handle_t& handle,
                             v_rands.size(),
                             static_cast<f_t>(1.1),
                             static_cast<f_t>(1.5),
-                            handle.get_stream());
+                            handle.get_stream().get());
 
       auto matrix_span = matrices.get_cost_matrix(vehicle_type, matrix_type);
 
@@ -309,7 +309,7 @@ rmm::device_uvector<cap_i_t> generate_vehicle_capacities(raft::handle_t& handle,
                              fleet_size,
                              static_cast<cap_i_t>(h_min_capacities[i]),
                              static_cast<cap_i_t>(h_max_capacities[i] + 1),
-                             handle.get_stream());
+                             handle.get_stream().get());
   }
   return capacities;
 }
@@ -334,7 +334,7 @@ rmm::device_uvector<demand_i_t> generate_demands(raft::handle_t& handle,
                              params.n_locations - 1,
                              static_cast<demand_i_t>(h_min_demand[i]),
                              static_cast<demand_i_t>(h_max_demand[i] + 1),
-                             handle.get_stream());
+                             handle.get_stream().get());
   }
   return demands;
 }
@@ -467,7 +467,7 @@ rmm ::device_uvector<i_t> create_service_time(raft::handle_t& handle,
                            v_service_time.size() - 1,
                            params.min_service_time,
                            params.max_service_time + 1,
-                           handle.get_stream());
+                           handle.get_stream().get());
   return v_service_time;
 }
 
@@ -488,7 +488,7 @@ time_window_t<i_t> generate_time_windows(raft::handle_t& handle,
   auto time_matrix    = matrices.get_time_matrix(0);
   auto v_service_time = create_service_time<i_t, f_t>(handle, params);
   detail::fill_time_windows<i_t, f_t>
-    <<<params.n_locations, 64, 0, handle.get_stream()>>>(time_matrix,
+    <<<params.n_locations, 64, 0, handle.get_stream().get()>>>(time_matrix,
                                                          v_earliest_time.data(),
                                                          v_latest_time.data(),
                                                          params.tw_tightness,

--- a/cpp/src/routing/generator/generator.cu
+++ b/cpp/src/routing/generator/generator.cu
@@ -229,11 +229,11 @@ d_mdarray_t<f_t> generate_matrices(raft::handle_t& handle,
 
   detail::build_cost_matrix<i_t, f_t>
     <<<n_blocks, n_threads, 0, handle.get_stream().get()>>>(cost_matrix.data(),
-                                                      std::get<0>(coordinates).data(),
-                                                      std::get<1>(coordinates).data(),
-                                                      params.n_locations,
-                                                      params.asymmetric,
-                                                      asymmetry_scalar);
+                                                            std::get<0>(coordinates).data(),
+                                                            std::get<1>(coordinates).data(),
+                                                            params.n_locations,
+                                                            params.asymmetric,
+                                                            asymmetry_scalar);
   RAFT_CHECK_CUDA(handle.get_stream().get());
 
   auto seed     = params.seed;
@@ -489,10 +489,10 @@ time_window_t<i_t> generate_time_windows(raft::handle_t& handle,
   auto v_service_time = create_service_time<i_t, f_t>(handle, params);
   detail::fill_time_windows<i_t, f_t>
     <<<params.n_locations, 64, 0, handle.get_stream().get()>>>(time_matrix,
-                                                         v_earliest_time.data(),
-                                                         v_latest_time.data(),
-                                                         params.tw_tightness,
-                                                         params.n_locations);
+                                                               v_earliest_time.data(),
+                                                               v_latest_time.data(),
+                                                               params.tw_tightness,
+                                                               params.n_locations);
   handle.sync_stream();
   RAFT_CHECK_CUDA(handle.get_stream().get());
 

--- a/cpp/src/routing/ges/compute_fragment_ejections.cu
+++ b/cpp/src/routing/ges/compute_fragment_ejections.cu
@@ -130,7 +130,7 @@ void launch_kernel_get_best_insertion_ejection_solution(
     blocks,
     kernel_args,
     shmem_bytes,
-    stream));
+    stream.get()));
 }
 
 #define CUOPT_INSTANTIATE_GET_BEST_INSERTION_EJECTION(BLOCK_SIZE, REQ)                        \

--- a/cpp/src/routing/ges/eject_until_feasible.cu
+++ b/cpp/src/routing/ges/eject_until_feasible.cu
@@ -383,7 +383,7 @@ void solution_t<i_t, f_t, REQUEST>::populate_ep_with_unserved(
   populate_ep_with_unserved_kernel<i_t, f_t, REQUEST, TPB>
     <<<1, TPB, 0, stream>>>(view(), EP.view(), ep_index_out.data());
   EP.index_ = ep_index_out.value(stream);
-  stream.synchronize();
+  stream.sync();
   if (EP.size() > 1) {
     thrust::default_random_engine g(problem_ptr->seed_gen.get_seed());
     thrust::shuffle(
@@ -408,7 +408,7 @@ void solution_t<i_t, f_t, REQUEST>::populate_ep_with_selected_unserved(
     view(), unserviced_view, EP.view(), ep_index_out.data(), problem_ptr->seed_gen.get_seed());
   RAFT_CHECK_CUDA(stream);
   EP.index_ = ep_index_out.value(stream);
-  stream.synchronize();
+  stream.sync();
 }
 
 template void solution_t<int, float, request_t::PDP>::eject_until_feasible(bool);

--- a/cpp/src/routing/ges/eject_until_feasible.cu
+++ b/cpp/src/routing/ges/eject_until_feasible.cu
@@ -406,7 +406,7 @@ void solution_t<i_t, f_t, REQUEST>::populate_ep_with_selected_unserved(
 
   populate_ep_with_selected_unserved_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, stream.get()>>>(
     view(), unserviced_view, EP.view(), ep_index_out.data(), problem_ptr->seed_gen.get_seed());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   EP.index_ = ep_index_out.value(stream);
   stream.sync();
 }

--- a/cpp/src/routing/ges/eject_until_feasible.cu
+++ b/cpp/src/routing/ges/eject_until_feasible.cu
@@ -365,7 +365,7 @@ void solution_t<i_t, f_t, REQUEST>::eject_until_feasible(bool add_slack_to_sol)
   bool is_set    = set_shmem_of_kernel(eject_until_feasible_kernel<i_t, f_t, REQUEST>, sh_size);
   cuopt_assert(is_set, "Not enough shared memory on device for get_all_feasible_insertion!");
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
-  eject_until_feasible_kernel<i_t, f_t, REQUEST><<<n_routes, TPB, sh_size, stream>>>(
+  eject_until_feasible_kernel<i_t, f_t, REQUEST><<<n_routes, TPB, sh_size, stream.get()>>>(
     view(), add_slack_to_sol, problem_ptr->seed_gen.get_seed());
   compute_cost();
   global_runtime_checks(false, true, "eject_until_feasible");
@@ -381,7 +381,7 @@ void solution_t<i_t, f_t, REQUEST>::populate_ep_with_unserved(
   rmm::device_scalar<i_t> ep_index_out(EP.index_, stream);
   const i_t TPB = 256;
   populate_ep_with_unserved_kernel<i_t, f_t, REQUEST, TPB>
-    <<<1, TPB, 0, stream>>>(view(), EP.view(), ep_index_out.data());
+    <<<1, TPB, 0, stream.get()>>>(view(), EP.view(), ep_index_out.data());
   EP.index_ = ep_index_out.value(stream);
   stream.sync();
   if (EP.size() > 1) {
@@ -404,7 +404,7 @@ void solution_t<i_t, f_t, REQUEST>::populate_ep_with_selected_unserved(
   auto unserviced_view =
     raft::device_span<i_t const>(unserviced_device.data(), unserviced_device.size());
 
-  populate_ep_with_selected_unserved_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, stream>>>(
+  populate_ep_with_selected_unserved_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, stream.get()>>>(
     view(), unserviced_view, EP.view(), ep_index_out.data(), problem_ptr->seed_gen.get_seed());
   RAFT_CHECK_CUDA(stream);
   EP.index_ = ep_index_out.value(stream);

--- a/cpp/src/routing/ges/ejection_pool.cuh
+++ b/cpp/src/routing/ges/ejection_pool.cuh
@@ -63,7 +63,7 @@ struct ejection_pool_t {
     // replace with thrust shuffle
     // how to get sol_handle::get_thrust_policy?
     if (size() > 1)
-      device_random_shuffle<elemt_t><<<1, 1, 0, stream_>>>(stack_.data(), size(), seed);
+      device_random_shuffle<elemt_t><<<1, 1, 0, stream_.get()>>>(stack_.data(), size(), seed);
   }
 
   bool empty() const

--- a/cpp/src/routing/ges/execute_insertion.cu
+++ b/cpp/src/routing/ges/execute_insertion.cu
@@ -308,7 +308,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::execute_best_insertion_ejectio
     <<<1,
        1024,
        shared_for_delete_array + shared_for_tmp_route,
-       solution_ptr->sol_handle->get_stream()>>>(solution_ptr->view(),
+       solution_ptr->sol_handle->get_stream().get()>>>(solution_ptr->view(),
                                                  d_request,
                                                  (uint64_t*)feasible_candidates_data_.data(),
                                                  EP.view(),
@@ -365,7 +365,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::perform_insertion(
   }
 
   execute_feasible_insert<i_t, f_t, REQUEST>
-    <<<1, 1024, shared_for_tmp_route, solution_ptr->sol_handle->get_stream()>>>(
+    <<<1, 1024, shared_for_tmp_route, solution_ptr->sol_handle->get_stream().get()>>>(
       solution_ptr->view(), request, selected_candidate);
   RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
   return true;
@@ -398,7 +398,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::find_single_insertion(
     <<<grid_size,
        threads_per_block,
        shared_for_tmp_route,
-       solution_ptr->sol_handle->get_stream()>>>(
+       solution_ptr->sol_handle->get_stream().get()>>>(
       solution_ptr->view(),
       request,
       feasible_move_t(cuopt::make_span(feasible_candidates_data_),

--- a/cpp/src/routing/ges/execute_insertion.cu
+++ b/cpp/src/routing/ges/execute_insertion.cu
@@ -261,7 +261,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::execute_best_insertion_ejectio
   for (; bit_cast<unsigned long long int, found_sol_t>(feasible_candidates_data_.front_element(
            solution_ptr->sol_handle->get_stream())) == unset_val &&
          !time_stop_condition_reached() && fragment_size + fragment_step <= max_fragment_size;) {
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     // Increment here and not in for loop to not have it incremented if conditions are not met
     fragment_size += fragment_step;
     shared_for_delete_array =
@@ -294,7 +294,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::execute_best_insertion_ejectio
         args,
         solution_ptr->sol_handle->get_stream());
     }
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   }
 
   // Didn't manage to insert even with deleting
@@ -314,7 +314,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::execute_best_insertion_ejectio
                                                  EP.view(),
                                                  fragment_step,
                                                  fragment_size);
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   // Update EP index, route_id contains the amount we deleted
   found_sol_t selected_move =
     feasible_candidates_data_.element(0, solution_ptr->sol_handle->get_stream());
@@ -345,7 +345,7 @@ found_sol_t select_random_initialized(rmm::device_uvector<found_sol_t>& feasible
                      }
                      if (!updated) { *output_ptr = data; }
                    });
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   return random_selected_candidate.value(solution_ptr->sol_handle->get_stream());
 }
 
@@ -367,7 +367,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::perform_insertion(
   execute_feasible_insert<i_t, f_t, REQUEST>
     <<<1, 1024, shared_for_tmp_route, solution_ptr->sol_handle->get_stream().get()>>>(
       solution_ptr->view(), request, selected_candidate);
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   return true;
 }
 
@@ -408,7 +408,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::find_single_insertion(
                       solution_ptr->get_n_routes()),
       solution_ptr->problem_ptr->seed_gen.get_seed());
 
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
   return feasible_candidates_size_.value(solution_ptr->sol_handle->get_stream());
 }

--- a/cpp/src/routing/ges/execute_insertion.cu
+++ b/cpp/src/routing/ges/execute_insertion.cu
@@ -309,11 +309,11 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::execute_best_insertion_ejectio
        1024,
        shared_for_delete_array + shared_for_tmp_route,
        solution_ptr->sol_handle->get_stream().get()>>>(solution_ptr->view(),
-                                                 d_request,
-                                                 (uint64_t*)feasible_candidates_data_.data(),
-                                                 EP.view(),
-                                                 fragment_step,
-                                                 fragment_size);
+                                                       d_request,
+                                                       (uint64_t*)feasible_candidates_data_.data(),
+                                                       EP.view(),
+                                                       fragment_step,
+                                                       fragment_size);
   RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   // Update EP index, route_id contains the amount we deleted
   found_sol_t selected_move =

--- a/cpp/src/routing/ges/guided_ejection_search.cu
+++ b/cpp/src/routing/ges/guided_ejection_search.cu
@@ -273,7 +273,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::guided_ejection_search_loop(i_
     incr_p_scores<i_t><<<1, 1, 0, solution_ptr->sol_handle->get_stream().get()>>>(
       request, p_scores_.data(), depot_included);
 
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     bool move_executed = config.frag_eject_first
                            ? execute_best_insertion_ejection_solution(request, counter)
                            : run_lexicographic_search(request);
@@ -306,7 +306,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::guided_ejection_search_loop(i_
         return false;
       }
 
-      RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+      RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
       // reinsert the request and increase the ejection failure counter
       EP.push_back_last();
       consecutive_ejection_failure++;

--- a/cpp/src/routing/ges/guided_ejection_search.cu
+++ b/cpp/src/routing/ges/guided_ejection_search.cu
@@ -270,7 +270,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::guided_ejection_search_loop(i_
     }
 
     // Increase penalty counter for this request
-    incr_p_scores<i_t><<<1, 1, 0, solution_ptr->sol_handle->get_stream()>>>(
+    incr_p_scores<i_t><<<1, 1, 0, solution_ptr->sol_handle->get_stream().get()>>>(
       request, p_scores_.data(), depot_included);
 
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());

--- a/cpp/src/routing/ges/guided_ejection_search.cu
+++ b/cpp/src/routing/ges/guided_ejection_search.cu
@@ -522,9 +522,9 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::route_minimizer_loop()
     std::tie(vehicle_id, random_route_id) = next_route_id();
     if (random_route_id < 0) { break; }
     // Save solution state before ges loop in case of route restoration
-    stream.synchronize();
+    stream.sync();
     ges_loop_save_state.copy_device_solution(*solution_ptr);
-    stream.synchronize();
+    stream.sync();
     solution_ptr->remove_routes(EP, std::vector<i_t>{random_route_id});
 
     // Routes can be empty when number of vehicles is more than number of requests
@@ -532,9 +532,9 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::route_minimizer_loop()
 
     // If ges loop left early, restore state
     if (!guided_ejection_search_loop(counter, true)) {
-      stream.synchronize();
+      stream.sync();
       solution_ptr->copy_device_solution(ges_loop_save_state);
-      stream.synchronize();
+      stream.sync();
     }
     solution_ptr->global_runtime_checks(true, true, "route_minimizer_loop");
   }

--- a/cpp/src/routing/ges/guided_ejection_search.cuh
+++ b/cpp/src/routing/ges/guided_ejection_search.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -12,7 +12,6 @@
 #include "ejection_pool.cuh"
 #include "found_solution.cuh"
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -219,7 +219,7 @@ std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico
     std::vector<i_t> sequence(global_sequence.element(0, stream) + 3);
     // copy including pickup and delivery
     raft::copy(sequence.data(), global_sequence.data() + 1, sequence.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return sequence;
   }
   return std::vector<i_t>{};

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -202,7 +202,7 @@ std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico
       size_t shared_size                   = shared_size_for_route + shared_size_for_intra_indices;
       i_t n_blocks                         = combinations.size();
       brute_force_lexico_kernel<i_t, f_t, REQUEST>
-        <<<n_blocks, TPB, shared_size, stream>>>(d_combinations.data(),
+        <<<n_blocks, TPB, shared_size, stream.get()>>>(d_combinations.data(),
                                                  sol.view(),
                                                  route.view(),
                                                  n_ejections,

--- a/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
+++ b/cpp/src/routing/ges/lexicographic_search/brute_force_lexico.cu
@@ -203,14 +203,14 @@ std::vector<i_t> guided_ejection_search_t<i_t, f_t, REQUEST>::brute_force_lexico
       i_t n_blocks                         = combinations.size();
       brute_force_lexico_kernel<i_t, f_t, REQUEST>
         <<<n_blocks, TPB, shared_size, stream.get()>>>(d_combinations.data(),
-                                                 sol.view(),
-                                                 route.view(),
-                                                 n_ejections,
-                                                 req,
-                                                 global_min_p.data(),
-                                                 global_sequence.data(),
-                                                 EP.view(),
-                                                 p_scores_.data());
+                                                       sol.view(),
+                                                       route.view(),
+                                                       n_ejections,
+                                                       req,
+                                                       global_min_p.data(),
+                                                       global_sequence.data(),
+                                                       EP.view(),
+                                                       p_scores_.data());
       // copy the best result and keep it here
       sol.sol_handle->sync_stream();
     }

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -713,7 +713,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
   solution_ptr->d_lock.set_value_async(zero, stream);
   global_random_counter_.set_value_async(zero, stream);
   lexicographic_search<i_t, f_t>
-    <<<n_blocks_lexico, threads_per_block_lexico, sh_size, stream>>>(solution_ptr->view(),
+    <<<n_blocks_lexico, threads_per_block_lexico, sh_size, stream.get()>>>(solution_ptr->view(),
                                                                      k_max,
                                                                      request_id,
                                                                      p_scores_.data(),
@@ -731,7 +731,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
       return false;
     }
     execute_lexico_move<i_t, f_t, REQUEST>
-      <<<1, threads_per_block_lexico, shared_for_tmp_route, stream>>>(solution_ptr->view(),
+      <<<1, threads_per_block_lexico, shared_for_tmp_route, stream.get()>>>(solution_ptr->view(),
                                                                       request_id,
                                                                       global_min_p_.data(),
                                                                       global_sequence_.data(),

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -713,13 +713,14 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
   solution_ptr->d_lock.set_value_async(zero, stream);
   global_random_counter_.set_value_async(zero, stream);
   lexicographic_search<i_t, f_t>
-    <<<n_blocks_lexico, threads_per_block_lexico, sh_size, stream.get()>>>(solution_ptr->view(),
-                                                                     k_max,
-                                                                     request_id,
-                                                                     p_scores_.data(),
-                                                                     global_min_p_.data(),
-                                                                     global_sequence_.data(),
-                                                                     global_random_counter_.data());
+    <<<n_blocks_lexico, threads_per_block_lexico, sh_size, stream.get()>>>(
+      solution_ptr->view(),
+      k_max,
+      request_id,
+      p_scores_.data(),
+      global_min_p_.data(),
+      global_sequence_.data(),
+      global_random_counter_.data());
   solution_ptr->sol_handle->sync_stream();
   RAFT_CHECK_CUDA(stream);
   // If global_min_p_ != max do the move
@@ -732,11 +733,11 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
     }
     execute_lexico_move<i_t, f_t, REQUEST>
       <<<1, threads_per_block_lexico, shared_for_tmp_route, stream.get()>>>(solution_ptr->view(),
-                                                                      request_id,
-                                                                      global_min_p_.data(),
-                                                                      global_sequence_.data(),
-                                                                      EP.view(),
-                                                                      p_scores_.data());
+                                                                            request_id,
+                                                                            global_min_p_.data(),
+                                                                            global_sequence_.data(),
+                                                                            EP.view(),
+                                                                            p_scores_.data());
     RAFT_CHECK_CUDA(stream);
     i_t removed_size = global_sequence_.element(1, stream);
     if constexpr (REQUEST == request_t::PDP) { removed_size = (removed_size - 1) / 2; }

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -668,7 +668,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
   request_info_t<i_t, REQUEST>* __restrict__ request_id)
 {
   auto stream = solution_ptr->sol_handle->get_stream();
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 
   i_t average_route_size = solution_ptr->get_num_orders() / solution_ptr->n_routes;
 
@@ -722,7 +722,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
       global_sequence_.data(),
       global_random_counter_.data());
   solution_ptr->sol_handle->sync_stream();
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   // If global_min_p_ != max do the move
   if (global_min_p_.value(stream) != max) {
     // cuopt_assert(compare_lexico_results(*this, solution, request_id, EP, k_max), "");
@@ -738,7 +738,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::run_lexicographic_search(
                                                                             global_sequence_.data(),
                                                                             EP.view(),
                                                                             p_scores_.data());
-    RAFT_CHECK_CUDA(stream);
+    RAFT_CHECK_CUDA(stream.get());
     i_t removed_size = global_sequence_.element(1, stream);
     if constexpr (REQUEST == request_t::PDP) { removed_size = (removed_size - 1) / 2; }
     EP.index_ += removed_size;

--- a/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
+++ b/cpp/src/routing/ges/lexicographic_search/lexicographic_search.cu
@@ -43,7 +43,7 @@ bool compare_lexico_results(guided_ejection_search_t<i_t, f_t, REQUEST>& ges,
     std::vector<i_t> lexico_sequence(2 * k_max + 1);
     raft::update_host(
       lexico_sequence.data(), ges.global_sequence_.data() + 2, 2 * k_max + 1, stream);
-    stream.synchronize();
+    stream.sync();
     p_val_seq_t p_val(0, 0);
     memcpy((uint32_t*)&p_val, &h_global_min, sizeof(uint32_t));
     cuopt_assert(p_val.p_val == brute_force_sequence[0], "p scores don't match");

--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -52,7 +52,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::repair_empty_routes()
     if (!set_shmem_of_kernel(execute_best_empty_route_move<i_t, f_t, REQUEST>, sh_route)) { break; }
     execute_best_empty_route_move<i_t, f_t, REQUEST>
       <<<1, TPB, sh_route, solution_ptr->sol_handle->get_stream().get()>>>(solution_ptr->view(),
-                                                                     best_move.data());
+                                                                           best_move.data());
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     ++counter;
   }
@@ -96,22 +96,22 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     // insert the request greedily to a position that will generate the least excess
     find_all_squeeze_pos<i_t, f_t, REQUEST, squeeze_mode>
       <<<n_blocks, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
-                                           EP.view(),
-                                           cuopt::make_span(best_squeeze_per_cand),
-                                           cuopt::make_span(best_squeeze_per_route),
-                                           include_objective,
-                                           weights,
-                                           excess_limit,
-                                           n_insertions,
-                                           inserted_requests.data());
+                                                 EP.view(),
+                                                 cuopt::make_span(best_squeeze_per_cand),
+                                                 cuopt::make_span(best_squeeze_per_route),
+                                                 include_objective,
+                                                 weights,
+                                                 excess_limit,
+                                                 n_insertions,
+                                                 inserted_requests.data());
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
     if constexpr (squeeze_mode) {
       size_t move_blocks = solution_ptr->get_num_requests();
       extract_best_per_route<i_t, f_t, REQUEST>
         <<<move_blocks, TPB, 0, stream.get()>>>(solution_ptr->view(),
-                                          cuopt::make_span(best_squeeze_per_cand),
-                                          cuopt::make_span(best_squeeze_per_route));
+                                                cuopt::make_span(best_squeeze_per_cand),
+                                                cuopt::make_span(best_squeeze_per_route));
       RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     }
 
@@ -121,19 +121,20 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     // execute squeeze moves
     execute_all_move<i_t, f_t, REQUEST, squeeze_mode>
-      <<<move_blocks, TPB, shmem_for_route, stream.get()>>>(solution_ptr->view(),
-                                                      cuopt::make_span(best_squeeze_per_cand),
-                                                      cuopt::make_span(best_squeeze_per_route),
-                                                      inserted_requests.data(),
-                                                      number_of_inserted.data());
+      <<<move_blocks, TPB, shmem_for_route, stream.get()>>>(
+        solution_ptr->view(),
+        cuopt::make_span(best_squeeze_per_cand),
+        cuopt::make_span(best_squeeze_per_route),
+        inserted_requests.data(),
+        number_of_inserted.data());
     RAFT_CHECK_CUDA(stream.get());
     auto n_inserted = number_of_inserted.value(stream);
 
     if (n_inserted == 0) {
       //  Some of the attempted requests could not be inserted in this call or following ones
       //  after perturbations
-      increase_multiple_p_scores<i_t, f_t, REQUEST>
-        <<<1, 64, 0, stream.get()>>>(EP.view(), p_scores_.data(), inserted_requests.data(), n_insertions);
+      increase_multiple_p_scores<i_t, f_t, REQUEST><<<1, 64, 0, stream.get()>>>(
+        EP.view(), p_scores_.data(), inserted_requests.data(), n_insertions);
       break;
     }
     counter += n_inserted;
@@ -171,8 +172,9 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_feasible_insertion
   i_t successful_insertions = try_multiple_insert<squeeze_mode>(
     n_insertions, default_weights, std::numeric_limits<f_t>::epsilon(), include_objective);
 
-  eject_inserted_requests<i_t, f_t, REQUEST><<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
-    EP.view(), inserted_requests.data(), n_insertions);
+  eject_inserted_requests<i_t, f_t, REQUEST>
+    <<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
+      EP.view(), inserted_requests.data(), n_insertions);
   RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
   // Index is not updated in device view
@@ -300,25 +302,26 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
     // insert the request greedily to a position that will generate the least excess
     find_best_squeeze_pos<i_t, f_t, REQUEST>
       <<<1, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
-                                    request,
-                                    best_move.data(),
-                                    include_objective,
-                                    local_search_ptr_->move_candidates.weights,
-                                    route_id);
+                                          request,
+                                          best_move.data(),
+                                          include_objective,
+                                          local_search_ptr_->move_candidates.weights,
+                                          route_id);
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   } else {
     find_best_squeeze_pos<i_t, f_t, REQUEST>
       <<<n_blocks, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
-                                           request,
-                                           best_move.data(),
-                                           include_objective,
-                                           local_search_ptr_->move_candidates.weights);
+                                                 request,
+                                                 best_move.data(),
+                                                 include_objective,
+                                                 local_search_ptr_->move_candidates.weights);
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   }
   cuopt_assert(best_move.value(stream).cost_counter.cost != std::numeric_limits<double>::max(),
                "At least a move should be found in squeeze");
   // execute squeeze
-  execute_move<i_t, f_t><<<1, 1, 0, stream.get()>>>(solution_ptr->view(), request, best_move.data());
+  execute_move<i_t, f_t>
+    <<<1, 1, 0, stream.get()>>>(solution_ptr->view(), request, best_move.data());
   solution_ptr->compute_cost();
   solution_ptr->global_runtime_checks(false, false, "squeeze");
   stream.sync();

--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -37,7 +37,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::repair_empty_routes()
     // reset the best move stored
     best_move.set_value_async(uninit_cand, solution_ptr->sol_handle->get_stream());
     find_best_empty_route_move<i_t, f_t, REQUEST>
-      <<<n_blocks, TPB, sh_find, solution_ptr->sol_handle->get_stream()>>>(
+      <<<n_blocks, TPB, sh_find, solution_ptr->sol_handle->get_stream().get()>>>(
         solution_ptr->view(), best_move.data(), include_objective, default_weights, excess_limit);
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
 
@@ -51,7 +51,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::repair_empty_routes()
 
     if (!set_shmem_of_kernel(execute_best_empty_route_move<i_t, f_t, REQUEST>, sh_route)) { break; }
     execute_best_empty_route_move<i_t, f_t, REQUEST>
-      <<<1, TPB, sh_route, solution_ptr->sol_handle->get_stream()>>>(solution_ptr->view(),
+      <<<1, TPB, sh_route, solution_ptr->sol_handle->get_stream().get()>>>(solution_ptr->view(),
                                                                      best_move.data());
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
     ++counter;
@@ -95,7 +95,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     // insert the request greedily to a position that will generate the least excess
     find_all_squeeze_pos<i_t, f_t, REQUEST, squeeze_mode>
-      <<<n_blocks, TPB, sh_size, stream>>>(solution_ptr->view(),
+      <<<n_blocks, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
                                            EP.view(),
                                            cuopt::make_span(best_squeeze_per_cand),
                                            cuopt::make_span(best_squeeze_per_route),
@@ -109,7 +109,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     if constexpr (squeeze_mode) {
       size_t move_blocks = solution_ptr->get_num_requests();
       extract_best_per_route<i_t, f_t, REQUEST>
-        <<<move_blocks, TPB, 0, stream>>>(solution_ptr->view(),
+        <<<move_blocks, TPB, 0, stream.get()>>>(solution_ptr->view(),
                                           cuopt::make_span(best_squeeze_per_cand),
                                           cuopt::make_span(best_squeeze_per_route));
       RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
@@ -121,7 +121,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     // execute squeeze moves
     execute_all_move<i_t, f_t, REQUEST, squeeze_mode>
-      <<<move_blocks, TPB, shmem_for_route, stream>>>(solution_ptr->view(),
+      <<<move_blocks, TPB, shmem_for_route, stream.get()>>>(solution_ptr->view(),
                                                       cuopt::make_span(best_squeeze_per_cand),
                                                       cuopt::make_span(best_squeeze_per_route),
                                                       inserted_requests.data(),
@@ -133,7 +133,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
       //  Some of the attempted requests could not be inserted in this call or following ones
       //  after perturbations
       increase_multiple_p_scores<i_t, f_t, REQUEST>
-        <<<1, 64, 0, stream>>>(EP.view(), p_scores_.data(), inserted_requests.data(), n_insertions);
+        <<<1, 64, 0, stream.get()>>>(EP.view(), p_scores_.data(), inserted_requests.data(), n_insertions);
       break;
     }
     counter += n_inserted;
@@ -171,7 +171,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_feasible_insertion
   i_t successful_insertions = try_multiple_insert<squeeze_mode>(
     n_insertions, default_weights, std::numeric_limits<f_t>::epsilon(), include_objective);
 
-  eject_inserted_requests<i_t, f_t, REQUEST><<<1, 32, 0, solution_ptr->sol_handle->get_stream()>>>(
+  eject_inserted_requests<i_t, f_t, REQUEST><<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
     EP.view(), inserted_requests.data(), n_insertions);
   RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
 
@@ -210,7 +210,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze_all_ep()
     if (successful_insertions == 0) { run_batches = false; }
 
     eject_inserted_requests<i_t, f_t, REQUEST>
-      <<<1, 32, 0, solution_ptr->sol_handle->get_stream()>>>(
+      <<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
         EP.view(), inserted_requests.data(), batch_size);
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
 
@@ -299,7 +299,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
     i_t route_id = dist_candidate(gen_candidate) % solution_ptr->get_n_routes();
     // insert the request greedily to a position that will generate the least excess
     find_best_squeeze_pos<i_t, f_t, REQUEST>
-      <<<1, TPB, sh_size, stream>>>(solution_ptr->view(),
+      <<<1, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
                                     request,
                                     best_move.data(),
                                     include_objective,
@@ -308,7 +308,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
     RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
   } else {
     find_best_squeeze_pos<i_t, f_t, REQUEST>
-      <<<n_blocks, TPB, sh_size, stream>>>(solution_ptr->view(),
+      <<<n_blocks, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
                                            request,
                                            best_move.data(),
                                            include_objective,
@@ -318,7 +318,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
   cuopt_assert(best_move.value(stream).cost_counter.cost != std::numeric_limits<double>::max(),
                "At least a move should be found in squeeze");
   // execute squeeze
-  execute_move<i_t, f_t><<<1, 1, 0, stream>>>(solution_ptr->view(), request, best_move.data());
+  execute_move<i_t, f_t><<<1, 1, 0, stream.get()>>>(solution_ptr->view(), request, best_move.data());
   solution_ptr->compute_cost();
   solution_ptr->global_runtime_checks(false, false, "squeeze");
   stream.sync();
@@ -378,7 +378,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze_breaks()
     return;
   }
 
-  squeeze_breaks_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, sh_size, stream>>>(
+  squeeze_breaks_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, sh_size, stream.get()>>>(
     solution_ptr->view(), false, local_search_ptr_->move_candidates.weights);
   RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
   solution_ptr->compute_cost();

--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -141,7 +141,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
 
   solution_ptr->compute_cost();
   solution_ptr->global_runtime_checks(false, false, "try_multiple_insert_end");
-  stream.synchronize();
+  stream.sync();
   return counter;
 }
 
@@ -321,7 +321,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
   execute_move<i_t, f_t><<<1, 1, 0, stream>>>(solution_ptr->view(), request, best_move.data());
   solution_ptr->compute_cost();
   solution_ptr->global_runtime_checks(false, false, "squeeze");
-  stream.synchronize();
+  stream.sync();
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>

--- a/cpp/src/routing/ges/squeeze.cu
+++ b/cpp/src/routing/ges/squeeze.cu
@@ -39,7 +39,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::repair_empty_routes()
     find_best_empty_route_move<i_t, f_t, REQUEST>
       <<<n_blocks, TPB, sh_find, solution_ptr->sol_handle->get_stream().get()>>>(
         solution_ptr->view(), best_move.data(), include_objective, default_weights, excess_limit);
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
     // If unable to find feasible moves, switch to least excess moves
     cand_t best_move_h = best_move.value(solution_ptr->sol_handle->get_stream());
@@ -53,7 +53,7 @@ bool guided_ejection_search_t<i_t, f_t, REQUEST>::repair_empty_routes()
     execute_best_empty_route_move<i_t, f_t, REQUEST>
       <<<1, TPB, sh_route, solution_ptr->sol_handle->get_stream().get()>>>(solution_ptr->view(),
                                                                      best_move.data());
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     ++counter;
   }
   solution_ptr->sol_handle->sync_stream();
@@ -104,7 +104,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
                                            excess_limit,
                                            n_insertions,
                                            inserted_requests.data());
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
     if constexpr (squeeze_mode) {
       size_t move_blocks = solution_ptr->get_num_requests();
@@ -112,7 +112,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
         <<<move_blocks, TPB, 0, stream.get()>>>(solution_ptr->view(),
                                           cuopt::make_span(best_squeeze_per_cand),
                                           cuopt::make_span(best_squeeze_per_route));
-      RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+      RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
     }
 
     size_t move_blocks = solution_ptr->get_n_routes();
@@ -126,7 +126,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_insert(i_t n_inser
                                                       cuopt::make_span(best_squeeze_per_route),
                                                       inserted_requests.data(),
                                                       number_of_inserted.data());
-    RAFT_CHECK_CUDA(stream);
+    RAFT_CHECK_CUDA(stream.get());
     auto n_inserted = number_of_inserted.value(stream);
 
     if (n_inserted == 0) {
@@ -173,7 +173,7 @@ i_t guided_ejection_search_t<i_t, f_t, REQUEST>::try_multiple_feasible_insertion
 
   eject_inserted_requests<i_t, f_t, REQUEST><<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
     EP.view(), inserted_requests.data(), n_insertions);
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
   // Index is not updated in device view
   EP.index_ -= successful_insertions;
@@ -212,7 +212,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze_all_ep()
     eject_inserted_requests<i_t, f_t, REQUEST>
       <<<1, 32, 0, solution_ptr->sol_handle->get_stream().get()>>>(
         EP.view(), inserted_requests.data(), batch_size);
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
 
     // Index is not updated in device view
     EP.index_ -= successful_insertions;
@@ -305,7 +305,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
                                     include_objective,
                                     local_search_ptr_->move_candidates.weights,
                                     route_id);
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   } else {
     find_best_squeeze_pos<i_t, f_t, REQUEST>
       <<<n_blocks, TPB, sh_size, stream.get()>>>(solution_ptr->view(),
@@ -313,7 +313,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze(
                                            best_move.data(),
                                            include_objective,
                                            local_search_ptr_->move_candidates.weights);
-    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+    RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   }
   cuopt_assert(best_move.value(stream).cost_counter.cost != std::numeric_limits<double>::max(),
                "At least a move should be found in squeeze");
@@ -380,7 +380,7 @@ void guided_ejection_search_t<i_t, f_t, REQUEST>::squeeze_breaks()
 
   squeeze_breaks_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, sh_size, stream.get()>>>(
     solution_ptr->view(), false, local_search_ptr_->move_candidates.weights);
-  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution_ptr->sol_handle->get_stream().get());
   solution_ptr->compute_cost();
   solution_ptr->global_runtime_checks(false, false, "squeeze_breaks_end");
   return;

--- a/cpp/src/routing/local_search/breaks_insertion.cu
+++ b/cpp/src/routing/local_search/breaks_insertion.cu
@@ -167,12 +167,12 @@ void find_break_insertions(solution_t<i_t, f_t, REQUEST>& sol,
     }
 
     find_break_insertions_kernel<i_t, f_t, REQUEST>
-      <<<n_blocks, TPB, sh_size, sol.sol_handle->get_stream()>>>(
+      <<<n_blocks, TPB, sh_size, sol.sol_handle->get_stream().get()>>>(
         sol.view(),
         move_candidates.include_objective,
         move_candidates.weights,
         move_candidates.breaks_move_candidates.view());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(sol.sol_handle->get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(sol.sol_handle->get_stream().get()));
   }
 }
 
@@ -254,7 +254,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_break_moves(solution_t<i_t, f_t,
   size_t shared_size = sol.check_routes_can_insert_and_get_sh_size(0);
   if (!set_shmem_of_kernel(execute_break_moves<i_t, f_t, REQUEST>, shared_size)) { return false; }
   execute_break_moves<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(sol.view(),
+    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
                                                                    move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 

--- a/cpp/src/routing/local_search/breaks_insertion.cu
+++ b/cpp/src/routing/local_search/breaks_insertion.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -255,7 +255,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_break_moves(solution_t<i_t, f_t,
   if (!set_shmem_of_kernel(execute_break_moves<i_t, f_t, REQUEST>, shared_size)) { return false; }
   execute_break_moves<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
-                                                                   move_candidates.view());
+                                                                         move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   sol.compute_cost();

--- a/cpp/src/routing/local_search/breaks_insertion.cu
+++ b/cpp/src/routing/local_search/breaks_insertion.cu
@@ -172,7 +172,7 @@ void find_break_insertions(solution_t<i_t, f_t, REQUEST>& sol,
         move_candidates.include_objective,
         move_candidates.weights,
         move_candidates.breaks_move_candidates.view());
-    RAFT_CUDA_TRY(cudaStreamSynchronize(sol.sol_handle->get_stream().get()));
+    sol.sol_handle->get_stream().sync();
   }
 }
 
@@ -256,7 +256,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_break_moves(solution_t<i_t, f_t,
   execute_break_moves<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
                                                                    move_candidates.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   sol.compute_cost();
   sol.sol_handle->sync_stream();

--- a/cpp/src/routing/local_search/compute_compatible.cu
+++ b/cpp/src/routing/local_search/compute_compatible.cu
@@ -452,7 +452,7 @@ void local_search_t<i_t, f_t, REQUEST>::calculate_route_compatibility(
       sol.view(),
       move_candidates.route_compatibility.data(),
       move_candidates.viables.compatibility_matrix.data());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
 // sort the viable matrix according to the distance after the insertion
@@ -637,7 +637,7 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
     initialize_incompatible_kernel<i_t, f_t, request_t::PDP>
       <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
         problem.view(), viables.compatibility_matrix.data(), sol_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+    handle_ptr->get_stream().sync();
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::PDP>
       <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
@@ -651,12 +651,12 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
                                                        viables.n_viable_from_deliveries.data(),
                                                        sol_view,
                                                        is_problem_run);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+    handle_ptr->get_stream().sync();
   } else {
     initialize_incompatible_kernel<i_t, f_t, request_t::VRP>
       <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
         problem.view(), viables.compatibility_matrix.data(), sol_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+    handle_ptr->get_stream().sync();
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::VRP>
       <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
@@ -670,7 +670,7 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
                                                        viables.n_viable_from_deliveries.data(),
                                                        sol_view,
                                                        is_problem_run);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+    handle_ptr->get_stream().sync();
   }
   problem.sort_viable_matrix(viables.viable_to_pickups, viables.viable_from_pickups);
   problem.sort_viable_matrix(viables.viable_to_deliveries, viables.viable_from_deliveries);

--- a/cpp/src/routing/local_search/compute_compatible.cu
+++ b/cpp/src/routing/local_search/compute_compatible.cu
@@ -640,17 +640,18 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
     handle_ptr->get_stream().sync();
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::PDP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
-                                                       viables.viable_to_pickups.data(),
-                                                       viables.viable_from_pickups.data(),
-                                                       viables.n_viable_to_pickups.data(),
-                                                       viables.n_viable_from_pickups.data(),
-                                                       viables.viable_to_deliveries.data(),
-                                                       viables.viable_from_deliveries.data(),
-                                                       viables.n_viable_to_deliveries.data(),
-                                                       viables.n_viable_from_deliveries.data(),
-                                                       sol_view,
-                                                       is_problem_run);
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
+        problem.view(),
+        viables.viable_to_pickups.data(),
+        viables.viable_from_pickups.data(),
+        viables.n_viable_to_pickups.data(),
+        viables.n_viable_from_pickups.data(),
+        viables.viable_to_deliveries.data(),
+        viables.viable_from_deliveries.data(),
+        viables.n_viable_to_deliveries.data(),
+        viables.n_viable_from_deliveries.data(),
+        sol_view,
+        is_problem_run);
     handle_ptr->get_stream().sync();
   } else {
     initialize_incompatible_kernel<i_t, f_t, request_t::VRP>
@@ -659,17 +660,18 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
     handle_ptr->get_stream().sync();
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::VRP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
-                                                       viables.viable_to_pickups.data(),
-                                                       viables.viable_from_pickups.data(),
-                                                       viables.n_viable_to_pickups.data(),
-                                                       viables.n_viable_from_pickups.data(),
-                                                       viables.viable_to_deliveries.data(),
-                                                       viables.viable_from_deliveries.data(),
-                                                       viables.n_viable_to_deliveries.data(),
-                                                       viables.n_viable_from_deliveries.data(),
-                                                       sol_view,
-                                                       is_problem_run);
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
+        problem.view(),
+        viables.viable_to_pickups.data(),
+        viables.viable_from_pickups.data(),
+        viables.n_viable_to_pickups.data(),
+        viables.n_viable_from_pickups.data(),
+        viables.viable_to_deliveries.data(),
+        viables.viable_from_deliveries.data(),
+        viables.n_viable_to_deliveries.data(),
+        viables.n_viable_from_deliveries.data(),
+        sol_view,
+        is_problem_run);
     handle_ptr->get_stream().sync();
   }
   problem.sort_viable_matrix(viables.viable_to_pickups, viables.viable_from_pickups);

--- a/cpp/src/routing/local_search/compute_compatible.cu
+++ b/cpp/src/routing/local_search/compute_compatible.cu
@@ -448,7 +448,7 @@ void local_search_t<i_t, f_t, REQUEST>::calculate_route_compatibility(
   i_t TPB      = 128;
   i_t n_blocks = sol.n_routes * sol.get_num_requests();
   calculate_route_compatibility_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(),
       move_candidates.route_compatibility.data(),
       move_candidates.viables.compatibility_matrix.data());
@@ -635,12 +635,12 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
   i_t n_blocks = (problem.get_num_requests() * problem.get_num_requests() - 1 + TPB) / TPB;
   if constexpr (REQUEST == request_t::PDP) {
     initialize_incompatible_kernel<i_t, f_t, request_t::PDP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
         problem.view(), viables.compatibility_matrix.data(), sol_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::PDP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(problem.view(),
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
                                                        viables.viable_to_pickups.data(),
                                                        viables.viable_from_pickups.data(),
                                                        viables.n_viable_to_pickups.data(),
@@ -651,15 +651,15 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
                                                        viables.n_viable_from_deliveries.data(),
                                                        sol_view,
                                                        is_problem_run);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
   } else {
     initialize_incompatible_kernel<i_t, f_t, request_t::VRP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(
         problem.view(), viables.compatibility_matrix.data(), sol_view);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
     n_blocks = (problem.get_num_orders() * problem.get_num_orders() - 1 + TPB) / TPB;
     initialize_viable_kernel<i_t, f_t, request_t::VRP>
-      <<<n_blocks, TPB, 0, handle_ptr->get_stream()>>>(problem.view(),
+      <<<n_blocks, TPB, 0, handle_ptr->get_stream().get()>>>(problem.view(),
                                                        viables.viable_to_pickups.data(),
                                                        viables.viable_from_pickups.data(),
                                                        viables.n_viable_to_pickups.data(),
@@ -670,7 +670,7 @@ void initialize_incompatible(problem_t<i_t, f_t>& problem, solution_t<i_t, f_t, 
                                                        viables.n_viable_from_deliveries.data(),
                                                        sol_view,
                                                        is_problem_run);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
   }
   problem.sort_viable_matrix(viables.viable_to_pickups, viables.viable_from_pickups);
   problem.sort_viable_matrix(viables.viable_to_deliveries, viables.viable_from_deliveries);

--- a/cpp/src/routing/local_search/compute_insertions.cu
+++ b/cpp/src/routing/local_search/compute_insertions.cu
@@ -862,7 +862,7 @@ void find_insertions(solution_t<i_t, f_t, REQUEST>& sol,
           sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
     }
   }
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   sol.sol_handle->sync_stream();
 }
 
@@ -893,7 +893,7 @@ void find_unserviced_insertions(solution_t<i_t, f_t, REQUEST>& sol,
   find_insertions_kernel<i_t, f_t, REQUEST, search_type_t::IMPROVE, insert_unserviced>
     <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   sol.sol_handle->sync_stream();
 }
 

--- a/cpp/src/routing/local_search/compute_insertions.cu
+++ b/cpp/src/routing/local_search/compute_insertions.cu
@@ -830,7 +830,7 @@ void find_insertions(solution_t<i_t, f_t, REQUEST>& sol,
                  "Not enough shared memory on device for computing local search insertions!");
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     find_insertions_kernel<i_t, f_t, REQUEST, search_type_t::IMPROVE, insert_unserviced>
-      <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(
+      <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
         sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
   } else {
     // for cross the load-balance factor is always 4
@@ -846,7 +846,7 @@ void find_insertions(solution_t<i_t, f_t, REQUEST>& sol,
                    "Not enough shared memory on device for computing local search insertions!");
       cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
       find_insertions_kernel<i_t, f_t, REQUEST, search_type_t::CROSS, insert_unserviced>
-        <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(
+        <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
           sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
     } else if (search_type == search_type_t::RANDOM) {
       // we don't search for relocates in random.
@@ -858,7 +858,7 @@ void find_insertions(solution_t<i_t, f_t, REQUEST>& sol,
                    "Not enough shared memory on device for computing local search insertions!");
       cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
       find_insertions_kernel<i_t, f_t, REQUEST, search_type_t::RANDOM, insert_unserviced>
-        <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(
+        <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
           sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
     }
   }
@@ -891,7 +891,7 @@ void find_unserviced_insertions(solution_t<i_t, f_t, REQUEST>& sol,
   cuopt_assert(is_set, "Not enough shared memory on device for computing local search insertions!");
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   find_insertions_kernel<i_t, f_t, REQUEST, search_type_t::IMPROVE, insert_unserviced>
-    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   sol.sol_handle->sync_stream();

--- a/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
+++ b/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
@@ -35,7 +35,7 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_init(graph_t<i_t, f_t>& graph)
 
   init_kernel<i_t, f_t, max_routes><<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
     graph.view(), d_valid_paths.subspan(level));
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   // we have a safe-guard in the kernel for the global array stores
   // do the safe guard here for the occupied size
   clamp_occupied<max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_valid_paths.subspan(level));
@@ -131,7 +131,7 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_find(graph_t<i_t, f_t>& graph,
         depot_included);
   }
 
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   return true;
 }
 
@@ -142,7 +142,7 @@ void detail::device_map_t<map_key_t, value_t>::clear(rmm::cuda_stream_view strea
   auto n_threads = 256;
   auto n_blocks  = std::min((max_vals + n_threads - 1) / n_threads, max_blocks);
   clear_map<map_key_t, value_t><<<n_blocks, n_threads, 0, stream.get()>>>(this->view());
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
 }
 
 template <size_t max_routes>
@@ -153,7 +153,7 @@ bool test_empty(typename detail::device_map_t<key_t<max_routes>, double>::view_t
   auto n_threads = 256;
   auto n_blocks  = (max_vals + n_threads - 1) / n_threads;
   test_empty<key_t<max_routes>, double><<<n_blocks, n_threads, 0, stream.get()>>>(map_view);
-  RAFT_CHECK_CUDA(stream);
+  RAFT_CHECK_CUDA(stream.get());
   return true;
 }
 
@@ -188,7 +188,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::get_cycle(graph_t<i_t, f_t>& graph,
   for (i_t cycle_id = 0; cycle_id < n_cycles; ++cycle_id) {
     init_cycle<i_t, f_t, max_routes>
       <<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_ret.view(), best_cycles.subspan(cycle_id));
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     i_t level = level_vec[cycle_id];
 
     for (int i = level; i > 0; --i) {
@@ -199,13 +199,13 @@ void ExactCycleFinder<i_t, f_t, max_routes>::get_cycle(graph_t<i_t, f_t>& graph,
                                                                d_ret.view(),
                                                                i,
                                                                (level + 1) - i);
-      RAFT_CHECK_CUDA(handle_ptr->get_stream());
+      RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     }
     close_cycle<i_t, f_t, max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(
       d_ret.view(), best_cycles.subspan(cycle_id), level + 1);
     cuopt_func_call(d_ret.total_cycle_cost +=
                     best_cycles.cost_ptr.element(cycle_id, handle_ptr->get_stream()));
-    RAFT_CHECK_CUDA(handle_ptr->get_stream());
+    RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   }
 }
 

--- a/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
+++ b/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
@@ -33,12 +33,14 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_init(graph_t<i_t, f_t>& graph)
   bool is_set     = set_shmem_of_kernel(init_kernel<i_t, f_t, max_routes>, sh_size);
   if (!is_set) { return false; }
 
-  init_kernel<i_t, f_t, max_routes><<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
-    graph.view(), d_valid_paths.subspan(level));
+  init_kernel<i_t, f_t, max_routes>
+    <<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
+      graph.view(), d_valid_paths.subspan(level));
   RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
   // we have a safe-guard in the kernel for the global array stores
   // do the safe guard here for the occupied size
-  clamp_occupied<max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_valid_paths.subspan(level));
+  clamp_occupied<max_routes>
+    <<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_valid_paths.subspan(level));
   return true;
 }
 
@@ -194,11 +196,11 @@ void ExactCycleFinder<i_t, f_t, max_routes>::get_cycle(graph_t<i_t, f_t>& graph,
     for (int i = level; i > 0; --i) {
       extend_cycle<i_t, f_t, max_routes>
         <<<n_blocks, n_threads, 0, handle_ptr->get_stream().get()>>>(graph.view(),
-                                                               d_valid_paths.subspan(i),
-                                                               best_cycles.subspan(cycle_id),
-                                                               d_ret.view(),
-                                                               i,
-                                                               (level + 1) - i);
+                                                                     d_valid_paths.subspan(i),
+                                                                     best_cycles.subspan(cycle_id),
+                                                                     d_ret.view(),
+                                                                     i,
+                                                                     (level + 1) - i);
       RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
     }
     close_cycle<i_t, f_t, max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(
@@ -350,10 +352,10 @@ void ExactCycleFinder<i_t, f_t, max_routes>::find_best_cycles(
   // record best cycles
   record_best_cycles<i_t, f_t, max_routes>
     <<<1, 1, 0, handle_ptr->get_stream().get()>>>(cycle_candidates.size * cycle_candidates.n_paths,
-                                            graph.view(),
-                                            cycle_candidates.view(),
-                                            best_cycles.view(),
-                                            sorted_key_indices.data());
+                                                  graph.view(),
+                                                  cycle_candidates.view(),
+                                                  best_cycles.view(),
+                                                  sorted_key_indices.data());
   get_cycle(graph, ret);
   cuopt_assert(check_cycle(graph, ret), "Recomputed cost mismatch");
 }

--- a/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
+++ b/cpp/src/routing/local_search/cycle_finder/cycle_finder.cu
@@ -33,12 +33,12 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_init(graph_t<i_t, f_t>& graph)
   bool is_set     = set_shmem_of_kernel(init_kernel<i_t, f_t, max_routes>, sh_size);
   if (!is_set) { return false; }
 
-  init_kernel<i_t, f_t, max_routes><<<n_blocks, n_threads, sh_size, handle_ptr->get_stream()>>>(
+  init_kernel<i_t, f_t, max_routes><<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
     graph.view(), d_valid_paths.subspan(level));
   RAFT_CHECK_CUDA(handle_ptr->get_stream());
   // we have a safe-guard in the kernel for the global array stores
   // do the safe guard here for the occupied size
-  clamp_occupied<max_routes><<<1, 1, 0, handle_ptr->get_stream()>>>(d_valid_paths.subspan(level));
+  clamp_occupied<max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_valid_paths.subspan(level));
   return true;
 }
 
@@ -79,7 +79,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_cycle_costs_by_key(int n_items
                                   n_items,
                                   begin_bit,
                                   end_bit,
-                                  handle_ptr->get_stream());
+                                  handle_ptr->get_stream().get());
 
   // Allocate temporary storage
   if (d_cub_storage_bytes.size() < temp_storage_bytes) {
@@ -95,7 +95,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_cycle_costs_by_key(int n_items
                                   n_items,
                                   begin_bit,
                                   end_bit,
-                                  handle_ptr->get_stream());
+                                  handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t, size_t max_routes>
@@ -112,7 +112,7 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_find(graph_t<i_t, f_t>& graph,
   if (last_level) {
     if (!set_shmem_of_kernel(find_kernel<i_t, f_t, max_routes, true>, sh_size)) { return false; }
     find_kernel<i_t, f_t, max_routes, true>
-      <<<n_blocks, n_threads, sh_size, handle_ptr->get_stream()>>>(
+      <<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
         level,
         graph.view(),
         d_valid_paths.subspan(level - 1),
@@ -122,7 +122,7 @@ bool ExactCycleFinder<i_t, f_t, max_routes>::call_find(graph_t<i_t, f_t>& graph,
   } else {
     if (!set_shmem_of_kernel(find_kernel<i_t, f_t, max_routes, false>, sh_size)) { return false; }
     find_kernel<i_t, f_t, max_routes, false>
-      <<<n_blocks, n_threads, sh_size, handle_ptr->get_stream()>>>(
+      <<<n_blocks, n_threads, sh_size, handle_ptr->get_stream().get()>>>(
         level,
         graph.view(),
         d_valid_paths.subspan(level - 1),
@@ -141,7 +141,7 @@ void detail::device_map_t<map_key_t, value_t>::clear(rmm::cuda_stream_view strea
   auto max_vals  = max_level * max_available;
   auto n_threads = 256;
   auto n_blocks  = std::min((max_vals + n_threads - 1) / n_threads, max_blocks);
-  clear_map<map_key_t, value_t><<<n_blocks, n_threads, 0, stream>>>(this->view());
+  clear_map<map_key_t, value_t><<<n_blocks, n_threads, 0, stream.get()>>>(this->view());
   RAFT_CHECK_CUDA(stream);
 }
 
@@ -152,7 +152,7 @@ bool test_empty(typename detail::device_map_t<key_t<max_routes>, double>::view_t
   auto max_vals  = map_view.max_available;
   auto n_threads = 256;
   auto n_blocks  = (max_vals + n_threads - 1) / n_threads;
-  test_empty<key_t<max_routes>, double><<<n_blocks, n_threads, 0, stream>>>(map_view);
+  test_empty<key_t<max_routes>, double><<<n_blocks, n_threads, 0, stream.get()>>>(map_view);
   RAFT_CHECK_CUDA(stream);
   return true;
 }
@@ -187,13 +187,13 @@ void ExactCycleFinder<i_t, f_t, max_routes>::get_cycle(graph_t<i_t, f_t>& graph,
   cuopt_func_call(d_ret.total_cycle_cost = 0.);
   for (i_t cycle_id = 0; cycle_id < n_cycles; ++cycle_id) {
     init_cycle<i_t, f_t, max_routes>
-      <<<1, 1, 0, handle_ptr->get_stream()>>>(d_ret.view(), best_cycles.subspan(cycle_id));
+      <<<1, 1, 0, handle_ptr->get_stream().get()>>>(d_ret.view(), best_cycles.subspan(cycle_id));
     RAFT_CHECK_CUDA(handle_ptr->get_stream());
     i_t level = level_vec[cycle_id];
 
     for (int i = level; i > 0; --i) {
       extend_cycle<i_t, f_t, max_routes>
-        <<<n_blocks, n_threads, 0, handle_ptr->get_stream()>>>(graph.view(),
+        <<<n_blocks, n_threads, 0, handle_ptr->get_stream().get()>>>(graph.view(),
                                                                d_valid_paths.subspan(i),
                                                                best_cycles.subspan(cycle_id),
                                                                d_ret.view(),
@@ -201,7 +201,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::get_cycle(graph_t<i_t, f_t>& graph,
                                                                (level + 1) - i);
       RAFT_CHECK_CUDA(handle_ptr->get_stream());
     }
-    close_cycle<i_t, f_t, max_routes><<<1, 1, 0, handle_ptr->get_stream()>>>(
+    close_cycle<i_t, f_t, max_routes><<<1, 1, 0, handle_ptr->get_stream().get()>>>(
       d_ret.view(), best_cycles.subspan(cycle_id), level + 1);
     cuopt_func_call(d_ret.total_cycle_cost +=
                     best_cycles.cost_ptr.element(cycle_id, handle_ptr->get_stream()));
@@ -300,7 +300,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_occupied(int level,
     curr_map.occupied_indices.data(),
     curr_level_occupied,
     [] __device__(int2 a, int2 b) -> bool { return a.y < b.y; },
-    handle_ptr->get_stream());
+    handle_ptr->get_stream().get());
   // Allocate temporary storage
   if (d_cub_storage_bytes.size() < temp_storage_bytes) {
     d_cub_storage_bytes.resize(temp_storage_bytes, handle_ptr->get_stream());
@@ -312,7 +312,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_occupied(int level,
     curr_map.occupied_indices.data(),
     curr_level_occupied,
     [] __device__(int2 a, int2 b) -> bool { return a.y < b.y; },
-    handle_ptr->get_stream());
+    handle_ptr->get_stream().get());
 
   // do an exclusive scan for the offsets of heads, this will be used in kernels
   temp_storage_bytes = 0;
@@ -321,7 +321,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_occupied(int level,
                                 curr_map.size_per_head.data(),
                                 curr_map.size_per_head.data(),
                                 graph.get_num_vertices() + 1,
-                                handle_ptr->get_stream());
+                                handle_ptr->get_stream().get());
   // Allocate temporary storage
   if (d_cub_storage_bytes.size() < temp_storage_bytes) {
     d_cub_storage_bytes.resize(temp_storage_bytes, handle_ptr->get_stream());
@@ -332,7 +332,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::sort_occupied(int level,
                                 curr_map.size_per_head.data(),
                                 curr_map.size_per_head.data(),
                                 graph.get_num_vertices() + 1,
-                                handle_ptr->get_stream());
+                                handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t, size_t max_routes>
@@ -349,7 +349,7 @@ void ExactCycleFinder<i_t, f_t, max_routes>::find_best_cycles(
   sort_cycle_costs_by_key(cycle_candidates.size * cycle_candidates.n_paths);
   // record best cycles
   record_best_cycles<i_t, f_t, max_routes>
-    <<<1, 1, 0, handle_ptr->get_stream()>>>(cycle_candidates.size * cycle_candidates.n_paths,
+    <<<1, 1, 0, handle_ptr->get_stream().get()>>>(cycle_candidates.size * cycle_candidates.n_paths,
                                             graph.view(),
                                             cycle_candidates.view(),
                                             best_cycles.view(),

--- a/cpp/src/routing/local_search/cycle_finder/cycle_finder.hpp
+++ b/cpp/src/routing/local_search/cycle_finder/cycle_finder.hpp
@@ -66,7 +66,8 @@ struct path_t {
     all_found.set_value_to_zero_async(stream);
     // device_bitset_t is all zeros when cleared; memset avoids a host-source copy, which
     // is not capturable into a CUDA graph on CUDA 13.
-    RAFT_CUDA_TRY(cudaMemsetAsync(all_mask.data(), 0, sizeof(device_bitset_t<max_routes>), stream.get()));
+    RAFT_CUDA_TRY(
+      cudaMemsetAsync(all_mask.data(), 0, sizeof(device_bitset_t<max_routes>), stream.get()));
   }
 
   struct view_t {

--- a/cpp/src/routing/local_search/cycle_finder/cycle_finder.hpp
+++ b/cpp/src/routing/local_search/cycle_finder/cycle_finder.hpp
@@ -66,7 +66,7 @@ struct path_t {
     all_found.set_value_to_zero_async(stream);
     // device_bitset_t is all zeros when cleared; memset avoids a host-source copy, which
     // is not capturable into a CUDA graph on CUDA 13.
-    RAFT_CUDA_TRY(cudaMemsetAsync(all_mask.data(), 0, sizeof(device_bitset_t<max_routes>), stream));
+    RAFT_CUDA_TRY(cudaMemsetAsync(all_mask.data(), 0, sizeof(device_bitset_t<max_routes>), stream.get()));
   }
 
   struct view_t {

--- a/cpp/src/routing/local_search/fill_gpu_graph.cu
+++ b/cpp/src/routing/local_search/fill_gpu_graph.cu
@@ -164,7 +164,7 @@ void local_search_t<i_t, f_t, REQUEST>::fill_gpu_graph(solution_t<i_t, f_t, REQU
   i_t n_blocks = solution.get_num_requests() + 1;
   fill_graph_kernel<i_t, f_t, REQUEST, TPB>
     <<<n_blocks, TPB, 0, stream>>>(solution.view(), move_candidates.view());
-  stream.synchronize();
+  stream.sync();
 }
 template void local_search_t<int, float, request_t::PDP>::fill_gpu_graph(
   solution_t<int, float, request_t::PDP>&);

--- a/cpp/src/routing/local_search/fill_gpu_graph.cu
+++ b/cpp/src/routing/local_search/fill_gpu_graph.cu
@@ -158,12 +158,12 @@ void local_search_t<i_t, f_t, REQUEST>::fill_gpu_graph(solution_t<i_t, f_t, REQU
   solution.sol_handle->sync_stream();
   const auto stream                   = solution.sol_handle->get_stream();
   move_candidates.graph.special_index = solution.get_num_orders() + solution.n_routes;
-  fill_intra_candidates<i_t, f_t, REQUEST><<<solution.n_routes, TPB, 0, stream>>>(
+  fill_intra_candidates<i_t, f_t, REQUEST><<<solution.n_routes, TPB, 0, stream.get()>>>(
     solution.view(), move_candidates.view(), solution.problem_ptr->seed_gen.get_seed());
   // +1 for special node
   i_t n_blocks = solution.get_num_requests() + 1;
   fill_graph_kernel<i_t, f_t, REQUEST, TPB>
-    <<<n_blocks, TPB, 0, stream>>>(solution.view(), move_candidates.view());
+    <<<n_blocks, TPB, 0, stream.get()>>>(solution.view(), move_candidates.view());
   stream.sync();
 }
 template void local_search_t<int, float, request_t::PDP>::fill_gpu_graph(

--- a/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
+++ b/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -44,7 +44,8 @@ auto compute_route_cost_differences(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   compute_route_cost_differences_kernel<i_t, f_t, REQUEST, TPB>
-    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
+    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(),
+                                                                   vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
@@ -61,7 +62,8 @@ auto compute_route_vehicle_assignments(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   compute_route_vehicle_assignments_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
+    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(),
+                                                                   vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
@@ -77,8 +79,9 @@ auto update_assignment(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   auto k_iter = vehicle_assignment.get_k_regrets() - 1;
-  update_assignment_kernel<i_t, f_t, REQUEST><<<k_iter, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
-    sol.view(), move_candidates.view(), vehicle_assignment.view());
+  update_assignment_kernel<i_t, f_t, REQUEST>
+    <<<k_iter, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
+      sol.view(), move_candidates.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }

--- a/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
+++ b/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
@@ -24,7 +24,7 @@ auto compute_route_costs(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   compute_route_costs_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   return true;
@@ -44,7 +44,7 @@ auto compute_route_cost_differences(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   compute_route_cost_differences_kernel<i_t, f_t, REQUEST, TPB>
-    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream()>>>(sol.view(), vehicle_assignment.view());
+    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   return true;
 }
@@ -61,7 +61,7 @@ auto compute_route_vehicle_assignments(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   compute_route_vehicle_assignments_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream()>>>(sol.view(), vehicle_assignment.view());
+    <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   return true;
 }
@@ -77,7 +77,7 @@ auto update_assignment(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
 
   auto k_iter = vehicle_assignment.get_k_regrets() - 1;
-  update_assignment_kernel<i_t, f_t, REQUEST><<<k_iter, TPB, shmem, sol.sol_handle->get_stream()>>>(
+  update_assignment_kernel<i_t, f_t, REQUEST><<<k_iter, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   return true;
@@ -91,7 +91,7 @@ void reset_vehicle_availability(solution_t<i_t, f_t, REQUEST>& sol,
   async_fill(vehicle_assignment.vehicle_availability, -1, sol.sol_handle->get_stream());
   auto k_iter = vehicle_assignment.get_k_regrets() - 1;
   reset_vehicle_availability_kernel<i_t, f_t, REQUEST>
-    <<<k_iter, TPB, 0, sol.sol_handle->get_stream()>>>(sol.view(), vehicle_assignment.view());
+    <<<k_iter, TPB, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 }
 
@@ -142,7 +142,7 @@ auto find_best_assignment(solution_t<i_t, f_t, REQUEST>& sol,
   bool is_set          = set_shmem_of_kernel(find_best_assignment_kernel<i_t, f_t, REQUEST>, shmem);
   if (!is_set) { return false; }
   find_best_assignment_kernel<i_t, f_t, REQUEST>
-    <<<1, TPB, shmem, sol.sol_handle->get_stream()>>>(sol.view(), vehicle_assignment.view());
+    <<<1, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   return true;
 }
@@ -159,7 +159,7 @@ auto update_solution(solution_t<i_t, f_t, REQUEST>& sol,
   bool is_set        = set_shmem_of_kernel(update_solution_kernel<i_t, f_t, REQUEST>, shmem);
   if (!is_set) { return false; }
   update_solution_kernel<i_t, f_t, REQUEST>
-    <<<sol.get_n_routes(), TPB, shmem, sol.sol_handle->get_stream()>>>(
+    <<<sol.get_n_routes(), TPB, shmem, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), vehicle_assignment.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 

--- a/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
+++ b/cpp/src/routing/local_search/hvrp/vehicle_assignment.cu
@@ -26,7 +26,7 @@ auto compute_route_costs(solution_t<i_t, f_t, REQUEST>& sol,
   compute_route_costs_kernel<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
 
@@ -45,7 +45,7 @@ auto compute_route_cost_differences(solution_t<i_t, f_t, REQUEST>& sol,
 
   compute_route_cost_differences_kernel<i_t, f_t, REQUEST, TPB>
     <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
 
@@ -62,7 +62,7 @@ auto compute_route_vehicle_assignments(solution_t<i_t, f_t, REQUEST>& sol,
 
   compute_route_vehicle_assignments_kernel<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
 
@@ -79,7 +79,7 @@ auto update_assignment(solution_t<i_t, f_t, REQUEST>& sol,
   auto k_iter = vehicle_assignment.get_k_regrets() - 1;
   update_assignment_kernel<i_t, f_t, REQUEST><<<k_iter, TPB, shmem, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
 
@@ -92,7 +92,7 @@ void reset_vehicle_availability(solution_t<i_t, f_t, REQUEST>& sol,
   auto k_iter = vehicle_assignment.get_k_regrets() - 1;
   reset_vehicle_availability_kernel<i_t, f_t, REQUEST>
     <<<k_iter, TPB, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -143,7 +143,7 @@ auto find_best_assignment(solution_t<i_t, f_t, REQUEST>& sol,
   if (!is_set) { return false; }
   find_best_assignment_kernel<i_t, f_t, REQUEST>
     <<<1, TPB, shmem, sol.sol_handle->get_stream().get()>>>(sol.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   return true;
 }
 
@@ -161,7 +161,7 @@ auto update_solution(solution_t<i_t, f_t, REQUEST>& sol,
   update_solution_kernel<i_t, f_t, REQUEST>
     <<<sol.get_n_routes(), TPB, shmem, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), vehicle_assignment.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   sol.compute_cost();
   sol.sol_handle->sync_stream();

--- a/cpp/src/routing/local_search/local_search.cu
+++ b/cpp/src/routing/local_search/local_search.cu
@@ -290,7 +290,7 @@ void local_search_t<i_t, f_t, REQUEST>::run_best_local_search(solution_t<i_t, f_
     calculate_route_compatibility(sol);
     find_insertions<i_t, f_t, REQUEST>(sol, move_candidates, search_type_t::IMPROVE);
 
-    RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
     sol.sol_handle->sync_stream();
     fill_gpu_graph(sol);
 
@@ -348,7 +348,7 @@ void local_search_t<i_t, f_t, REQUEST>::run_random_local_search(solution_t<i_t, 
   calculate_route_compatibility(sol);
   find_insertions<i_t, f_t, REQUEST>(sol, move_candidates, search_type_t::RANDOM);
 
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   sol.sol_handle->sync_stream();
   populate_random_moves(sol);
 

--- a/cpp/src/routing/local_search/perform_moves.cu
+++ b/cpp/src/routing/local_search/perform_moves.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -429,7 +429,7 @@ bool local_search_t<i_t, f_t, REQUEST>::populate_cross_moves(
   }
   populate_cross_moves_kernel<i_t, f_t, REQUEST>
     <<<1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(solution.view(),
-                                                             move_candidates.view());
+                                                                   move_candidates.view());
   solution.sol_handle->sync_stream();
   return true;
 }
@@ -443,10 +443,11 @@ void local_search_t<i_t, f_t, REQUEST>::populate_move_path(
   if (n_cycles) {
     populate_move_path_kernel<i_t, f_t, REQUEST>
       <<<n_cycles, 32, 0, solution.sol_handle->get_stream().get()>>>(solution.view(),
-                                                               move_candidates.view());
+                                                                     move_candidates.view());
   }
   populate_intra_candidates<i_t, f_t, REQUEST>
-    <<<1, 128, 0, solution.sol_handle->get_stream().get()>>>(solution.view(), move_candidates.view());
+    <<<1, 128, 0, solution.sol_handle->get_stream().get()>>>(solution.view(),
+                                                             move_candidates.view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>

--- a/cpp/src/routing/local_search/perform_moves.cu
+++ b/cpp/src/routing/local_search/perform_moves.cu
@@ -419,7 +419,7 @@ bool local_search_t<i_t, f_t, REQUEST>::populate_cross_moves(
     return false;
   }
   populate_cross_list_kernel<i_t, f_t, REQUEST>
-    <<<solution.get_num_orders() - 1, TPB, sh_size, solution.sol_handle->get_stream()>>>(
+    <<<solution.get_num_orders() - 1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(
       solution.view(), move_candidates.view());
 
   sh_size = sizeof(i_t) * (solution.n_routes + 1) * solution.n_routes;
@@ -428,7 +428,7 @@ bool local_search_t<i_t, f_t, REQUEST>::populate_cross_moves(
     return false;
   }
   populate_cross_moves_kernel<i_t, f_t, REQUEST>
-    <<<1, TPB, sh_size, solution.sol_handle->get_stream()>>>(solution.view(),
+    <<<1, TPB, sh_size, solution.sol_handle->get_stream().get()>>>(solution.view(),
                                                              move_candidates.view());
   solution.sol_handle->sync_stream();
   return true;
@@ -442,11 +442,11 @@ void local_search_t<i_t, f_t, REQUEST>::populate_move_path(
   auto n_cycles = move_candidates.cycles.n_cycles_.value(solution.sol_handle->get_stream());
   if (n_cycles) {
     populate_move_path_kernel<i_t, f_t, REQUEST>
-      <<<n_cycles, 32, 0, solution.sol_handle->get_stream()>>>(solution.view(),
+      <<<n_cycles, 32, 0, solution.sol_handle->get_stream().get()>>>(solution.view(),
                                                                move_candidates.view());
   }
   populate_intra_candidates<i_t, f_t, REQUEST>
-    <<<1, 128, 0, solution.sol_handle->get_stream()>>>(solution.view(), move_candidates.view());
+    <<<1, 128, 0, solution.sol_handle->get_stream().get()>>>(solution.view(), move_candidates.view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -464,7 +464,7 @@ void local_search_t<i_t, f_t, REQUEST>::perform_moves(solution_t<i_t, f_t, REQUE
   cuopt_assert(is_set, "Not enough shared memory on device for performing the local search move!");
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   insert_graph_nodes_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shared_size, stream>>>(solution.view(), move_candidates.view());
+    <<<n_blocks, TPB, shared_size, stream.get()>>>(solution.view(), move_candidates.view());
   solution.compute_route_id_per_node();
   solution.compute_cost();
   solution.global_runtime_checks(false, false, "perform_moves_end");

--- a/cpp/src/routing/local_search/prize_collection.cu
+++ b/cpp/src/routing/local_search/prize_collection.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -229,7 +229,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
 
   get_best_move_per_route<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
-                                                                   move_candidates.view());
+                                                                         move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   if (!move_candidates.prize_move_candidates.has_improving_routes(sol.sol_handle)) { return false; }
@@ -237,8 +237,9 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
   n_blocks    = sol.get_n_routes();
   shared_size = sol.check_routes_can_insert_and_get_sh_size(request_info_t<i_t, REQUEST>::size());
   if (!set_shmem_of_kernel(execute_moves<i_t, f_t, REQUEST>, shared_size)) { return false; }
-  execute_moves<i_t, f_t, REQUEST><<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
-    sol.view(), move_candidates.view());
+  execute_moves<i_t, f_t, REQUEST>
+    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
+                                                                         move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   sol.compute_cost();

--- a/cpp/src/routing/local_search/prize_collection.cu
+++ b/cpp/src/routing/local_search/prize_collection.cu
@@ -230,7 +230,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
   get_best_move_per_route<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
                                                                    move_candidates.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   if (!move_candidates.prize_move_candidates.has_improving_routes(sol.sol_handle)) { return false; }
 
@@ -239,7 +239,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
   if (!set_shmem_of_kernel(execute_moves<i_t, f_t, REQUEST>, shared_size)) { return false; }
   execute_moves<i_t, f_t, REQUEST><<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   sol.compute_cost();
 

--- a/cpp/src/routing/local_search/prize_collection.cu
+++ b/cpp/src/routing/local_search/prize_collection.cu
@@ -228,7 +228,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
   size_t shared_size = 0;
 
   get_best_move_per_route<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(sol.view(),
+    <<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(sol.view(),
                                                                    move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 
@@ -237,7 +237,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_prize_collection(solution_t<i_t,
   n_blocks    = sol.get_n_routes();
   shared_size = sol.check_routes_can_insert_and_get_sh_size(request_info_t<i_t, REQUEST>::size());
   if (!set_shmem_of_kernel(execute_moves<i_t, f_t, REQUEST>, shared_size)) { return false; }
-  execute_moves<i_t, f_t, REQUEST><<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream()>>>(
+  execute_moves<i_t, f_t, REQUEST><<<n_blocks, TPB, shared_size, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 

--- a/cpp/src/routing/local_search/random_cross.cu
+++ b/cpp/src/routing/local_search/random_cross.cu
@@ -203,7 +203,7 @@ void select_random_route_pairs(solution_t<i_t, f_t, REQUEST>& sol,
     return;
   }
   select_random_route_pairs_kernel<i_t, f_t, REQUEST>
-    <<<nblocks, nthreads, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<nblocks, nthreads, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 }
@@ -216,7 +216,7 @@ void pick_random_move_per_route_pair(solution_t<i_t, f_t, REQUEST>& sol,
   i_t n_route_pair       = sol.n_routes * sol.n_routes;
   auto nblocks           = (n_route_pair + nthreads - 1) / nthreads;
   pick_random_move_per_route_pair_kernel<i_t, f_t, REQUEST>
-    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream()>>>(
+    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 }
@@ -228,7 +228,7 @@ void get_offsets_of_route_pairs(solution_t<i_t, f_t, REQUEST>& sol,
 {
   constexpr i_t nthreads = 256;
   auto nblocks           = ((n_random_moves + 1) + nthreads - 1) / nthreads;
-  extract_offsets_kernel<i_t, f_t, REQUEST><<<nblocks, nthreads, 0, sol.sol_handle->get_stream()>>>(
+  extract_offsets_kernel<i_t, f_t, REQUEST><<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view(), n_random_moves);
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 }
@@ -248,7 +248,7 @@ i_t sort_random_moves_by_route_pair_idx(solution_t<i_t, f_t, REQUEST>& sol,
     random_candidates.moves_per_route_pair.data(),
     n_random_moves,
     [] __device__(int2 a, int2 b) -> bool { return a.y < b.y; },
-    sol.sol_handle->get_stream());
+    sol.sol_handle->get_stream().get());
   // Allocate temporary storage
   if (random_candidates.d_cub_storage_bytes.size() < temp_storage_bytes) {
     random_candidates.d_cub_storage_bytes.resize(temp_storage_bytes, sol.sol_handle->get_stream());
@@ -260,7 +260,7 @@ i_t sort_random_moves_by_route_pair_idx(solution_t<i_t, f_t, REQUEST>& sol,
     random_candidates.moves_per_route_pair.data(),
     n_random_moves,
     [] __device__(int2 a, int2 b) -> bool { return a.y < b.y; },
-    sol.sol_handle->get_stream());
+    sol.sol_handle->get_stream().get());
   return n_random_moves;
 }
 
@@ -272,7 +272,7 @@ void local_search_t<i_t, f_t, REQUEST>::populate_random_moves(solution_t<i_t, f_
   constexpr i_t nthreads = 256;
   auto nblocks           = sol.get_num_depot_excluded_orders();
   fill_random_route_pair_moves<i_t, f_t, REQUEST>
-    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream()>>>(sol.view(), move_candidates.view());
+    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   // sort valid moves by route pair index
   i_t n_random_moves = sort_random_moves_by_route_pair_idx(sol, move_candidates);

--- a/cpp/src/routing/local_search/random_cross.cu
+++ b/cpp/src/routing/local_search/random_cross.cu
@@ -228,8 +228,9 @@ void get_offsets_of_route_pairs(solution_t<i_t, f_t, REQUEST>& sol,
 {
   constexpr i_t nthreads = 256;
   auto nblocks           = ((n_random_moves + 1) + nthreads - 1) / nthreads;
-  extract_offsets_kernel<i_t, f_t, REQUEST><<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
-    sol.view(), move_candidates.view(), n_random_moves);
+  extract_offsets_kernel<i_t, f_t, REQUEST>
+    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
+      sol.view(), move_candidates.view(), n_random_moves);
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
@@ -272,7 +273,8 @@ void local_search_t<i_t, f_t, REQUEST>::populate_random_moves(solution_t<i_t, f_
   constexpr i_t nthreads = 256;
   auto nblocks           = sol.get_num_depot_excluded_orders();
   fill_random_route_pair_moves<i_t, f_t, REQUEST>
-    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), move_candidates.view());
+    <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(sol.view(),
+                                                                   move_candidates.view());
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   // sort valid moves by route pair index
   i_t n_random_moves = sort_random_moves_by_route_pair_idx(sol, move_candidates);

--- a/cpp/src/routing/local_search/random_cross.cu
+++ b/cpp/src/routing/local_search/random_cross.cu
@@ -205,7 +205,7 @@ void select_random_route_pairs(solution_t<i_t, f_t, REQUEST>& sol,
   select_random_route_pairs_kernel<i_t, f_t, REQUEST>
     <<<nblocks, nthreads, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -218,7 +218,7 @@ void pick_random_move_per_route_pair(solution_t<i_t, f_t, REQUEST>& sol,
   pick_random_move_per_route_pair_kernel<i_t, f_t, REQUEST>
     <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -230,7 +230,7 @@ void get_offsets_of_route_pairs(solution_t<i_t, f_t, REQUEST>& sol,
   auto nblocks           = ((n_random_moves + 1) + nthreads - 1) / nthreads;
   extract_offsets_kernel<i_t, f_t, REQUEST><<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(
     sol.view(), move_candidates.view(), n_random_moves);
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -273,7 +273,7 @@ void local_search_t<i_t, f_t, REQUEST>::populate_random_moves(solution_t<i_t, f_
   auto nblocks           = sol.get_num_depot_excluded_orders();
   fill_random_route_pair_moves<i_t, f_t, REQUEST>
     <<<nblocks, nthreads, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), move_candidates.view());
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   // sort valid moves by route pair index
   i_t n_random_moves = sort_random_moves_by_route_pair_idx(sol, move_candidates);
   if (n_random_moves == 0) return;

--- a/cpp/src/routing/local_search/sliding_tsp.cu
+++ b/cpp/src/routing/local_search/sliding_tsp.cu
@@ -427,7 +427,7 @@ void resize_temp_storage(solution_t<i_t, f_t, REQUEST>& sol,
                                 distances_ptr,
                                 distances_ptr,
                                 n_nodes + 1,
-                                sol.sol_handle->get_stream());
+                                sol.sol_handle->get_stream().get());
 
   if (temp_storage_bytes > 0) {
     move_candidates.temp_storage.resize(temp_storage_bytes, sol.sol_handle->get_stream());
@@ -446,11 +446,11 @@ void compute_cumulative_distances(solution_t<i_t, f_t, REQUEST>& sol,
   auto n_fill_blocks = (sol.get_num_orders() + n_threads - 1) / n_threads;
   if (reverse) {
     fill_reverse_distances_kernel<i_t, f_t, REQUEST>
-      <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream()>>>(sol.view());
+      <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
     RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   } else {
     fill_forward_distances_kernel<i_t, f_t, REQUEST>
-      <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream()>>>(sol.view());
+      <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
     RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
   }
 
@@ -460,7 +460,7 @@ void compute_cumulative_distances(solution_t<i_t, f_t, REQUEST>& sol,
                                 distances_ptr,
                                 distances_ptr,
                                 n_nodes + 2,
-                                sol.sol_handle->get_stream());
+                                sol.sol_handle->get_stream().get());
 
   if (n_temp_storage_bytes > 0) {
     cuopt_expects(n_temp_storage_bytes == temp_storage_bytes,
@@ -473,7 +473,7 @@ void compute_cumulative_distances(solution_t<i_t, f_t, REQUEST>& sol,
                                 distances_ptr,
                                 distances_ptr,
                                 n_nodes + 2,
-                                sol.sol_handle->get_stream());
+                                sol.sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -510,7 +510,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
   if (!set_shmem_of_kernel(find_sliding_moves_tsp<i_t, f_t, REQUEST>, sh_size)) { return false; }
 
   find_sliding_moves_tsp<i_t, f_t, REQUEST>
-    <<<n_blocks, n_threads, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, n_threads, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(),
       move_candidates.view(),
       cuopt::make_span(sampled_tsp_data_),
@@ -526,7 +526,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
   async_fill(moved_region_node_infos_, NodeInfo<i_t>{}, sol.sol_handle->get_stream());
 
   set_moved_regions_kernel<i_t, f_t, REQUEST>
-    <<<sol.get_n_routes(), 64, 0, sol.sol_handle->get_stream()>>>(
+    <<<sol.get_n_routes(), 64, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(), cuopt::make_span(moved_region_node_infos_));
   RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
 
@@ -548,7 +548,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
                });
 
   execute_sliding_moves_tsp<i_t, f_t, REQUEST>
-    <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(),
       move_candidates.view(),
       cuopt::make_span(sampled_tsp_data_),

--- a/cpp/src/routing/local_search/sliding_tsp.cu
+++ b/cpp/src/routing/local_search/sliding_tsp.cu
@@ -447,11 +447,11 @@ void compute_cumulative_distances(solution_t<i_t, f_t, REQUEST>& sol,
   if (reverse) {
     fill_reverse_distances_kernel<i_t, f_t, REQUEST>
       <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
-    RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   } else {
     fill_forward_distances_kernel<i_t, f_t, REQUEST>
       <<<n_fill_blocks, n_threads, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
-    RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
   }
 
   size_t n_temp_storage_bytes = 0;
@@ -515,7 +515,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
       move_candidates.view(),
       cuopt::make_span(sampled_tsp_data_),
       cuopt::make_span(locks_));
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   n_moves_found = thrust::count_if(rmm::exec_policy(sol.sol_handle->get_stream()),
                                    sampled_tsp_data_.begin(),
@@ -528,7 +528,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
   set_moved_regions_kernel<i_t, f_t, REQUEST>
     <<<sol.get_n_routes(), 64, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(), cuopt::make_span(moved_region_node_infos_));
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   cuopt_func_call(
     move_candidates.debug_delta.set_value_to_zero_async(sol.sol_handle->get_stream()));
@@ -553,7 +553,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_tsp(
       move_candidates.view(),
       cuopt::make_span(sampled_tsp_data_),
       cuopt::make_span(moved_region_node_infos_));
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   compute_cumulative_distances<i_t, f_t, REQUEST, false>(
     sol, move_candidates, n_nodes, n_threads, temp_storage_bytes);

--- a/cpp/src/routing/local_search/sliding_window.cu
+++ b/cpp/src/routing/local_search/sliding_window.cu
@@ -1083,7 +1083,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
   }
   sliding_cuda_graph.end_capture(solution.sol_handle->get_stream());
   sliding_cuda_graph.launch_graph(solution.sol_handle->get_stream());
-  RAFT_CHECK_CUDA(solution.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution.sol_handle->get_stream().get());
   n_moves_found = thrust::count_if(solution.sol_handle->get_thrust_policy(),
                                    found_sliding_solution_data_.begin(),
                                    found_sliding_solution_data_.end(),
@@ -1109,7 +1109,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
       found_sliding_solution_data_.data(),
       move_candidates.view(),
       move_candidates.debug_delta.data());
-  RAFT_CHECK_CUDA(solution.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(solution.sol_handle->get_stream().get());
   cuopt_func_call(solution.compute_cost());
   cuopt_func_call(cost_after =
                     solution.get_cost(move_candidates.include_objective, move_candidates.weights));

--- a/cpp/src/routing/local_search/sliding_window.cu
+++ b/cpp/src/routing/local_search/sliding_window.cu
@@ -1065,7 +1065,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
       <<<n_blocks,  // One block for each node
          thread_per_block,
          shared_for_tmp_route,
-         solution.sol_handle->get_stream()>>>(solution.view(),
+         solution.sol_handle->get_stream().get()>>>(solution.view(),
                                               found_sliding_solution_data_.data(),
                                               move_candidates.view(),
                                               locks_.data(),
@@ -1075,7 +1075,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
       <<<n_blocks,  // One block for each node
          thread_per_block,
          shared_for_tmp_route,
-         solution.sol_handle->get_stream()>>>(solution.view(),
+         solution.sol_handle->get_stream().get()>>>(solution.view(),
                                               found_sliding_solution_data_.data(),
                                               move_candidates.view(),
                                               locks_.data(),
@@ -1104,7 +1104,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
 
   // One block for each found route
   execute_sliding_move<i_t, f_t, REQUEST>
-    <<<solution.n_routes, 256, aligned_shared_size, solution.sol_handle->get_stream()>>>(
+    <<<solution.n_routes, 256, aligned_shared_size, solution.sol_handle->get_stream().get()>>>(
       solution.view(),
       found_sliding_solution_data_.data(),
       move_candidates.view(),

--- a/cpp/src/routing/local_search/sliding_window.cu
+++ b/cpp/src/routing/local_search/sliding_window.cu
@@ -1066,20 +1066,20 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_sliding_window(
          thread_per_block,
          shared_for_tmp_route,
          solution.sol_handle->get_stream().get()>>>(solution.view(),
-                                              found_sliding_solution_data_.data(),
-                                              move_candidates.view(),
-                                              locks_.data(),
-                                              blocks_per_node);
+                                                    found_sliding_solution_data_.data(),
+                                                    move_candidates.view(),
+                                                    locks_.data(),
+                                                    blocks_per_node);
   } else {
     kernel_perform_sliding_window<i_t, f_t, REQUEST, false>
       <<<n_blocks,  // One block for each node
          thread_per_block,
          shared_for_tmp_route,
          solution.sol_handle->get_stream().get()>>>(solution.view(),
-                                              found_sliding_solution_data_.data(),
-                                              move_candidates.view(),
-                                              locks_.data(),
-                                              blocks_per_node);
+                                                    found_sliding_solution_data_.data(),
+                                                    move_candidates.view(),
+                                                    locks_.data(),
+                                                    blocks_per_node);
   }
   sliding_cuda_graph.end_capture(solution.sol_handle->get_stream());
   sliding_cuda_graph.launch_graph(solution.sol_handle->get_stream());

--- a/cpp/src/routing/local_search/two_opt.cu
+++ b/cpp/src/routing/local_search/two_opt.cu
@@ -399,7 +399,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_two_opt(
       cuopt::make_span(two_opt_cand_data_),
       cuopt::make_span(sampled_nodes_data_),
       cuopt::make_span(locks_));
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   n_moves_found = thrust::count_if(sol.sol_handle->get_thrust_policy(),
                                    sampled_nodes_data_.begin(),
@@ -448,7 +448,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_two_opt(
         cuopt::make_span(two_opt_cand_data_),
         cuopt::make_span(moved_regions_));
   }
-  RAFT_CHECK_CUDA(sol.sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol.sol_handle->get_stream().get());
 
   cuopt_func_call(sol.compute_cost());
   cuopt_func_call(cost_after =

--- a/cpp/src/routing/local_search/two_opt.cu
+++ b/cpp/src/routing/local_search/two_opt.cu
@@ -393,7 +393,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_two_opt(
   if (!set_shmem_of_kernel(find_two_opt_moves<i_t, f_t, REQUEST>, sh_size)) { return false; }
 
   find_two_opt_moves<i_t, f_t, REQUEST>
-    <<<n_blocks, n_threads, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, n_threads, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(),
       move_candidates.view(),
       cuopt::make_span(two_opt_cand_data_),
@@ -434,7 +434,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_two_opt(
                           sol.sol_handle->get_stream());
     async_fill(moved_regions_, 0, sol.sol_handle->get_stream());
     execute_recycle<i_t, f_t, REQUEST, n_threads>
-      <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream()>>>(
+      <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream().get()>>>(
         sol.view(),
         move_candidates.view(),
         cuopt::make_span(sampled_nodes_data_),
@@ -442,7 +442,7 @@ bool local_search_t<i_t, f_t, REQUEST>::perform_two_opt(
   } else {
     if (!set_shmem_of_kernel(execute_two_opt_moves<i_t, f_t, REQUEST>, sh_size)) { return false; }
     execute_two_opt_moves<i_t, f_t, REQUEST>
-      <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream()>>>(
+      <<<sol.get_n_routes(), n_threads, sh_size, sol.sol_handle->get_stream().get()>>>(
         sol.view(),
         move_candidates.view(),
         cuopt::make_span(two_opt_cand_data_),

--- a/cpp/src/routing/local_search/vrp/nodes_to_search.cu
+++ b/cpp/src/routing/local_search/vrp/nodes_to_search.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/routing/local_search/vrp/nodes_to_search.cu
+++ b/cpp/src/routing/local_search/vrp/nodes_to_search.cu
@@ -56,7 +56,7 @@ void run_extract_kernel(solution_t<i_t, f_t, REQUEST>& sol,
   i_t TPB      = 256;
   i_t n_blocks = sol.get_n_routes();
   extract_nodes_to_search_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream().get()>>>(
       sol.view(), nodes_to_search.view(), restore_phase);
 }
 

--- a/cpp/src/routing/local_search/vrp/vrp_execute.cu
+++ b/cpp/src/routing/local_search/vrp/vrp_execute.cu
@@ -381,7 +381,7 @@ i_t extract_non_overlapping_moves(solution_t<i_t, f_t, REQUEST>& sol,
   i_t n_blocks_for_compact = (sol.n_routes * sol.n_routes + TPB - 1) / TPB;
   compact_best_route_pair_moves<i_t, f_t, REQUEST>
     <<<n_blocks_for_compact, TPB, 0, sol.sol_handle->get_stream().get()>>>(sol.view(),
-                                                                     move_candidates.view());
+                                                                           move_candidates.view());
   i_t n_best_route_pair_moves =
     move_candidates.vrp_move_candidates.n_best_route_pair_moves.value(sol.sol_handle->get_stream());
   n_best_route_pair_moves = std::min(n_best_route_pair_moves, max_n_best_route_pair_moves);

--- a/cpp/src/routing/local_search/vrp/vrp_execute.cu
+++ b/cpp/src/routing/local_search/vrp/vrp_execute.cu
@@ -380,7 +380,7 @@ i_t extract_non_overlapping_moves(solution_t<i_t, f_t, REQUEST>& sol,
   i_t TPB                  = 128;
   i_t n_blocks_for_compact = (sol.n_routes * sol.n_routes + TPB - 1) / TPB;
   compact_best_route_pair_moves<i_t, f_t, REQUEST>
-    <<<n_blocks_for_compact, TPB, 0, sol.sol_handle->get_stream()>>>(sol.view(),
+    <<<n_blocks_for_compact, TPB, 0, sol.sol_handle->get_stream().get()>>>(sol.view(),
                                                                      move_candidates.view());
   i_t n_best_route_pair_moves =
     move_candidates.vrp_move_candidates.n_best_route_pair_moves.value(sol.sol_handle->get_stream());
@@ -393,7 +393,7 @@ i_t extract_non_overlapping_moves(solution_t<i_t, f_t, REQUEST>& sol,
                "Not enough shared memory on device for extract_non_overlapping_moves_kernel!");
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   extract_non_overlapping_moves_kernel<i_t, f_t, REQUEST>
-    <<<1, TPB, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<1, TPB, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), sol.problem_ptr->seed_gen.get_seed());
   return move_candidates.vrp_move_candidates.n_of_selected_moves.value(
     sol.sol_handle->get_stream());
@@ -407,7 +407,7 @@ void find_max_added_size(solution_t<i_t, f_t, REQUEST>& sol,
   i_t TPB      = 32;
   i_t n_blocks = n_moves_found;
   find_max_added_size_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream()>>>(sol.view(), move_candidates.view());
+    <<<n_blocks, TPB, 0, sol.sol_handle->get_stream().get()>>>(sol.view(), move_candidates.view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -454,7 +454,7 @@ bool execute_vrp_moves(solution_t<i_t, f_t, REQUEST>& sol,
                               dimBlock,
                               kernelArgs,
                               sh_size,
-                              sol.sol_handle->get_stream());
+                              sol.sol_handle->get_stream().get());
   sol.compute_route_id_per_node();
   sol.compute_cost();
   // move_candidates.vrp_execute_graph.end_capture(sol.sol_handle->get_stream());

--- a/cpp/src/routing/local_search/vrp/vrp_search.cu
+++ b/cpp/src/routing/local_search/vrp/vrp_search.cu
@@ -652,7 +652,7 @@ bool find_vrp_moves(solution_t<i_t, f_t, REQUEST>& sol,
 
   if (sol.problem_ptr->is_cvrp()) {
     compute_reverse_distances<i_t, f_t, REQUEST>
-      <<<sol.get_n_routes(), 32, 0, sol.sol_handle->get_stream()>>>(sol.view());
+      <<<sol.get_n_routes(), 32, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
   }
   i_t TPB             = std::min(max_n_neighbors, sol.problem_ptr->get_num_orders());
   size_t size_of_frag = dimensions_route_t<i_t, f_t, REQUEST>::get_shared_size(
@@ -672,7 +672,7 @@ bool find_vrp_moves(solution_t<i_t, f_t, REQUEST>& sol,
   move_candidates.vrp_move_candidates.find_kernel_graph.start_capture(sol.sol_handle->get_stream());
   move_candidates.vrp_move_candidates.reset(sol.sol_handle);
   find_vrp_moves_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, sh_size, sol.sol_handle->get_stream()>>>(
+    <<<n_blocks, TPB, sh_size, sol.sol_handle->get_stream().get()>>>(
       sol.view(), move_candidates.view(), recycle);
   move_candidates.vrp_move_candidates.find_kernel_graph.end_capture(sol.sol_handle->get_stream());
   move_candidates.vrp_move_candidates.find_kernel_graph.launch_graph(sol.sol_handle->get_stream());

--- a/cpp/src/routing/order_info.cu
+++ b/cpp/src/routing/order_info.cu
@@ -113,7 +113,7 @@ void check_depot_times(data_model_view_t<i_t, f_t> const& data_model)
   i_t depot_earliest, depot_latest;
   raft::copy(&depot_earliest, earliest, 1, handle_ptr->get_stream());
   raft::copy(&depot_latest, latest, 1, handle_ptr->get_stream());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+  handle_ptr->get_stream().sync();
 
   rmm::device_uvector<i_t> v_latest_time(n_orders, handle_ptr->get_stream());
   rmm::device_uvector<i_t> v_earliest_time(n_orders, handle_ptr->get_stream());
@@ -195,7 +195,7 @@ void populate_order_info(data_model_view_t<i_t, f_t> const& data_model,
       thrust::max_element(handle_ptr_->get_thrust_policy(), temp_abs.begin(), temp_abs.end());
     i_t h_max_element;
     raft::copy(&h_max_element, max_element_ptr, 1, stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
     cuopt_expects(norders - 1 == h_max_element,
                   error_type_t::ValidationError,
                   "Index given is too big or an index in the delivery pickup pairs is missing!");

--- a/cpp/src/routing/order_info.cu
+++ b/cpp/src/routing/order_info.cu
@@ -113,7 +113,7 @@ void check_depot_times(data_model_view_t<i_t, f_t> const& data_model)
   i_t depot_earliest, depot_latest;
   raft::copy(&depot_earliest, earliest, 1, handle_ptr->get_stream());
   raft::copy(&depot_latest, latest, 1, handle_ptr->get_stream());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
 
   rmm::device_uvector<i_t> v_latest_time(n_orders, handle_ptr->get_stream());
   rmm::device_uvector<i_t> v_earliest_time(n_orders, handle_ptr->get_stream());
@@ -195,7 +195,7 @@ void populate_order_info(data_model_view_t<i_t, f_t> const& data_model,
       thrust::max_element(handle_ptr_->get_thrust_policy(), temp_abs.begin(), temp_abs.end());
     i_t h_max_element;
     raft::copy(&h_max_element, max_element_ptr, 1, stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     cuopt_expects(norders - 1 == h_max_element,
                   error_type_t::ValidationError,
                   "Index given is too big or an index in the delivery pickup pairs is missing!");

--- a/cpp/src/routing/order_info.cu
+++ b/cpp/src/routing/order_info.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -36,9 +36,9 @@ void populate_time_windows(data_model_view_t<i_t, f_t> const& data_model,
     raft::copy(order_info_.v_earliest_time_.data(),
                earliest,
                order_info_.get_num_orders(),
-               stream_view.value());
+               stream_view.get());
     raft::copy(
-      order_info_.v_latest_time_.data(), latest, order_info_.get_num_orders(), stream_view.value());
+      order_info_.v_latest_time_.data(), latest, order_info_.get_num_orders(), stream_view.get());
   } else {
     // subtract -1 to ensure that we can set max values for service times
     // in vehicle order match

--- a/cpp/src/routing/problem/problem.cu
+++ b/cpp/src/routing/problem/problem.cu
@@ -720,7 +720,7 @@ void problem_t<i_t, f_t>::populate_special_nodes()
   special_nodes.earliest_time    = cuopt::device_copy(node_earliest_h, handle_ptr->get_stream());
   special_nodes.latest_time      = cuopt::device_copy(node_latest_h, handle_ptr->get_stream());
   special_nodes.break_loc_to_idx = cuopt::device_copy(break_loc_to_idx_h, handle_ptr->get_stream());
-  RAFT_CHECK_CUDA(handle_ptr->get_stream());
+  RAFT_CHECK_CUDA(handle_ptr->get_stream().get());
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/routing/route/capacity_route.cuh
+++ b/cpp/src/routing/route/capacity_route.cuh
@@ -72,7 +72,7 @@ class capacity_route_t {
                                         std::min(old_stride, new_stride) * sizeof(i_t),
                                         n_dims,
                                         cudaMemcpyDeviceToDevice,
-                                        stream.value()));
+                                        stream.get()));
       }
       vec = std::move(new_vec);
     };

--- a/cpp/src/routing/solution/pool_allocator.cuh
+++ b/cpp/src/routing/solution/pool_allocator.cuh
@@ -70,7 +70,7 @@ class pool_allocator_t {
     }
   }
 
-  void sync_all_streams() const { stream.synchronize(); }
+  void sync_all_streams() const { stream.sync(); }
 
   // problem description
   rmm::cuda_stream_view stream;

--- a/cpp/src/routing/solution/solution.cu
+++ b/cpp/src/routing/solution/solution.cu
@@ -543,7 +543,7 @@ void solution_t<i_t, f_t, REQUEST>::copy_device_solution(solution_t<i_t, f_t, RE
   const auto n_blocks = n_routes;
   copy_routes<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view(), src_sol.view());
-  RAFT_CHECK_CUDA(sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol_handle->get_stream().get());
 
   cuopt_assert(route_node_map.intra_route_idx_per_node.size() == (size_t)get_num_orders(),
                "Intra route size mismatch!");
@@ -569,7 +569,7 @@ void solution_t<i_t, f_t, REQUEST>::copy_device_solution(solution_t<i_t, f_t, RE
     n_infeasible_routes.data(), src_sol.n_infeasible_routes.data(), 1, sol_handle->get_stream());
   unset_routes_to_copy();
   sol_handle->sync_stream();
-  RAFT_CHECK_CUDA(sol_handle->get_stream());
+  RAFT_CHECK_CUDA(sol_handle->get_stream().get());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -629,10 +629,10 @@ void solution_t<i_t, f_t, REQUEST>::shift_move_routes(
     remap_route_nodes<i_t, f_t, REQUEST>
       <<<n_blocks, threads_per_block, 0, sol_handle->get_stream().get()>>>(
         routes_view.data(), route_node_map.view(), route_ids_device_copy.data(), route_ids.size());
-    RAFT_CHECK_CUDA(sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol_handle->get_stream().get());
     shift_routes_kernel<i_t, f_t, REQUEST><<<1, 1, 0, sol_handle->get_stream().get()>>>(
       view(), route_ids_device_copy.data(), route_ids.size());
-    RAFT_CHECK_CUDA(sol_handle->get_stream());
+    RAFT_CHECK_CUDA(sol_handle->get_stream().get());
   }
   sol_handle->sync_stream();
   n_routes -= route_ids.size();

--- a/cpp/src/routing/solution/solution.cu
+++ b/cpp/src/routing/solution/solution.cu
@@ -171,8 +171,9 @@ void solution_t<i_t, f_t, REQUEST>::add_nodes_to_route(
   bool is_set    = set_shmem_of_kernel(insert_nodes_to_route_kernel<i_t, f_t, REQUEST>, sh_size);
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   i_t TPB = 256;
-  insert_nodes_to_route_kernel<i_t, f_t, REQUEST><<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(
-    view(), route_id, intra_idx, n_nodes_to_insert, temp_nodes.data());
+  insert_nodes_to_route_kernel<i_t, f_t, REQUEST>
+    <<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(
+      view(), route_id, intra_idx, n_nodes_to_insert, temp_nodes.data());
   thrust::fill(sol_handle->get_thrust_policy(),
                routes_to_search.data() + route_id,
                routes_to_search.data() + route_id + 1,
@@ -193,7 +194,8 @@ void solution_t<i_t, f_t, REQUEST>::add_nodes_to_best(
     bool is_set    = set_shmem_of_kernel(insert_node_to_best_kernel<i_t, f_t, REQUEST>, sh_size);
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     insert_node_to_best_kernel<i_t, f_t, REQUEST>
-      <<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(view(), node, include_objective, weights);
+      <<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(
+        view(), node, include_objective, weights);
     sol_handle->sync_stream();
   }
   this->global_runtime_checks(false, false, "add_nodes_to_best");
@@ -585,7 +587,8 @@ void solution_t<i_t, f_t, REQUEST>::compute_cost()
   objective_cost.set_value_async(zero_obj, sol_handle->get_stream());
   n_infeasible_routes.set_value_to_zero_async(sol_handle->get_stream());
   if (get_n_routes() < 1) return;
-  compute_cost_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view());
+  compute_cost_kernel<i_t, f_t, REQUEST>
+    <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -732,7 +735,8 @@ i_t solution_t<i_t, f_t, REQUEST>::compute_max_active()
 {
   raft::common::nvtx::range fun_scope("compute_max_active");
   i_t TPB = 1024;
-  compute_max_active_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, sol_handle->get_stream().get()>>>(view());
+  compute_max_active_kernel<i_t, f_t, REQUEST>
+    <<<1, TPB, 0, sol_handle->get_stream().get()>>>(view());
   max_active_nodes = max_active_nodes_for_all_routes.value(sol_handle->get_stream());
   return max_active_nodes;
 }
@@ -742,8 +746,8 @@ void solution_t<i_t, f_t, REQUEST>::compute_route_id_per_node()
 {
   raft::common::nvtx::range fun_scope("compute_route_id_per_node");
   i_t TPB = 256;
-  compute_route_id_kernel<i_t, f_t, REQUEST>
-    <<<n_routes, TPB, 0, sol_handle->get_stream().get()>>>(routes_view.data(), route_node_map.view());
+  compute_route_id_kernel<i_t, f_t, REQUEST><<<n_routes, TPB, 0, sol_handle->get_stream().get()>>>(
+    routes_view.data(), route_node_map.view());
   global_runtime_checks(false, false, "compute_route_id_per_node");
 }
 

--- a/cpp/src/routing/solution/solution.cu
+++ b/cpp/src/routing/solution/solution.cu
@@ -323,7 +323,7 @@ void solution_t<i_t, f_t, REQUEST>::random_init_routes()
 {
   raft::common::nvtx::range fun_scope("random_init_routes");
   auto stream = sol_handle->get_stream();
-  stream.synchronize();
+  stream.sync();
   const i_t one = 1;
   d_sol_found.set_value_async(one, stream);
   std::vector<i_t> indices(get_num_requests());
@@ -343,7 +343,7 @@ void solution_t<i_t, f_t, REQUEST>::random_init_routes()
     }
   }
   set_initial_nodes(d_indices, n_routes);
-  stream.synchronize();
+  stream.sync();
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>

--- a/cpp/src/routing/solution/solution.cu
+++ b/cpp/src/routing/solution/solution.cu
@@ -171,7 +171,7 @@ void solution_t<i_t, f_t, REQUEST>::add_nodes_to_route(
   bool is_set    = set_shmem_of_kernel(insert_nodes_to_route_kernel<i_t, f_t, REQUEST>, sh_size);
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   i_t TPB = 256;
-  insert_nodes_to_route_kernel<i_t, f_t, REQUEST><<<1, TPB, sh_size, sol_handle->get_stream()>>>(
+  insert_nodes_to_route_kernel<i_t, f_t, REQUEST><<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(
     view(), route_id, intra_idx, n_nodes_to_insert, temp_nodes.data());
   thrust::fill(sol_handle->get_thrust_policy(),
                routes_to_search.data() + route_id,
@@ -193,7 +193,7 @@ void solution_t<i_t, f_t, REQUEST>::add_nodes_to_best(
     bool is_set    = set_shmem_of_kernel(insert_node_to_best_kernel<i_t, f_t, REQUEST>, sh_size);
     cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
     insert_node_to_best_kernel<i_t, f_t, REQUEST>
-      <<<1, TPB, sh_size, sol_handle->get_stream()>>>(view(), node, include_objective, weights);
+      <<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(view(), node, include_objective, weights);
     sol_handle->sync_stream();
   }
   this->global_runtime_checks(false, false, "add_nodes_to_best");
@@ -214,7 +214,7 @@ bool solution_t<i_t, f_t, REQUEST>::remove_nodes(const std::vector<NodeInfo<>>& 
   cuopt_assert(is_set, "Not enough shared memory on device for remove_nodes!");
   cuopt_expects(is_set, error_type_t::OutOfMemoryError, "Not enough shared memory on device");
   i_t TPB = 256;
-  remove_nodes_kernel<i_t, f_t, REQUEST><<<1, TPB, sh_size, sol_handle->get_stream()>>>(
+  remove_nodes_kernel<i_t, f_t, REQUEST><<<1, TPB, sh_size, sol_handle->get_stream().get()>>>(
     view(), n_nodes_to_eject, temp_nodes.data(), empty_route_produced.data());
   sol_handle->sync_stream();
   return !empty_route_produced.value(sol_handle->get_stream());
@@ -542,7 +542,7 @@ void solution_t<i_t, f_t, REQUEST>::copy_device_solution(solution_t<i_t, f_t, RE
   const i_t TPB       = 256;
   const auto n_blocks = n_routes;
   copy_routes<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol_handle->get_stream()>>>(view(), src_sol.view());
+    <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view(), src_sol.view());
   RAFT_CHECK_CUDA(sol_handle->get_stream());
 
   cuopt_assert(route_node_map.intra_route_idx_per_node.size() == (size_t)get_num_orders(),
@@ -585,7 +585,7 @@ void solution_t<i_t, f_t, REQUEST>::compute_cost()
   objective_cost.set_value_async(zero_obj, sol_handle->get_stream());
   n_infeasible_routes.set_value_to_zero_async(sol_handle->get_stream());
   if (get_n_routes() < 1) return;
-  compute_cost_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, 0, sol_handle->get_stream()>>>(view());
+  compute_cost_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -627,10 +627,10 @@ void solution_t<i_t, f_t, REQUEST>::shift_move_routes(
   if (n_blocks > 0) {
     // Decrement route_id_per_node for this route
     remap_route_nodes<i_t, f_t, REQUEST>
-      <<<n_blocks, threads_per_block, 0, sol_handle->get_stream()>>>(
+      <<<n_blocks, threads_per_block, 0, sol_handle->get_stream().get()>>>(
         routes_view.data(), route_node_map.view(), route_ids_device_copy.data(), route_ids.size());
     RAFT_CHECK_CUDA(sol_handle->get_stream());
-    shift_routes_kernel<i_t, f_t, REQUEST><<<1, 1, 0, sol_handle->get_stream()>>>(
+    shift_routes_kernel<i_t, f_t, REQUEST><<<1, 1, 0, sol_handle->get_stream().get()>>>(
       view(), route_ids_device_copy.data(), route_ids.size());
     RAFT_CHECK_CUDA(sol_handle->get_stream());
   }
@@ -679,7 +679,7 @@ void solution_t<i_t, f_t, REQUEST>::remove_routes(
 
     cuopt_assert(ejection_pool.index_ >= 0, "Index should be at least 0");
     set_deleted_routes_kernel<i_t, f_t, REQUEST>
-      <<<routes_to_remove.size(), 1, 0, sol_handle->get_stream()>>>(
+      <<<routes_to_remove.size(), 1, 0, sol_handle->get_stream().get()>>>(
         view(),
         cuopt::make_span(routes_view),
         cuopt::make_span(temp_int_vector),
@@ -706,7 +706,7 @@ void solution_t<i_t, f_t, REQUEST>::remove_routes(const std::vector<i_t>& routes
                  "route to remove should be in range");
   }
   set_deleted_routes_kernel<i_t, f_t, REQUEST>
-    <<<routes_to_remove.size(), 1, 0, sol_handle->get_stream()>>>(
+    <<<routes_to_remove.size(), 1, 0, sol_handle->get_stream().get()>>>(
       view(), cuopt::make_span(routes_view), cuopt::make_span(temp_int_vector));
   shift_move_routes(routes_to_remove, temp_int_vector);
 }
@@ -732,7 +732,7 @@ i_t solution_t<i_t, f_t, REQUEST>::compute_max_active()
 {
   raft::common::nvtx::range fun_scope("compute_max_active");
   i_t TPB = 1024;
-  compute_max_active_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, sol_handle->get_stream()>>>(view());
+  compute_max_active_kernel<i_t, f_t, REQUEST><<<1, TPB, 0, sol_handle->get_stream().get()>>>(view());
   max_active_nodes = max_active_nodes_for_all_routes.value(sol_handle->get_stream());
   return max_active_nodes;
 }
@@ -743,7 +743,7 @@ void solution_t<i_t, f_t, REQUEST>::compute_route_id_per_node()
   raft::common::nvtx::range fun_scope("compute_route_id_per_node");
   i_t TPB = 256;
   compute_route_id_kernel<i_t, f_t, REQUEST>
-    <<<n_routes, TPB, 0, sol_handle->get_stream()>>>(routes_view.data(), route_node_map.view());
+    <<<n_routes, TPB, 0, sol_handle->get_stream().get()>>>(routes_view.data(), route_node_map.view());
   global_runtime_checks(false, false, "compute_route_id_per_node");
 }
 

--- a/cpp/src/routing/solution/solution_handle.cuh
+++ b/cpp/src/routing/solution/solution_handle.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -44,7 +44,7 @@ class solution_handle_t {
   rmm::exec_policy& get_thrust_policy() const noexcept { return *thrust_policy_; }
   rmm::cuda_stream_view get_stream() const noexcept { return stream_view_; }
   i_t get_device() const { return dev_id_; }
-  void sync_stream() const { stream_view_.synchronize(); };
+  void sync_stream() const { stream_view_.sync(); };
 
   const cudaDeviceProp& get_device_properties() const
   {

--- a/cpp/src/routing/util_kernels/compute_backward_forward.cu
+++ b/cpp/src/routing/util_kernels/compute_backward_forward.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/routing/util_kernels/compute_backward_forward.cu
+++ b/cpp/src/routing/util_kernels/compute_backward_forward.cu
@@ -46,7 +46,7 @@ void solution_t<i_t, f_t, REQUEST>::compute_backward_forward()
   constexpr i_t TPB = 32;
   if (n_routes) {
     compute_backward_forward_kernel<i_t, f_t, REQUEST>
-      <<<n_routes * 2, TPB, 0, sol_handle->get_stream()>>>(view().routes);
+      <<<n_routes * 2, TPB, 0, sol_handle->get_stream().get()>>>(view().routes);
     sol_handle->sync_stream();
   }
 }
@@ -58,7 +58,7 @@ void solution_t<i_t, f_t, REQUEST>::compute_actual_arrival_times()
   constexpr i_t TPB = 32;
   if (n_routes && problem_ptr->dimensions_info.has_dimension(dim_t::TIME))
     compute_actual_arrival_kernel<i_t, f_t, REQUEST>
-      <<<n_routes, TPB, 0, sol_handle->get_stream()>>>(view().routes);
+      <<<n_routes, TPB, 0, sol_handle->get_stream().get()>>>(view().routes);
 }
 
 template void solution_t<int, float, request_t::PDP>::compute_backward_forward();

--- a/cpp/src/routing/util_kernels/runtime_checks.cu
+++ b/cpp/src/routing/util_kernels/runtime_checks.cu
@@ -255,12 +255,12 @@ bool global_runtime_checks_(solution_t<i_t, f_t, REQUEST>& solution,
 
   solution.run_coherence_check();
   async_fill(solution.runtime_check_histo, 0, solution.sol_handle->get_stream());
-  fill_histo<i_t, f_t, REQUEST><<<solution.get_n_routes(), 1, 0, stream>>>(
+  fill_histo<i_t, f_t, REQUEST><<<solution.get_n_routes(), 1, 0, stream.get()>>>(
     solution.view(), solution.runtime_check_histo.data());
 
   const bool depot_included = solution.problem_ptr->order_info.depot_included_;
   check_histogram<i_t, f_t, REQUEST>
-    <<<(solution.get_num_depot_excluded_orders() + 32 - 1) / 32, 32, 0, stream>>>(
+    <<<(solution.get_num_depot_excluded_orders() + 32 - 1) / 32, 32, 0, stream.get()>>>(
       solution.runtime_check_histo.data(),
       solution.get_num_orders(),
       all_nodes_should_be_served,
@@ -268,7 +268,7 @@ bool global_runtime_checks_(solution_t<i_t, f_t, REQUEST>& solution,
 
   if (solution.problem_ptr->get_max_break_dimensions() > 0) {
     auto sh_size = solution.problem_ptr->get_max_break_dimensions() * sizeof(i_t);
-    check_breaks<i_t, f_t, REQUEST><<<solution.get_n_routes(), 32, sh_size, stream>>>(
+    check_breaks<i_t, f_t, REQUEST><<<solution.get_n_routes(), 32, sh_size, stream.get()>>>(
       solution.view(), all_nodes_should_be_served);
   }
 
@@ -304,14 +304,14 @@ template <typename i_t, typename f_t, request_t REQUEST>
 void solution_t<i_t, f_t, REQUEST>::run_feasibility_check()
 {
   cuopt_func_call((feasibility_check<i_t, f_t, REQUEST>
-                   <<<get_n_routes(), 1, 0, sol_handle->get_stream()>>>(view())));
+                   <<<get_n_routes(), 1, 0, sol_handle->get_stream().get()>>>(view())));
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
 void solution_t<i_t, f_t, REQUEST>::run_coherence_check()
 {
   cuopt_func_call((node_global_coherence_check<i_t, f_t, REQUEST>
-                   <<<get_n_routes(), 1, 0, sol_handle->get_stream()>>>(view())));
+                   <<<get_n_routes(), 1, 0, sol_handle->get_stream().get()>>>(view())));
 }
 
 template void solution_t<int, float, request_t::PDP>::global_runtime_checks(

--- a/cpp/src/routing/util_kernels/set_initial_nodes.cu
+++ b/cpp/src/routing/util_kernels/set_initial_nodes.cu
@@ -227,8 +227,8 @@ void solution_t<i_t, f_t, REQUEST>::set_initial_nodes(const rmm::device_uvector<
                -1);
   constexpr i_t TPB = 32;
   i_t n_blocks      = (desired_n_routes + TPB - 1) / TPB;
-  set_initial_nodes_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view(), problem_ptr->view(), d_indices.data());
+  set_initial_nodes_kernel<i_t, f_t, REQUEST><<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(
+    view(), problem_ptr->view(), d_indices.data());
 
   sol_handle->get_stream().sync();
 }

--- a/cpp/src/routing/util_kernels/set_initial_nodes.cu
+++ b/cpp/src/routing/util_kernels/set_initial_nodes.cu
@@ -228,7 +228,7 @@ void solution_t<i_t, f_t, REQUEST>::set_initial_nodes(const rmm::device_uvector<
   constexpr i_t TPB = 32;
   i_t n_blocks      = (desired_n_routes + TPB - 1) / TPB;
   set_initial_nodes_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol_handle->get_stream()>>>(view(), problem_ptr->view(), d_indices.data());
+    <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view(), problem_ptr->view(), d_indices.data());
 
   sol_handle->get_stream().sync();
 }
@@ -239,7 +239,7 @@ void solution_t<i_t, f_t, REQUEST>::set_nodes_data_of_solution()
   constexpr i_t TPB = 32;
   i_t n_blocks      = n_routes;
   set_nodes_data_of_solution_kernel<i_t, f_t, REQUEST>
-    <<<n_blocks, TPB, 0, sol_handle->get_stream()>>>(view(), problem_ptr->view());
+    <<<n_blocks, TPB, 0, sol_handle->get_stream().get()>>>(view(), problem_ptr->view());
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -247,7 +247,7 @@ void solution_t<i_t, f_t, REQUEST>::set_nodes_data_of_route(i_t route_id)
 {
   constexpr i_t TPB = 32;
   set_nodes_data_of_route_kernel<i_t, f_t, REQUEST>
-    <<<1, TPB, 0, sol_handle->get_stream()>>>(view(), problem_ptr->view(), route_id);
+    <<<1, TPB, 0, sol_handle->get_stream().get()>>>(view(), problem_ptr->view(), route_id);
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>
@@ -257,7 +257,7 @@ void solution_t<i_t, f_t, REQUEST>::set_nodes_data_of_new_routes(i_t added_route
   constexpr i_t TPB     = 32;
   i_t starting_route_id = prev_route_size;
   set_nodes_data_of_new_routes_kernel<i_t, f_t, REQUEST>
-    <<<added_routes, TPB, 0, sol_handle->get_stream()>>>(
+    <<<added_routes, TPB, 0, sol_handle->get_stream().get()>>>(
       view(), problem_ptr->view(), starting_route_id);
 }
 

--- a/cpp/src/routing/util_kernels/set_initial_nodes.cu
+++ b/cpp/src/routing/util_kernels/set_initial_nodes.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */
@@ -230,7 +230,7 @@ void solution_t<i_t, f_t, REQUEST>::set_initial_nodes(const rmm::device_uvector<
   set_initial_nodes_kernel<i_t, f_t, REQUEST>
     <<<n_blocks, TPB, 0, sol_handle->get_stream()>>>(view(), problem_ptr->view(), d_indices.data());
 
-  sol_handle->get_stream().synchronize();
+  sol_handle->get_stream().sync();
 }
 
 template <typename i_t, typename f_t, request_t REQUEST>

--- a/cpp/src/routing/utilities/check_input.cu
+++ b/cpp/src/routing/utilities/check_input.cu
@@ -39,7 +39,7 @@ void transform_absolute(rmm::device_uvector<T>& v, rmm::cuda_stream_view stream_
     rmm::exec_policy(stream_view), v.begin(), v.end(), v.begin(), [] __device__(T x) -> T {
       return x < 0 ? -x : x;
     });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 }
 
 /**
@@ -70,7 +70,7 @@ bool check_pickup_tw(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) > thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
   return !violates_sanity;
 }
 
@@ -98,7 +98,7 @@ bool check_pickup_demands(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) != -thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
   return !violates_sanity;
 }
 
@@ -117,7 +117,7 @@ bool check_pdp_values(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) != thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
   return !violates_sanity;
 }
 
@@ -139,7 +139,7 @@ bool is_symmetric_matrix(f_t const* matrix, i_t width, raft::handle_t const* han
                                width,
                                width,
                                handle_ptr->get_stream().get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
+  handle_ptr->get_stream().sync();
 
   return thrust::equal(handle_ptr->get_thrust_policy(),
                        matrix,
@@ -164,7 +164,7 @@ bool check_min_latest_with_depot(rmm::device_uvector<i_t>& v_latest_time,
   i_t* min_latest_ptr = thrust::min_element(
     rmm::exec_policy(stream_view), v_latest_time.begin() + 1, v_latest_time.end());
   raft::copy(&min_latest, min_latest_ptr, 1, stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 
   return min_latest >= depot_earliest;
 }
@@ -184,7 +184,7 @@ bool check_max_earliest_with_depot(rmm::device_uvector<i_t>& v_earliest_time,
   i_t* max_earliest_ptr = thrust::max_element(
     rmm::exec_policy(stream_view), v_earliest_time.begin() + 1, v_earliest_time.end());
   raft::copy(&max_earliest, max_earliest_ptr, 1, stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
 
   return max_earliest <= depot_latest;
 }
@@ -227,7 +227,7 @@ bool check_min_max_values(const T* ptr,
     thrust::minmax_element(rmm::exec_policy(stream_view), ptr, ptr + size);
   raft::copy(&min, pair.first, 1, stream_view.get());
   raft::copy(&max, pair.second, 1, stream_view.get());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
+  stream_view.sync();
   return (min >= static_cast<T>(min_value)) && (max <= static_cast<T>(max_value));
 }
 

--- a/cpp/src/routing/utilities/check_input.cu
+++ b/cpp/src/routing/utilities/check_input.cu
@@ -138,8 +138,8 @@ bool is_symmetric_matrix(f_t const* matrix, i_t width, raft::handle_t const* han
                                transposed_matrix.data_handle(),
                                width,
                                width,
-                               handle_ptr->get_stream());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream()));
+                               handle_ptr->get_stream().get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(handle_ptr->get_stream().get()));
 
   return thrust::equal(handle_ptr->get_thrust_policy(),
                        matrix,

--- a/cpp/src/routing/utilities/check_input.cu
+++ b/cpp/src/routing/utilities/check_input.cu
@@ -39,7 +39,7 @@ void transform_absolute(rmm::device_uvector<T>& v, rmm::cuda_stream_view stream_
     rmm::exec_policy(stream_view), v.begin(), v.end(), v.begin(), [] __device__(T x) -> T {
       return x < 0 ? -x : x;
     });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 }
 
 /**
@@ -70,7 +70,7 @@ bool check_pickup_tw(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) > thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   return !violates_sanity;
 }
 
@@ -98,7 +98,7 @@ bool check_pickup_demands(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) != -thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   return !violates_sanity;
 }
 
@@ -117,7 +117,7 @@ bool check_pdp_values(const i_t* pickup_indices,
     zip_iterator,
     zip_iterator + n_requests,
     [] __device__(const auto& x) -> bool { return thrust::get<0>(x) != thrust::get<1>(x); });
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   return !violates_sanity;
 }
 
@@ -163,8 +163,8 @@ bool check_min_latest_with_depot(rmm::device_uvector<i_t>& v_latest_time,
   i_t min_latest;
   i_t* min_latest_ptr = thrust::min_element(
     rmm::exec_policy(stream_view), v_latest_time.begin() + 1, v_latest_time.end());
-  raft::copy(&min_latest, min_latest_ptr, 1, stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  raft::copy(&min_latest, min_latest_ptr, 1, stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 
   return min_latest >= depot_earliest;
 }
@@ -183,8 +183,8 @@ bool check_max_earliest_with_depot(rmm::device_uvector<i_t>& v_earliest_time,
   i_t max_earliest;
   i_t* max_earliest_ptr = thrust::max_element(
     rmm::exec_policy(stream_view), v_earliest_time.begin() + 1, v_earliest_time.end());
-  raft::copy(&max_earliest, max_earliest_ptr, 1, stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  raft::copy(&max_earliest, max_earliest_ptr, 1, stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
 
   return max_earliest <= depot_latest;
 }
@@ -225,9 +225,9 @@ bool check_min_max_values(const T* ptr,
   T min, max;
   thrust::pair<const T*, const T*> pair =
     thrust::minmax_element(rmm::exec_policy(stream_view), ptr, ptr + size);
-  raft::copy(&min, pair.first, 1, stream_view.value());
-  raft::copy(&max, pair.second, 1, stream_view.value());
-  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.value()));
+  raft::copy(&min, pair.first, 1, stream_view.get());
+  raft::copy(&max, pair.second, 1, stream_view.get());
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream_view.get()));
   return (min >= static_cast<T>(min_value)) && (max <= static_cast<T>(max_value));
 }
 
@@ -262,7 +262,7 @@ void check_guess(i_t const* guess_id,
                     d_int_drop_return_trip.data(),
                     id);
   raft::update_host(
-    h_drop_return_trip.data(), d_int_drop_return_trip.data(), fleet_size, stream_view.value());
+    h_drop_return_trip.data(), d_int_drop_return_trip.data(), fleet_size, stream_view.get());
 
   thrust::transform(rmm::exec_policy(stream_view),
                     skip_first_trip,
@@ -270,7 +270,7 @@ void check_guess(i_t const* guess_id,
                     d_int_skip_first_trip.data(),
                     id);
   raft::update_host(
-    h_skip_first_trip.data(), d_int_skip_first_trip.data(), fleet_size, stream_view.value());
+    h_skip_first_trip.data(), d_int_skip_first_trip.data(), fleet_size, stream_view.get());
 
   raft::update_host(h_guess_id.data(), guess_id, size, stream_view);
   raft::update_host(h_truck_id.data(), truck_id, size, stream_view);

--- a/cpp/src/routing/utilities/cython.cu
+++ b/cpp/src/routing/utilities/cython.cu
@@ -125,7 +125,7 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
     auto routing_solution = cuopt::routing::solve(*data_models[i], *settings);
 
     // Make sure current solve is finished
-    stream_pool.get_stream(i).synchronize();
+    stream_pool.get_stream(i).sync();
 
     // Create buffers and reassociate them with the original stream so they
     // outlive the local stream which will be destroyed at end of loop iteration
@@ -152,7 +152,7 @@ std::vector<std::unique_ptr<vehicle_routing_ret_t>> call_batch_solve(
 
     // Restore the old stream
     raft::resource::set_cuda_stream(*(data_models[i]->get_handle_ptr()), old_stream);
-    old_stream.synchronize();
+    old_stream.sync();
   }
 
   return list;

--- a/cpp/src/utilities/copy_helpers.hpp
+++ b/cpp/src/utilities/copy_helpers.hpp
@@ -124,7 +124,7 @@ auto host_copy(T const* device_ptr, size_t size, rmm::cuda_stream_view stream_vi
   if (!device_ptr) return std::vector<T>{};
   std::vector<T> host_vec(size);
   raft::copy(host_vec.data(), device_ptr, size, stream_view);
-  stream_view.synchronize();
+  stream_view.sync();
   return host_vec;
 }
 
@@ -150,7 +150,7 @@ inline auto host_copy(bool const* device_ptr, size_t size, rmm::cuda_stream_view
   for (size_t i = 0; i < h_int_vec.size(); ++i) {
     h_bool_vec[i] = static_cast<bool>(h_int_vec[i]);
   }
-  stream_view.synchronize();
+  stream_view.sync();
   return h_bool_vec;
 }
 
@@ -167,7 +167,7 @@ auto host_copy(rmm::device_uvector<T> const& device_vec, rmm::cuda_stream_view s
 {
   std::vector<T, Allocator> host_vec(device_vec.size());
   raft::copy(host_vec.data(), device_vec.data(), device_vec.size(), stream_view);
-  stream_view.synchronize();
+  stream_view.sync();
   return host_vec;
 }
 

--- a/cpp/src/utilities/event_handler.cuh
+++ b/cpp/src/utilities/event_handler.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/utilities/event_handler.cuh
+++ b/cpp/src/utilities/event_handler.cuh
@@ -23,17 +23,17 @@ class event_handler_t {
 
   void record(rmm::cuda_stream_view stream_view)
   {
-    RAFT_CUDA_TRY(cudaEventRecord(event_, stream_view));
+    RAFT_CUDA_TRY(cudaEventRecord(event_, stream_view.get()));
   }
 
   void record_with_flags(rmm::cuda_stream_view stream_view, int flags)
   {
-    RAFT_CUDA_TRY(cudaEventRecordWithFlags(event_, stream_view, flags));
+    RAFT_CUDA_TRY(cudaEventRecordWithFlags(event_, stream_view.get(), flags));
   }
 
   void stream_wait(rmm::cuda_stream_view stream_view)
   {
-    RAFT_CUDA_TRY(cudaStreamWaitEvent(stream_view, event_));
+    RAFT_CUDA_TRY(cudaStreamWaitEvent(stream_view.get(), event_));
   }
 
   float elapsed_time_since_ms(const event_handler_t& start)

--- a/cpp/src/utilities/manual_cuda_graph.cuh
+++ b/cpp/src/utilities/manual_cuda_graph.cuh
@@ -71,15 +71,15 @@ class manual_cuda_graph_t {
   void run(rmm::cuda_stream_view stream, F&& work)
   {
     if (instance_ != nullptr) {
-      RAFT_CUDA_TRY(cudaGraphLaunch(instance_, stream.value()));
+      RAFT_CUDA_TRY(cudaGraphLaunch(instance_, stream.get()));
       return;
     }
 
     // RAII: if user code throws mid-capture, end capture so the stream isn't
     // left in capture state. Errors are swallowed -- we're already unwinding.
-    capture_guard_t guard{stream.value()};
+    capture_guard_t guard{stream.get()};
 
-    RAFT_CUDA_TRY(cudaStreamBeginCapture(stream.value(), cudaStreamCaptureModeThreadLocal));
+    RAFT_CUDA_TRY(cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeThreadLocal));
     guard.capture_active = true;
 
     cudaGraph_t captured = nullptr;
@@ -92,7 +92,7 @@ class manual_cuda_graph_t {
       // call). End the capture and let its status disambiguate: if the capture was
       // invalidated the recorded work was never issued, so recover by re-running
       // `work` eagerly; otherwise the error is genuine and is rethrown.
-      cudaError_t catch_end_err = cudaStreamEndCapture(stream.value(), &captured);
+      cudaError_t catch_end_err = cudaStreamEndCapture(stream.get(), &captured);
       guard.capture_active      = false;
       if (catch_end_err == cudaErrorStreamCaptureInvalidated) {
         cudaGetLastError();
@@ -103,7 +103,7 @@ class manual_cuda_graph_t {
       throw;
     }
 
-    cudaError_t end_err  = cudaStreamEndCapture(stream.value(), &captured);
+    cudaError_t end_err  = cudaStreamEndCapture(stream.get(), &captured);
     guard.capture_active = false;
 
     if (end_err == cudaErrorStreamCaptureInvalidated) {
@@ -124,7 +124,7 @@ class manual_cuda_graph_t {
     RAFT_CUDA_TRY_NO_THROW(cudaGraphDestroy(captured));
     RAFT_CUDA_TRY(inst_err);
 
-    RAFT_CUDA_TRY(cudaGraphLaunch(instance_, stream.value()));
+    RAFT_CUDA_TRY(cudaGraphLaunch(instance_, stream.get()));
   }
 
   bool is_initialized() const noexcept { return instance_ != nullptr; }

--- a/cpp/src/utilities/vector_helpers.cuh
+++ b/cpp/src/utilities/vector_helpers.cuh
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/src/utilities/vector_helpers.cuh
+++ b/cpp/src/utilities/vector_helpers.cuh
@@ -43,7 +43,7 @@ void async_fill(rmm::device_uvector<T>& vec, T item, rmm::cuda_stream_view strea
 {
   constexpr size_t TPB = 256;
   size_t n_blocks      = (vec.size() + TPB - 1) / TPB;
-  fill_kernel<<<n_blocks, TPB, 0, stream>>>(vec.data(), item, vec.size());
+  fill_kernel<<<n_blocks, TPB, 0, stream.get()>>>(vec.data(), item, vec.size());
 }
 
 template <typename T>
@@ -51,7 +51,7 @@ void async_fill(T* vec, T item, size_t size, rmm::cuda_stream_view stream)
 {
   constexpr size_t TPB = 256;
   size_t n_blocks      = (size + TPB - 1) / TPB;
-  fill_kernel<<<n_blocks, TPB, 0, stream>>>(vec, item, size);
+  fill_kernel<<<n_blocks, TPB, 0, stream.get()>>>(vec, item, size);
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ void async_sequence(rmm::device_uvector<T>& vec, rmm::cuda_stream_view stream)
 {
   constexpr size_t TPB = 256;
   size_t n_blocks      = (vec.size() + TPB - 1) / TPB;
-  sequence_kernel<<<n_blocks, TPB, 0, stream>>>(vec.data(), vec.size());
+  sequence_kernel<<<n_blocks, TPB, 0, stream.get()>>>(vec.data(), vec.size());
 }
 
 template <typename T>
@@ -69,7 +69,7 @@ void async_sequence_with_multiplier(rmm::device_uvector<T>& vec,
 {
   constexpr size_t TPB = 256;
   size_t n_blocks      = (vec.size() + TPB - 1) / TPB;
-  sequence_with_multiplier_kernel<<<n_blocks, TPB, 0, stream>>>(vec.data(), mult, vec.size());
+  sequence_with_multiplier_kernel<<<n_blocks, TPB, 0, stream.get()>>>(vec.data(), mult, vec.size());
 }
 
 template <typename T>

--- a/cpp/tests/distance_engine/waypoint_matrix_test.cpp
+++ b/cpp/tests/distance_engine/waypoint_matrix_test.cpp
@@ -59,7 +59,7 @@ class waypoint_matrix_waypoints_sequence_test_t
     std::vector<f_t> h_cost_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_cost_matrix.data(), d_cost_matrix.data(), h_cost_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
 
     for (size_t i = 0; i != h_cost_matrix.size(); ++i)
       EXPECT_EQ(h_cost_matrix[i], expected_cost_matrix[i]);
@@ -78,7 +78,7 @@ class waypoint_matrix_waypoints_sequence_test_t
                h_sequence_offsets.size(),
                stream);
     raft::copy(h_full_path.data(), (i_t*)d_full_path.get()->data(), h_full_path.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
 
     for (size_t i = 0; i != h_sequence_offsets.size(); ++i)
       EXPECT_EQ(h_sequence_offsets[i], expected_sequence_offsets[i]);
@@ -154,7 +154,7 @@ class waypoint_matrix_shortest_path_cost_t
     std::vector<f_t> h_custom_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_custom_matrix.data(), d_custom_matrix.data(), h_custom_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
 
     for (size_t i = 0; i != h_custom_matrix.size(); ++i)
       EXPECT_EQ(h_custom_matrix[i], ref_custom_matrix[i]);
@@ -207,7 +207,7 @@ class waypoint_matrix_cost_matrix_test_t
     std::vector<f_t> h_cost_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_cost_matrix.data(), d_cost_matrix.data(), h_cost_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
 
     for (size_t i = 0; i != h_cost_matrix.size(); ++i)
       EXPECT_NEAR(h_cost_matrix[i], this->ref_cost_matrix[i], 0.001f);

--- a/cpp/tests/distance_engine/waypoint_matrix_test.cpp
+++ b/cpp/tests/distance_engine/waypoint_matrix_test.cpp
@@ -59,7 +59,7 @@ class waypoint_matrix_waypoints_sequence_test_t
     std::vector<f_t> h_cost_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_cost_matrix.data(), d_cost_matrix.data(), h_cost_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 
     for (size_t i = 0; i != h_cost_matrix.size(); ++i)
       EXPECT_EQ(h_cost_matrix[i], expected_cost_matrix[i]);
@@ -78,7 +78,7 @@ class waypoint_matrix_waypoints_sequence_test_t
                h_sequence_offsets.size(),
                stream);
     raft::copy(h_full_path.data(), (i_t*)d_full_path.get()->data(), h_full_path.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 
     for (size_t i = 0; i != h_sequence_offsets.size(); ++i)
       EXPECT_EQ(h_sequence_offsets[i], expected_sequence_offsets[i]);
@@ -154,7 +154,7 @@ class waypoint_matrix_shortest_path_cost_t
     std::vector<f_t> h_custom_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_custom_matrix.data(), d_custom_matrix.data(), h_custom_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 
     for (size_t i = 0; i != h_custom_matrix.size(); ++i)
       EXPECT_EQ(h_custom_matrix[i], ref_custom_matrix[i]);
@@ -207,7 +207,7 @@ class waypoint_matrix_cost_matrix_test_t
     std::vector<f_t> h_cost_matrix(this->target_locations.size() * this->target_locations.size());
 
     raft::copy(h_cost_matrix.data(), d_cost_matrix.data(), h_cost_matrix.size(), stream);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream.get()));
 
     for (size_t i = 0; i != h_cost_matrix.size(); ++i)
       EXPECT_NEAR(h_cost_matrix[i], this->ref_cost_matrix[i], 0.001f);

--- a/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
+++ b/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
@@ -34,9 +34,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 TEST(barrier, chess_set)

--- a/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
+++ b/cpp/tests/dual_simplex/unit_tests/solve_barrier.cu
@@ -35,8 +35,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 TEST(barrier, chess_set)

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -503,7 +503,7 @@ TEST(pdlp_class, initial_solution_test)
                                                                               solver_settings);
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -518,7 +518,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_primal = device_copy(initial_primal, handle_.get_stream());
     solver.set_initial_primal_solution(d_initial_primal);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -530,7 +530,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -545,7 +545,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -557,7 +557,7 @@ TEST(pdlp_class, initial_solution_test)
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver_settings.hyper_params.update_step_size_on_initial_solution = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -568,7 +568,7 @@ TEST(pdlp_class, initial_solution_test)
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = false;
@@ -580,7 +580,7 @@ TEST(pdlp_class, initial_solution_test)
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = true;
     solver_settings.hyper_params.update_step_size_on_initial_solution     = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = false;
@@ -598,7 +598,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_primal = device_copy(initial_primal, handle_.get_stream());
     solver.set_initial_primal_solution(d_initial_primal);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -612,7 +612,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -799,7 +799,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver.set_initial_primal_weight(test_initial_primal_weight);
     solver.set_initial_step_size(test_initial_step_size);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_EQ(test_initial_step_size, solver.get_step_size_h(0));
     EXPECT_EQ(test_initial_primal_weight, solver.get_primal_weight_h(0));
   }
@@ -834,7 +834,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver2.set_initial_primal_solution(d_initial_primal);
     solver2.set_initial_dual_solution(d_initial_dual);
     solver2.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     const double sovler2_step_size     = solver2.get_step_size_h(0);
     const double sovler2_primal_weight = solver2.get_primal_weight_h(0);
     EXPECT_NOT_NEAR(previous_step_size, sovler2_step_size, factor_tolerance);
@@ -851,7 +851,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver3.set_initial_dual_solution(d_initial_dual);
     solver3.set_initial_dual_solution(d_initial_dual);
     solver3.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream()));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
     EXPECT_NOT_NEAR(sovler2_step_size, solver3.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(sovler2_primal_weight, solver3.get_primal_weight_h(0), factor_tolerance);
   }

--- a/cpp/tests/linear_programming/pdlp_test.cu
+++ b/cpp/tests/linear_programming/pdlp_test.cu
@@ -503,7 +503,7 @@ TEST(pdlp_class, initial_solution_test)
                                                                               solver_settings);
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -518,7 +518,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_primal = device_copy(initial_primal, handle_.get_stream());
     solver.set_initial_primal_solution(d_initial_primal);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -530,7 +530,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -545,7 +545,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
   }
@@ -557,7 +557,7 @@ TEST(pdlp_class, initial_solution_test)
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver_settings.hyper_params.update_step_size_on_initial_solution = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -568,7 +568,7 @@ TEST(pdlp_class, initial_solution_test)
     auto pdlp_timer = timer_t(solver_settings.time_limit);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = false;
@@ -580,7 +580,7 @@ TEST(pdlp_class, initial_solution_test)
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = true;
     solver_settings.hyper_params.update_step_size_on_initial_solution     = true;
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_primal_weight_on_initial_solution = false;
@@ -598,7 +598,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_primal = device_copy(initial_primal, handle_.get_stream());
     solver.set_initial_primal_solution(d_initial_primal);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -612,7 +612,7 @@ TEST(pdlp_class, initial_solution_test)
     auto d_initial_dual = device_copy(initial_dual, handle_.get_stream());
     solver.set_initial_dual_solution(d_initial_dual);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NEAR(initial_step_size_afiro, solver.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(initial_primal_weight_afiro, solver.get_primal_weight_h(0), factor_tolerance);
     solver_settings.hyper_params.update_step_size_on_initial_solution = false;
@@ -799,7 +799,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver.set_initial_primal_weight(test_initial_primal_weight);
     solver.set_initial_step_size(test_initial_step_size);
     solver.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_EQ(test_initial_step_size, solver.get_step_size_h(0));
     EXPECT_EQ(test_initial_primal_weight, solver.get_primal_weight_h(0));
   }
@@ -834,7 +834,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver2.set_initial_primal_solution(d_initial_primal);
     solver2.set_initial_dual_solution(d_initial_dual);
     solver2.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     const double sovler2_step_size     = solver2.get_step_size_h(0);
     const double sovler2_primal_weight = solver2.get_primal_weight_h(0);
     EXPECT_NOT_NEAR(previous_step_size, sovler2_step_size, factor_tolerance);
@@ -851,7 +851,7 @@ TEST(pdlp_class, initial_primal_weight_step_size_test)
     solver3.set_initial_dual_solution(d_initial_dual);
     solver3.set_initial_dual_solution(d_initial_dual);
     solver3.run_solver(pdlp_timer);
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle_.get_stream().get()));
+    handle_.get_stream().sync();
     EXPECT_NOT_NEAR(sovler2_step_size, solver3.get_step_size_h(0), factor_tolerance);
     EXPECT_NEAR(sovler2_primal_weight, solver3.get_primal_weight_h(0), factor_tolerance);
   }

--- a/cpp/tests/linear_programming/unit_tests/solution_interface_test.cu
+++ b/cpp/tests/linear_programming/unit_tests/solution_interface_test.cu
@@ -28,6 +28,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <numeric>
 #include <stdexcept>
 
@@ -145,7 +147,7 @@ static std::unique_ptr<cpu_mip_solution_t<int, double>> make_cpu_mip_solution()
 // Build a gpu_lp_solution_t with known device data (no solver needed)
 static gpu_lp_solution_t<int, double> make_gpu_lp_solution()
 {
-  auto stream = rmm::cuda_stream_per_thread;
+  auto stream = cuda::stream_ref{cudaStreamPerThread};
 
   rmm::device_uvector<double> primal(kNVars, stream);
   rmm::device_uvector<double> dual(kNCons, stream);
@@ -180,7 +182,7 @@ static gpu_lp_solution_t<int, double> make_gpu_lp_solution()
 // Build a gpu_mip_solution_t with known device data (no solver needed)
 static gpu_mip_solution_t<int, double> make_gpu_mip_solution()
 {
-  auto stream = rmm::cuda_stream_per_thread;
+  auto stream = cuda::stream_ref{cudaStreamPerThread};
 
   rmm::device_uvector<double> sol(kNVars, stream);
   std::vector<double> h_sol = {1.0, 0.0, 1.0};

--- a/cpp/tests/mip/bounds_standardization_test.cu
+++ b/cpp/tests/mip/bounds_standardization_test.cu
@@ -36,8 +36,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 void test_bounds_standardization_test(std::string test_instance)

--- a/cpp/tests/mip/bounds_standardization_test.cu
+++ b/cpp/tests/mip/bounds_standardization_test.cu
@@ -35,9 +35,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 void test_bounds_standardization_test(std::string test_instance)

--- a/cpp/tests/mip/elim_var_remap_test.cu
+++ b/cpp/tests/mip/elim_var_remap_test.cu
@@ -38,9 +38,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 std::vector<int> select_k_random(int population_size, int sample_size)

--- a/cpp/tests/mip/elim_var_remap_test.cu
+++ b/cpp/tests/mip/elim_var_remap_test.cu
@@ -39,8 +39,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 std::vector<int> select_k_random(int population_size, int sample_size)

--- a/cpp/tests/mip/feasibility_jump_tests.cu
+++ b/cpp/tests/mip/feasibility_jump_tests.cu
@@ -41,9 +41,10 @@ void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 struct fj_tweaks_t {

--- a/cpp/tests/mip/load_balancing_test.cu
+++ b/cpp/tests/mip/load_balancing_test.cu
@@ -38,9 +38,10 @@ void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 std::tuple<std::vector<int>, std::vector<double>, std::vector<double>> select_k_random(

--- a/cpp/tests/mip/multi_probe_test.cu
+++ b/cpp/tests/mip/multi_probe_test.cu
@@ -37,9 +37,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 std::tuple<std::vector<int>, std::vector<double>, std::vector<double>> select_k_random(

--- a/cpp/tests/mip/multi_probe_test.cu
+++ b/cpp/tests/mip/multi_probe_test.cu
@@ -38,8 +38,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 std::tuple<std::vector<int>, std::vector<double>, std::vector<double>> select_k_random(

--- a/cpp/tests/routing/level0/l0_routing_test.cu
+++ b/cpp/tests/routing/level0/l0_routing_test.cu
@@ -408,7 +408,7 @@ class routing_retail_test_t : public base_test_t<i_t, f_t>,
                         d_int_skip_first_trip.end(),
                         d_skip_first_trip.begin(),
                         id);
-      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.get()));
+      this->stream_view_.sync();
       data_model.set_drop_return_trips(d_drop_return_trip.data());
       data_model.set_skip_first_trips(d_skip_first_trip.data());
     }

--- a/cpp/tests/routing/level0/l0_routing_test.cu
+++ b/cpp/tests/routing/level0/l0_routing_test.cu
@@ -372,11 +372,11 @@ class routing_retail_test_t : public base_test_t<i_t, f_t>,
       raft::copy(this->vehicle_earliest_d.data(),
                  this->vehicle_earliest_h.data(),
                  input_.n_vehicles,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       raft::copy(this->vehicle_latest_d.data(),
                  this->vehicle_latest_h.data(),
                  input_.n_vehicles,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       data_model.set_vehicle_time_windows(this->vehicle_earliest_d.data(),
                                           this->vehicle_latest_d.data());
     }
@@ -392,7 +392,7 @@ class routing_retail_test_t : public base_test_t<i_t, f_t>,
       raft::copy(d_int_drop_return_trip.data(),
                  this->drop_return_trips_h.data(),
                  input_.n_vehicles,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       thrust::transform(this->handle_.get_thrust_policy(),
                         d_int_drop_return_trip.begin(),
                         d_int_drop_return_trip.end(),
@@ -402,13 +402,13 @@ class routing_retail_test_t : public base_test_t<i_t, f_t>,
       raft::copy(d_int_skip_first_trip.data(),
                  this->skip_first_trips_h.data(),
                  input_.n_vehicles,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       thrust::transform(this->handle_.get_thrust_policy(),
                         d_int_skip_first_trip.begin(),
                         d_int_skip_first_trip.end(),
                         d_skip_first_trip.begin(),
                         id);
-      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.value()));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.get()));
       data_model.set_drop_return_trips(d_drop_return_trip.data());
       data_model.set_skip_first_trips(d_skip_first_trip.data());
     }
@@ -423,11 +423,11 @@ class routing_retail_test_t : public base_test_t<i_t, f_t>,
       raft::copy(this->random_demand_d.data(),
                  shuffled_vec.data(),
                  this->n_orders,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       raft::copy(this->mixed_capacity_d.data(),
                  input_.mixed_capacity_h.data(),
                  this->n_vehicles,
-                 this->stream_view_.value());
+                 this->stream_view_.get());
       data_model.add_capacity_dimension(
         "random", this->random_demand_d.data(), this->mixed_capacity_d.data());
     }

--- a/cpp/tests/routing/level0/l0_vehicle_order_match.cu
+++ b/cpp/tests/routing/level0/l0_vehicle_order_match.cu
@@ -58,7 +58,7 @@ class vehicle_order_test_t : public base_test_t<i_t, f_t>, public ::testing::Tes
                         d_int_vec.end(),
                         d_drop_return_trip.begin(),
                         cuda::std::identity{});
-      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.value()));
+      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.get()));
     }
     data_model.set_drop_return_trips(d_drop_return_trip.data());
 

--- a/cpp/tests/routing/level0/l0_vehicle_order_match.cu
+++ b/cpp/tests/routing/level0/l0_vehicle_order_match.cu
@@ -58,7 +58,7 @@ class vehicle_order_test_t : public base_test_t<i_t, f_t>, public ::testing::Tes
                         d_int_vec.end(),
                         d_drop_return_trip.begin(),
                         cuda::std::identity{});
-      RAFT_CUDA_TRY(cudaStreamSynchronize(this->stream_view_.get()));
+      this->stream_view_.sync();
     }
     data_model.set_drop_return_trips(d_drop_return_trip.data());
 

--- a/cpp/tests/routing/unit_tests/local_search_cand_test.cu
+++ b/cpp/tests/routing/unit_tests/local_search_cand_test.cu
@@ -1,6 +1,6 @@
 /* clang-format off */
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /* clang-format on */

--- a/cpp/tests/routing/unit_tests/local_search_cand_test.cu
+++ b/cpp/tests/routing/unit_tests/local_search_cand_test.cu
@@ -357,7 +357,7 @@ class routing_ges_test_t : public ::testing::TestWithParam<std::tuple<bool, test
     } else if (this->test_type == test_t::INFEASIBLE) {
       double w[] = {100., 10000., 100., 100., 100.};
       introduce_infeasibility<i_t, f_t, REQUEST>
-        <<<1, 1, 0, sol.sol_handle->get_stream()>>>(sol.view());
+        <<<1, 1, 0, sol.sol_handle->get_stream().get()>>>(sol.view());
       sol.set_nodes_data_of_solution();
       sol.compute_initial_data();
       f_t old_cost = sol.get_total_cost(w);

--- a/cpp/tests/routing/unit_tests/top_k.cu
+++ b/cpp/tests/routing/unit_tests/top_k.cu
@@ -159,7 +159,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                   rmm::device_uvector<i_t>& out_index)
   {
     constexpr int TPB = 128;
-    top_k_indices<TPB, i_t><<<width, TPB, 0, this->stream_view_>>>(width,
+    top_k_indices<TPB, i_t><<<width, TPB, 0, this->stream_view_.get()>>>(width,
                                                                    cuopt::make_span(input_cost),
                                                                    cuopt::make_span(output_cost),
                                                                    cuopt::make_span(out_index));

--- a/cpp/tests/routing/unit_tests/top_k.cu
+++ b/cpp/tests/routing/unit_tests/top_k.cu
@@ -98,7 +98,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
 
     raft::copy(d_input_cost.data(), h_input_cost.data(), h_input_cost.size(), this->stream_view_);
 
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     call_top_k(d_input_cost, d_output_cost, d_out_index);
 
     verify_top_k(h_input_cost, d_output_cost, d_out_index);
@@ -163,7 +163,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                                                                    cuopt::make_span(input_cost),
                                                                    cuopt::make_span(output_cost),
                                                                    cuopt::make_span(out_index));
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     RAFT_CUDA_TRY(cudaGetLastError());
   }
 
@@ -171,15 +171,15 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                     rmm::device_uvector<double>& d_output_cost,
                     rmm::device_uvector<i_t>& d_out_index)
   {
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     std::vector<double> h_output_cost(d_output_cost.size());
     raft::copy(
       h_output_cost.data(), d_output_cost.data(), d_output_cost.size(), this->stream_view_);
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
 
     std::vector<i_t> h_sorted_index(d_out_index.size());
     raft::copy(h_sorted_index.data(), d_out_index.data(), d_out_index.size(), this->stream_view_);
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     std::vector<double> sorted_data(width);
     for (int i = 0; i < width; ++i) {
       // copy row i
@@ -238,7 +238,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
     rmm::device_uvector<std::byte> d_cub_storage_bytes(0, this->stream_view_);
     d_cub_storage_bytes.resize(tmp_storage_bytes, this->stream_view_);
     double elapsed_ms;
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     {
       time_it t(&elapsed_ms);
       for (int i = 0; i < iter; ++i) {
@@ -254,7 +254,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                                             segment_marker.data() + 1,
                                             this->stream_view_);
       }
-      this->stream_view_.synchronize();
+      this->stream_view_.sync();
     }
     return elapsed_ms;
   }
@@ -268,13 +268,13 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
     raft::copy(d_input_cost.data(), input_cost.data(), input_cost.size(), this->stream_view_);
 
     double elapsed_ms;
-    this->stream_view_.synchronize();
+    this->stream_view_.sync();
     {
       time_it t(&elapsed_ms);
       for (int i = 0; i < iter; ++i) {
         call_top_k(d_input_cost, d_output_cost, d_out_index);
       }
-      this->stream_view_.synchronize();
+      this->stream_view_.sync();
     }
     return elapsed_ms;
   }

--- a/cpp/tests/routing/unit_tests/top_k.cu
+++ b/cpp/tests/routing/unit_tests/top_k.cu
@@ -234,7 +234,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                                         num_segments,
                                         segment_marker.data(),
                                         segment_marker.data() + 1,
-                                        this->stream_view_);
+                                        this->stream_view_.get());
     rmm::device_uvector<std::byte> d_cub_storage_bytes(0, this->stream_view_);
     d_cub_storage_bytes.resize(tmp_storage_bytes, this->stream_view_);
     double elapsed_ms;
@@ -252,7 +252,7 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                                             num_segments,
                                             segment_marker.data(),
                                             segment_marker.data() + 1,
-                                            this->stream_view_);
+                                            this->stream_view_.get());
       }
       this->stream_view_.sync();
     }

--- a/cpp/tests/routing/unit_tests/top_k.cu
+++ b/cpp/tests/routing/unit_tests/top_k.cu
@@ -159,10 +159,11 @@ class top_cand_test_t : public routing_test_t<i_t, f_t>, public ::testing::TestW
                   rmm::device_uvector<i_t>& out_index)
   {
     constexpr int TPB = 128;
-    top_k_indices<TPB, i_t><<<width, TPB, 0, this->stream_view_.get()>>>(width,
-                                                                   cuopt::make_span(input_cost),
-                                                                   cuopt::make_span(output_cost),
-                                                                   cuopt::make_span(out_index));
+    top_k_indices<TPB, i_t>
+      <<<width, TPB, 0, this->stream_view_.get()>>>(width,
+                                                    cuopt::make_span(input_cost),
+                                                    cuopt::make_span(output_cost),
+                                                    cuopt::make_span(out_index));
     this->stream_view_.sync();
     RAFT_CUDA_TRY(cudaGetLastError());
   }

--- a/cpp/tests/routing/utilities/check_constraints.cu
+++ b/cpp/tests/routing/utilities/check_constraints.cu
@@ -10,8 +10,6 @@
 
 #include <utilities/copy_helpers.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/cpp/tests/socp/general_quadratic_test.cu
+++ b/cpp/tests/socp/general_quadratic_test.cu
@@ -40,9 +40,9 @@ using qc_t = optimization_problem_interface_t<i_t, f_t>::quadratic_constraint_t;
 static void init_handler(const raft::handle_t* handle_ptr)
 {
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 // Test: general convex quadratic constraint with dense PD Q matrix.

--- a/cpp/tests/socp/general_quadratic_test.cu
+++ b/cpp/tests/socp/general_quadratic_test.cu
@@ -41,8 +41,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 // Test: general convex quadratic constraint with dense PD Q matrix.

--- a/cpp/tests/socp/second_order_cone_kernels.cu
+++ b/cpp/tests/socp/second_order_cone_kernels.cu
@@ -7,6 +7,8 @@
 
 #include <barrier/second_order_cone_kernels.cuh>
 
+#include <cuda/stream>
+
 #include <utilities/copy_helpers.hpp>
 
 #include <gtest/gtest.h>
@@ -20,7 +22,7 @@ namespace cuopt::mathematical_optimization::barrier::test {
 
 TEST(second_order_cone_kernels, topology_and_scratch_layout)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 2, 5};
   rmm::device_uvector<double> x(10, stream);
@@ -62,7 +64,7 @@ TEST(second_order_cone_kernels, topology_and_scratch_layout)
 
 TEST(second_order_cone_kernels, segmented_sum_uses_all_cone_size_buckets)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{65, 3, 66, 32769};
   rmm::device_uvector<double> x(32903, stream);
@@ -93,7 +95,7 @@ TEST(second_order_cone_kernels, segmented_sum_uses_all_cone_size_buckets)
 
 TEST(second_order_cone_kernels, nt_scaling_matches_host_reference)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 65, 32769};
   std::size_t n_cone_entries = 0;
@@ -204,7 +206,7 @@ TEST(second_order_cone_kernels, nt_scaling_matches_host_reference)
 
 TEST(second_order_cone_kernels, nt_scaling_many_small_one_medium_cone)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   // chainsing-like topology: many small cones plus one dim-1000 medium cone (warp_cone_dim=64).
   std::vector<int> cone_dimensions;
@@ -309,7 +311,7 @@ TEST(second_order_cone_kernels, nt_scaling_many_small_one_medium_cone)
 
 TEST(second_order_cone_kernels, cone_step_length_many_small_one_sparse_medium_cone)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions;
   for (int i = 0; i < 20; ++i) {
@@ -367,7 +369,7 @@ TEST(second_order_cone_kernels, cone_step_length_many_small_one_sparse_medium_co
 
 TEST(second_order_cone_kernels, cone_step_length_keeps_iterate_in_cone)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 65, 32769, 40000};
   std::size_t n_cone_entries = 0;
@@ -521,7 +523,7 @@ TEST(second_order_cone_kernels, cone_step_length_keeps_iterate_in_cone)
 
 TEST(second_order_cone_kernels, scaling_operators_match_host_reference)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 65, 32769};
   std::size_t n_cone_entries = 0;
@@ -650,7 +652,7 @@ TEST(second_order_cone_kernels, scaling_operators_match_host_reference)
 
 TEST(second_order_cone_kernels, combined_cone_rhs_matches_host_reference)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 65, 32769};
   std::size_t n_cone_entries = 0;
@@ -812,7 +814,7 @@ TEST(second_order_cone_kernels, combined_cone_rhs_matches_host_reference)
 
 TEST(second_order_cone_kernels, sparse_cone_classification)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   // threshold=5: cones of dim 3,2 are dense; dim 6,32769 are sparse
   std::vector<int> cone_dimensions{3, 6, 2, 32769};
@@ -866,7 +868,7 @@ sparse_scaling_head_t sparse_scaling_head_reference(double w0)
 
 TEST(second_order_cone_kernels, update_scaling_sparse_matches_reference)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 6};
   rmm::device_uvector<double> x(9, stream);
@@ -924,7 +926,7 @@ TEST(second_order_cone_kernels, update_scaling_sparse_matches_reference)
 
 TEST(second_order_cone_kernels, update_scaling_sparse_two_cones)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   // sparse cones: dim 6 (offset 3) and dim 5 (offset 9)
   std::vector<int> cone_dimensions{3, 6, 5};

--- a/cpp/tests/socp/solve_barrier_socp.cu
+++ b/cpp/tests/socp/solve_barrier_socp.cu
@@ -27,9 +27,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
 {
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
-    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
   RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream()));
+    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
 }
 
 TEST(barrier, cone_metadata_reindexed_when_slack_is_inserted_before_cones)

--- a/cpp/tests/socp/solve_barrier_socp.cu
+++ b/cpp/tests/socp/solve_barrier_socp.cu
@@ -28,8 +28,9 @@ static void init_handler(const raft::handle_t* handle_ptr)
   // Init cuBlas / cuSparse context here to avoid having it during solving time
   RAFT_CUBLAS_TRY(raft::linalg::detail::cublassetpointermode(
     handle_ptr->get_cublas_handle(), CUBLAS_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
-  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(
-    handle_ptr->get_cusparse_handle(), CUSPARSE_POINTER_MODE_DEVICE, handle_ptr->get_stream().get()));
+  RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsesetpointermode(handle_ptr->get_cusparse_handle(),
+                                                                 CUSPARSE_POINTER_MODE_DEVICE,
+                                                                 handle_ptr->get_stream().get()));
 }
 
 TEST(barrier, cone_metadata_reindexed_when_slack_is_inserted_before_cones)

--- a/cpp/tests/socp/sparse_augmented_kkt_test.cu
+++ b/cpp/tests/socp/sparse_augmented_kkt_test.cu
@@ -9,6 +9,8 @@
 #include <barrier/device_sparse_matrix.cuh>
 #include <barrier/second_order_cone_kernels.cuh>
 
+#include <cuda/stream>
+
 #include <utilities/copy_helpers.hpp>
 
 #include <gtest/gtest.h>
@@ -49,7 +51,7 @@ std::vector<double> expected_Hs_diag(const cone_data_t<int, double>& cones,
 
 TEST(sparse_augmented_kkt, cone_counts_and_expansion_size)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 6, 5};
   rmm::device_uvector<double> x(14, stream);
@@ -66,7 +68,7 @@ TEST(sparse_augmented_kkt, cone_counts_and_expansion_size)
 
 TEST(sparse_augmented_kkt, scatter_sparse_hessian_into_augmented)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   // Two sparse cones so the fused entry-parallel kernel has more than one sparse-cone
   // boundary to get right.
@@ -177,7 +179,7 @@ TEST(sparse_augmented_kkt, scatter_sparse_hessian_into_augmented)
 
 TEST(sparse_augmented_kkt, sparse_augmented_matvec)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{6};
   rmm::device_uvector<double> x(6, stream);
@@ -256,7 +258,7 @@ TEST(sparse_augmented_kkt, sparse_augmented_matvec)
 
 TEST(sparse_augmented_kkt, update_scaling_sparse_dim_1000)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{1000};
   rmm::device_uvector<double> x(1000, stream);
@@ -350,7 +352,7 @@ TEST(sparse_augmented_kkt, update_scaling_sparse_dim_1000)
 
 TEST(sparse_augmented_kkt, gpu_augmented_csr_metadata_matches_host)
 {
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   std::vector<int> cone_dimensions{3, 6, 5};
   rmm::device_uvector<double> x(14, stream);
@@ -411,7 +413,7 @@ TEST(sparse_augmented_kkt, augmented_csr_indices_mixed_dense_sparse_qp)
   // and the right-hand side b are irrelevant and left unset.
   using i_t   = int;
   using f_t   = double;
-  auto stream = rmm::cuda_stream_default;
+  auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   // Layout: 1 linear var, dense Q^3 cone (cols [1,4)), sparse Q^4 cone (cols
   // [4,8)), 2 constraints. Factorization size = n + m + p = 8 + 2 + 2 = 12.


### PR DESCRIPTION
## Description

Use the `get()` and `sync()` compatibility aliases added in [RMM #2537](https://github.com/rapidsai/rmm/pull/2537). These spellings are shared by `rmm::cuda_stream_view` and `cuda::stream_ref`.

This preserves existing stream types and public APIs while extracting mechanical accessor updates from the broader stream migration. It is independently buildable without [RMM #2372](https://github.com/rapidsai/rmm/pull/2372) and leaves the migration PR focused on actual type and signature changes.

This updates raw CUDA, library, kernel-launch, and legacy API boundaries throughout routing and mathematical optimization code while preserving current stream types. The remaining signature migration stays in [cuOpt #1828](https://github.com/NVIDIA/cuopt/pull/1828).

## Issue

[rapidsai/build-planning#318](https://github.com/rapidsai/build-planning/issues/318)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [x] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [x] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
