### PR TITLE
Improve time-to-first-incumbent, unify solution callback publication, scaffolding changes

### DIFF
--- a/benchmarks/linear_programming/cuopt/row_audit.hpp
+++ b/benchmarks/linear_programming/cuopt/row_audit.hpp
@@ -1,0 +1,143 @@
+/* clang-format off */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* clang-format on */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+namespace cuopt_bench {
+
+struct row_sum_t {
+  double activity;
+  double positive_activity;
+  double error_bound;
+};
+
+template <typename value_t, typename index_t, typename solution_t>
+row_sum_t row_sum_fp64(const value_t* values,
+                       const index_t* indices,
+                       int64_t begin,
+                       int64_t end,
+                       const solution_t* solution)
+{
+  double activity = 0.0;
+  double positive = 0.0;
+  double abs_sum  = 0.0;
+  for (int64_t entry = begin; entry < end; ++entry) {
+    const double term = (double)values[entry] * (double)solution[indices[entry]];
+    activity += term;
+    abs_sum += std::fabs(term);
+    if (term > 0.0) positive += term;
+  }
+  const double width = (double)(end - begin);
+  return {activity, positive, (width + 1.0) * std::numeric_limits<double>::epsilon() * abs_sum};
+}
+
+struct row_sum_wide_t {
+  _Float128 activity;
+  _Float128 positive_activity;
+};
+
+template <typename value_t, typename index_t, typename solution_t>
+row_sum_wide_t row_sum_exact(const value_t* values,
+                             const index_t* indices,
+                             int64_t begin,
+                             int64_t end,
+                             const solution_t* solution)
+{
+  _Float128 activity = 0;
+  _Float128 positive = 0;
+  for (int64_t entry = begin; entry < end; ++entry) {
+    const _Float128 term = (_Float128)values[entry] * (_Float128)solution[indices[entry]];
+    activity += term;
+    if (term > 0) positive += term;
+  }
+  return {activity, positive};
+}
+
+inline double scaled_tolerance(double absolute_tolerance, double first, double second)
+{
+  return absolute_tolerance * std::max({1.0, std::fabs(first), std::fabs(second)});
+}
+
+inline std::pair<double, double> scaled_row_limits(double absolute_tolerance,
+                                                   double positive_activity,
+                                                   double lower_bound,
+                                                   double upper_bound)
+{
+  return {lower_bound - scaled_tolerance(absolute_tolerance, positive_activity, lower_bound),
+          upper_bound + scaled_tolerance(absolute_tolerance, positive_activity, upper_bound)};
+}
+
+inline std::pair<double, double> scaled_bound_limits(double absolute_tolerance,
+                                                     double value,
+                                                     double lower_bound,
+                                                     double upper_bound)
+{
+  return {lower_bound - scaled_tolerance(absolute_tolerance, lower_bound, value),
+          upper_bound + scaled_tolerance(absolute_tolerance, upper_bound, value)};
+}
+
+inline double bound_excess(double value,
+                           double lower_bound,
+                           double upper_bound,
+                           double absolute_tolerance)
+{
+  const auto limits = scaled_bound_limits(absolute_tolerance, value, lower_bound, upper_bound);
+  return std::max(std::max(limits.first - value, value - limits.second), 0.0);
+}
+
+struct row_verdict_t {
+  double activity;
+  double excess;
+  double raw_excess;
+  double lower_limit;
+  double upper_limit;
+  bool escalated;
+};
+
+template <typename value_t, typename index_t, typename solution_t, typename limits_t>
+row_verdict_t check_row(const value_t* values,
+                        const index_t* indices,
+                        int64_t begin,
+                        int64_t end,
+                        const solution_t* solution,
+                        double lower_bound,
+                        double upper_bound,
+                        limits_t limits)
+{
+  const row_sum_t sum = row_sum_fp64(values, indices, begin, end, solution);
+  auto bound          = limits(sum.positive_activity);
+  const bool satisfied =
+    sum.activity - sum.error_bound >= bound.first && sum.activity + sum.error_bound <= bound.second;
+  const bool undecided =
+    sum.activity + sum.error_bound >= bound.first && sum.activity - sum.error_bound <= bound.second;
+
+  if (satisfied || !undecided) {
+    const double excess =
+      std::max(std::max(bound.first - sum.activity, sum.activity - bound.second), 0.0);
+    const double raw_excess =
+      std::max(std::max(lower_bound - sum.activity, sum.activity - upper_bound), 0.0);
+    return {sum.activity, excess, raw_excess, bound.first, bound.second, false};
+  }
+
+  const row_sum_wide_t wide = row_sum_exact(values, indices, begin, end, solution);
+  bound                     = limits((double)wide.positive_activity);
+  const _Float128 zero      = 0;
+  const double excess       = (double)std::max(
+    std::max((_Float128)bound.first - wide.activity, wide.activity - (_Float128)bound.second),
+    zero);
+  const double raw_excess = (double)std::max(
+    std::max((_Float128)lower_bound - wide.activity, wide.activity - (_Float128)upper_bound), zero);
+  return {(double)wide.activity, excess, raw_excess, bound.first, bound.second, true};
+}
+
+}  // namespace cuopt_bench

--- a/benchmarks/linear_programming/cuopt/run_mip.cpp
+++ b/benchmarks/linear_programming/cuopt/run_mip.cpp
@@ -7,13 +7,16 @@
 #include "initial_solution_reader.hpp"
 #include "mip_test_instances.hpp"
 #include "miplib2017_bks.hpp"
+#include "row_audit.hpp"
 
+#include <cuopt/mathematical_optimization/cuopt_c.h>
 #include <cstdio>
 #include <cuopt/mathematical_optimization/io/parser.hpp>
 #include <cuopt/mathematical_optimization/mip/solver_settings.hpp>
 #include <cuopt/mathematical_optimization/mip/solver_solution.hpp>
 #include <cuopt/mathematical_optimization/optimization_problem_interface.hpp>
 #include <cuopt/mathematical_optimization/solve.hpp>
+#include <cuopt/mathematical_optimization/utilities/internals.hpp>
 #include <utilities/logger.hpp>
 
 #include <raft/core/handle.hpp>
@@ -30,11 +33,14 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <argparse/argparse.hpp>
+#include <cmath>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <queue>
 #include <stdexcept>
 #include <string>
+#include <syncstream>
 #include <vector>
 
 #include "initial_problem_check.hpp"
@@ -86,6 +92,181 @@ void write_to_output_file(const std::string& out_dir,
 
 inline auto make_async() { return rmm::mr::cuda_async_memory_resource(); }
 
+constexpr bool use_c_api = true;
+
+struct c_api_handles_t {
+  c_api_handles_t()                                  = default;
+  c_api_handles_t(const c_api_handles_t&)            = delete;
+  c_api_handles_t& operator=(const c_api_handles_t&) = delete;
+
+  ~c_api_handles_t()
+  {
+    cuOptDestroySolution(&solution);
+    cuOptDestroySolverSettings(&settings);
+    cuOptDestroyProblem(&problem);
+  }
+
+  cuOptOptimizationProblem problem{};
+  cuOptSolverSettings settings{};
+  cuOptSolution solution{};
+};
+
+struct solve_result_t {
+  double objective_value{};
+  double solution_bound{};
+  double mip_gap{};
+  cuopt_int_t termination_status{};
+
+  double get_objective_value() const { return objective_value; }
+  double get_solution_bound() const { return solution_bound; }
+  double get_mip_gap() const { return mip_gap; }
+};
+
+static void configure_c_api_settings(
+  cuOptSolverSettings c_settings,
+  const cuopt::mathematical_optimization::mip_solver_settings_t<int, double>& settings)
+{
+  cuOptSetFloatParameter(c_settings, CUOPT_TIME_LIMIT, settings.time_limit);
+  cuOptSetFloatParameter(c_settings, CUOPT_WORK_LIMIT, settings.work_limit);
+  cuOptSetIntegerParameter(c_settings, CUOPT_NUM_CPU_THREADS, settings.num_cpu_threads);
+  cuOptSetIntegerParameter(c_settings, CUOPT_MIP_DETERMINISM_MODE, settings.determinism_mode);
+  cuOptSetFloatParameter(
+    c_settings, CUOPT_MIP_RELATIVE_TOLERANCE, settings.tolerances.relative_tolerance);
+  cuOptSetFloatParameter(
+    c_settings, CUOPT_MIP_ABSOLUTE_TOLERANCE, settings.tolerances.absolute_tolerance);
+  cuOptSetFloatParameter(
+    c_settings, CUOPT_MIP_INTEGRALITY_TOLERANCE, settings.tolerances.integrality_tolerance);
+  cuOptSetIntegerParameter(c_settings, CUOPT_PRESOLVE, (cuopt_int_t)settings.presolver);
+  cuOptSetIntegerParameter(
+    c_settings, CUOPT_MIP_RELIABILITY_BRANCHING, settings.reliability_branching);
+  cuOptSetIntegerParameter(c_settings, CUOPT_MIP_CLIQUE_CUTS, settings.clique_cuts);
+  cuOptSetIntegerParameter(c_settings, CUOPT_RANDOM_SEED, settings.seed);
+  cuOptSetParameter(
+    c_settings, CUOPT_MIP_HEURISTICS_ONLY, settings.heuristics_only ? "true" : "false");
+  cuOptSetParameter(c_settings, CUOPT_LOG_TO_CONSOLE, settings.log_to_console ? "true" : "false");
+  cuOptSetParameter(c_settings, CUOPT_LOG_FILE, settings.log_file.c_str());
+}
+
+static bool verify_solution(
+  const cuopt::mathematical_optimization::io::mps_data_model_t<int, double>& problem,
+  const std::vector<double>& solution,
+  double reported_objective,
+  const cuopt::mathematical_optimization::mip_solver_settings_t<int, double>::tolerances_t&
+    tolerances,
+  size_t incumbent)
+{
+  const auto& values                 = problem.get_constraint_matrix_values();
+  const auto& indices                = problem.get_constraint_matrix_indices();
+  const auto& offsets                = problem.get_constraint_matrix_offsets();
+  const auto& row_lower_bounds       = problem.get_constraint_lower_bounds();
+  const auto& row_upper_bounds       = problem.get_constraint_upper_bounds();
+  const auto& variable_lower_bounds  = problem.get_variable_lower_bounds();
+  const auto& variable_upper_bounds  = problem.get_variable_upper_bounds();
+  const auto& variable_types         = problem.get_variable_types();
+  const auto& objective_coefficients = problem.get_objective_coefficients();
+
+  if (variable_lower_bounds.size() != variable_types.size() ||
+      variable_upper_bounds.size() != variable_types.size() ||
+      objective_coefficients.size() != variable_types.size()) {
+    std::osyncstream(std::cerr) << "Incumbent " << incumbent
+                                << " cannot be checked against malformed variable data\n";
+    return false;
+  }
+  if (solution.size() != variable_types.size()) {
+    std::osyncstream(std::cerr) << "Incumbent " << incumbent << " has " << solution.size()
+                                << " variables; expected " << variable_types.size() << "\n";
+    return false;
+  }
+
+  _Float128 objective = 0;
+  for (size_t variable = 0; variable < solution.size(); ++variable) {
+    const double value = solution[variable];
+    if (!std::isfinite(value)) {
+      std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << incumbent
+                                  << " variable " << variable << " is not finite: " << value
+                                  << "\n";
+      return false;
+    }
+    const auto bound_limits = cuopt_bench::scaled_bound_limits(tolerances.absolute_tolerance,
+                                                               value,
+                                                               variable_lower_bounds[variable],
+                                                               variable_upper_bounds[variable]);
+    const double lower_bound_tolerance = variable_lower_bounds[variable] - bound_limits.first;
+    const double upper_bound_tolerance = bound_limits.second - variable_upper_bounds[variable];
+    if (value < bound_limits.first || value > bound_limits.second) {
+      std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << incumbent
+                                  << " variable " << variable << " violates bounds: value=" << value
+                                  << " lb=" << variable_lower_bounds[variable]
+                                  << " ub=" << variable_upper_bounds[variable]
+                                  << " lower_tolerance=" << lower_bound_tolerance
+                                  << " upper_tolerance=" << upper_bound_tolerance << "\n";
+      return false;
+    }
+    if (variable_types[variable] == 'I' && value != std::round(value)) {
+      std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << incumbent
+                                  << " variable " << variable
+                                  << " is not exactly integral: value=" << value
+                                  << " residual=" << std::abs(value - std::round(value)) << "\n";
+      return false;
+    }
+    objective += (_Float128)objective_coefficients[variable] * (_Float128)solution[variable];
+  }
+
+  if (row_upper_bounds.size() != row_lower_bounds.size() ||
+      offsets.size() != row_lower_bounds.size() + 1) {
+    std::osyncstream(std::cerr) << "Incumbent " << incumbent
+                                << " cannot be checked against malformed row data\n";
+    return false;
+  }
+  for (size_t row = 0; row < row_lower_bounds.size(); ++row) {
+    const double lower_bound = row_lower_bounds[row];
+    const double upper_bound = row_upper_bounds[row];
+
+    // fp64 first. _Float128 is soft-float on x86-64; only rows whose rounding-error
+    // interval meets a bound pay for it. Bound is (nnz+1)*eps*abs_sum.
+    const auto verdict = cuopt_bench::check_row(
+      values.data(),
+      indices.data(),
+      (int64_t)offsets[row],
+      (int64_t)offsets[row + 1],
+      solution.data(),
+      lower_bound,
+      upper_bound,
+      [&](double positive_activity) {
+        return cuopt_bench::scaled_row_limits(
+          tolerances.absolute_tolerance, positive_activity, lower_bound, upper_bound);
+      });
+    if (verdict.excess > 0.0) {
+      std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << incumbent << " row "
+                                  << row << " violates bounds: activity=" << verdict.activity
+                                  << " lb=" << lower_bound << " ub=" << upper_bound
+                                  << " lower_tolerance=" << (lower_bound - verdict.lower_limit)
+                                  << " upper_tolerance=" << (verdict.upper_limit - upper_bound)
+                                  << "\n";
+      return false;
+    }
+  }
+
+  const double recomputed_objective =
+    problem.get_objective_scaling_factor() * ((double)objective + problem.get_objective_offset());
+  const double objective_difference = std::abs(recomputed_objective - reported_objective);
+  const double objective_scale =
+    std::max(std::abs(recomputed_objective), std::abs(reported_objective));
+  const double relative_objective_tolerance = objective_scale * tolerances.relative_tolerance;
+  if (!std::isfinite(recomputed_objective) || !std::isfinite(reported_objective) ||
+      (objective_difference > tolerances.absolute_tolerance &&
+       objective_difference > relative_objective_tolerance)) {
+    std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << incumbent
+                                << " objective mismatch: reported=" << reported_objective
+                                << " recomputed=" << recomputed_objective
+                                << " difference=" << objective_difference
+                                << " absolute_tolerance=" << tolerances.absolute_tolerance
+                                << " relative_threshold=" << relative_objective_tolerance << "\n";
+    return false;
+  }
+  return true;
+}
+
 void read_single_solution_from_path(const std::string& path,
                                     const std::vector<std::string>& var_names,
                                     std::vector<std::vector<double>>& solutions)
@@ -136,6 +317,89 @@ std::vector<std::vector<double>> read_solution_from_dir(const std::string file_p
   return initial_solutions;
 }
 
+struct incumbent_record_t {
+  std::vector<double> solution;
+  double reported_objective;
+  double work_timestamp;
+  double wall_time;
+};
+
+class incumbent_tracker_t : public cuopt::internals::get_solution_callback_t {
+ public:
+  incumbent_tracker_t(std::chrono::high_resolution_clock::time_point start_time,
+                      size_t num_variables)
+    : start_time_(start_time), num_variables_(num_variables)
+  {
+  }
+
+  void get_solution(void* data, void* cost, void* /*solution_bound*/, void* /*user_data*/) override
+  {
+    record_solution(static_cast<double*>(data), *static_cast<double*>(cost));
+  }
+
+  void record_solution(const double* solution, double objective)
+  {
+    const auto now = std::chrono::high_resolution_clock::now();
+    records_.push_back({std::vector<double>(solution, solution + num_variables_),
+                        objective,
+                        0.0,
+                        std::chrono::duration<double>(now - start_time_).count()});
+  }
+
+  void write_csv(
+    const std::string& path,
+    const cuopt::mathematical_optimization::io::mps_data_model_t<int, double>& problem,
+    const cuopt::mathematical_optimization::mip_solver_settings_t<int, double>::tolerances_t&
+      tolerances,
+    int num_cpu_threads) const
+  {
+    std::ofstream file(path);
+    if (!file.is_open()) {
+      std::cerr << "Error opening incumbent file " << path << std::endl;
+      return;
+    }
+    constexpr double bks_rounding_threshold = 0.5e-6;
+    const auto bks = cuopt_bench::lookup_miplib_bks(problem.get_problem_name());
+    file << "index,objective,work_timestamp,wall_time_s,valid\n";
+    std::vector<char> valid(records_.size());
+#pragma omp parallel for schedule(static) num_threads(num_cpu_threads)
+    for (size_t i = 0; i < records_.size(); ++i) {
+      valid[i] = verify_solution(
+        problem, records_[i].solution, records_[i].reported_objective, tolerances, i);
+      if (bks.has_value()) {
+        const double objective      = records_[i].reported_objective;
+        const double scale          = std::max({std::abs(objective), std::abs(*bks), 1.0});
+        const double normalized_gap = (objective - *bks) / scale;
+        if (normalized_gap < -bks_rounding_threshold) {
+          std::osyncstream(std::cerr) << std::setprecision(17) << "Incumbent " << i << " objective "
+                                      << objective << " is below MIPLIB BKS " << *bks << "\n";
+          valid[i] = 0;
+        }
+      }
+    }
+    for (size_t i = 0; i < records_.size(); ++i) {
+      file << i << "," << std::setprecision(15) << records_[i].reported_objective << ","
+           << records_[i].work_timestamp << "," << std::setprecision(6) << records_[i].wall_time
+           << "," << int(valid[i]) << "\n";
+    }
+  }
+
+  size_t size() const { return records_.size(); }
+
+ private:
+  std::chrono::high_resolution_clock::time_point start_time_;
+  size_t num_variables_;
+  std::vector<incumbent_record_t> records_;
+};
+
+static void c_api_incumbent_callback(const cuopt_float_t* solution,
+                                     const cuopt_float_t* objective_value,
+                                     const cuopt_float_t* /*solution_bound*/,
+                                     void* user_data)
+{
+  static_cast<incumbent_tracker_t*>(user_data)->record_solution(solution, *objective_value);
+}
+
 int run_single_file(std::string file_path,
                     int device,
                     int batch_id,
@@ -151,8 +415,12 @@ int run_single_file(std::string file_path,
                     double work_limit,
                     bool deterministic)
 {
-  const raft::handle_t handle_{};
+  (void)cudaFree(0);
+
+  std::unique_ptr<raft::handle_t> handle;
+  if constexpr (!use_c_api) { handle = std::make_unique<raft::handle_t>(); }
   cuopt::mathematical_optimization::mip_solver_settings_t<int, double> settings;
+  c_api_handles_t c_api;
   std::string base_filename = file_path.substr(file_path.find_last_of("/\\") + 1);
   // if output directory is given, set the log file
   if (write_log_file) {
@@ -165,6 +433,18 @@ int run_single_file(std::string file_path,
       settings.log_file    = log_file;
     }
   }
+  settings.time_limit       = time_limit;
+  settings.work_limit       = work_limit;
+  settings.heuristics_only  = heuristics_only;
+  settings.num_cpu_threads  = num_cpu_threads;
+  settings.log_to_console   = log_to_console;
+  settings.determinism_mode = deterministic ? CUOPT_MODE_DETERMINISTIC : CUOPT_MODE_OPPORTUNISTIC;
+  settings.tolerances.relative_tolerance = 1e-12;
+  settings.tolerances.absolute_tolerance = 1e-6;
+  settings.presolver                     = cuopt::mathematical_optimization::presolver_t::Default;
+  settings.reliability_branching         = reliability_branching;
+  settings.clique_cuts                   = -1;
+  settings.seed                          = 42;
 
   // This benchmark and the solver library have separate loggers, both writing settings.log_file.
   // Configure the solver's first so its own initializer reuses that configuration rather than
@@ -173,6 +453,10 @@ int run_single_file(std::string file_path,
   auto solver_log = cuopt::mathematical_optimization::configure_logging(
     settings.log_file, log_to_console, /*truncate=*/true);
   cuopt::init_logger_t bench_log(settings.log_file, log_to_console, /*truncate=*/false);
+  if constexpr (use_c_api) {
+    cuOptCreateSolverSettings(&c_api.settings);
+    configure_c_api_settings(c_api.settings, settings);
+  }
 
   constexpr bool input_mps_strict = false;
   cuopt::mathematical_optimization::io::mps_data_model_t<int, double> mps_data_model;
@@ -206,42 +490,74 @@ int run_single_file(std::string file_path,
                                             settings.tolerances.relative_tolerance,
                                             settings.tolerances.integrality_tolerance);
       if (feasible_variables) {
-        settings.add_initial_solution(
-          initial_solution.data(), initial_solution.size(), handle_.get_stream());
+        if constexpr (use_c_api) {
+          cuOptAddMIPStart(c_api.settings, initial_solution.data(), initial_solution.size());
+        } else {
+          settings.add_initial_solution(
+            initial_solution.data(), initial_solution.size(), handle->get_stream());
+        }
       }
     }
   }
-  settings.time_limit       = time_limit;
-  settings.work_limit       = work_limit;
-  settings.heuristics_only  = heuristics_only;
-  settings.num_cpu_threads  = num_cpu_threads;
-  settings.log_to_console   = log_to_console;
-  settings.determinism_mode = deterministic ? CUOPT_MODE_DETERMINISTIC : CUOPT_MODE_OPPORTUNISTIC;
-  settings.tolerances.relative_tolerance = 1e-12;
-  settings.tolerances.absolute_tolerance = 1e-6;
-  settings.presolver                     = cuopt::mathematical_optimization::presolver_t::Default;
-  settings.reliability_branching         = reliability_branching;
-  settings.clique_cuts                   = -1;
-  settings.seed                          = 42;
   cuopt::mathematical_optimization::benchmark_info_t benchmark_info;
-  settings.benchmark_info_ptr = &benchmark_info;
-  auto start_run_solver       = std::chrono::high_resolution_clock::now();
-  auto solution = cuopt::mathematical_optimization::solve_mip(&handle_, mps_data_model, settings);
+  if constexpr (!use_c_api) { settings.benchmark_info_ptr = &benchmark_info; }
+  std::chrono::high_resolution_clock::time_point start_run_solver;
+  std::unique_ptr<incumbent_tracker_t> incumbent_tracker;
+  solve_result_t solution;
+  if constexpr (use_c_api) {
+    if (mps_data_model.get_objective_scaling_factor() != 1.0) {
+      throw std::runtime_error("cuOptCreateRangedProblem does not support objective scaling");
+    }
+    cuOptCreateRangedProblem(mps_data_model.get_n_constraints(),
+                             mps_data_model.get_n_variables(),
+                             mps_data_model.get_sense() ? CUOPT_MAXIMIZE : CUOPT_MINIMIZE,
+                             mps_data_model.get_objective_offset(),
+                             mps_data_model.get_objective_coefficients().data(),
+                             mps_data_model.get_constraint_matrix_offsets().data(),
+                             mps_data_model.get_constraint_matrix_indices().data(),
+                             mps_data_model.get_constraint_matrix_values().data(),
+                             mps_data_model.get_constraint_lower_bounds().data(),
+                             mps_data_model.get_constraint_upper_bounds().data(),
+                             mps_data_model.get_variable_lower_bounds().data(),
+                             mps_data_model.get_variable_upper_bounds().data(),
+                             mps_data_model.get_variable_types().data(),
+                             &c_api.problem);
+
+    start_run_solver = std::chrono::high_resolution_clock::now();
+    incumbent_tracker =
+      std::make_unique<incumbent_tracker_t>(start_run_solver, mps_data_model.get_n_variables());
+    cuOptSetMIPGetSolutionCallback(
+      c_api.settings, c_api_incumbent_callback, incumbent_tracker.get());
+    cuOptSolve(c_api.problem, c_api.settings, &c_api.solution);
+    cuOptGetTerminationStatus(c_api.solution, &solution.termination_status);
+    cuOptGetObjectiveValue(c_api.solution, &solution.objective_value);
+    cuOptGetSolutionBound(c_api.solution, &solution.solution_bound);
+    cuOptGetMIPGap(c_api.solution, &solution.mip_gap);
+  } else {
+    start_run_solver = std::chrono::high_resolution_clock::now();
+    incumbent_tracker =
+      std::make_unique<incumbent_tracker_t>(start_run_solver, mps_data_model.get_n_variables());
+    settings.set_mip_callback(incumbent_tracker.get());
+    auto cpp_solution =
+      cuopt::mathematical_optimization::solve_mip(handle.get(), mps_data_model, settings);
+    solution.objective_value    = cpp_solution.get_objective_value();
+    solution.solution_bound     = cpp_solution.get_solution_bound();
+    solution.mip_gap            = cpp_solution.get_mip_gap();
+    solution.termination_status = (cuopt_int_t)cpp_solution.get_termination_status();
+    // solution.write_to_sol_file(base_filename + ".sol", handle_.get_stream());
+  }
   CUOPT_LOG_INFO(
     "first obj: %f last improvement of best feasible: %f last improvement after recombination: %f",
     benchmark_info.objective_of_initial_population,
     benchmark_info.last_improvement_of_best_feasible,
     benchmark_info.last_improvement_after_recombination);
-  // solution.write_to_sol_file(base_filename + ".sol", handle_.get_stream());
   std::chrono::milliseconds duration;
   auto end = std::chrono::high_resolution_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start_run_solver);
   CUOPT_LOG_INFO("run_solver %d", duration.count());
-  handle_.sync_stream();
-  int sol_found  = int(solution.get_termination_status() ==
-                        cuopt::mathematical_optimization::mip_termination_status_t::FeasibleFound ||
-                      solution.get_termination_status() ==
-                        cuopt::mathematical_optimization::mip_termination_status_t::Optimal);
+  if constexpr (!use_c_api) { handle->sync_stream(); }
+  int sol_found  = int(solution.termination_status == CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND ||
+                      solution.termination_status == CUOPT_TERMINATION_STATUS_OPTIMAL);
   double obj_val = sol_found ? solution.get_objective_value() : std::numeric_limits<double>::max();
   if (sol_found) {
     CUOPT_LOG_INFO("%s: solution found, obj: %f", base_filename.c_str(), obj_val);
@@ -261,19 +577,11 @@ int run_single_file(std::string file_path,
                                   .count() /
                                 1000.0;
     std::string _status_str;
-    switch (solution.get_termination_status()) {
-      case cuopt::mathematical_optimization::mip_termination_status_t::Optimal:
-        _status_str = "Optimal";
-        break;
-      case cuopt::mathematical_optimization::mip_termination_status_t::FeasibleFound:
-        _status_str = "FeasibleFound";
-        break;
-      case cuopt::mathematical_optimization::mip_termination_status_t::TimeLimit:
-        _status_str = "TimeLimit";
-        break;
-      case cuopt::mathematical_optimization::mip_termination_status_t::Infeasible:
-        _status_str = "Infeasible";
-        break;
+    switch (solution.termination_status) {
+      case CUOPT_TERMINATION_STATUS_OPTIMAL: _status_str = "Optimal"; break;
+      case CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND: _status_str = "FeasibleFound"; break;
+      case CUOPT_TERMINATION_STATUS_TIME_LIMIT: _status_str = "TimeLimit"; break;
+      case CUOPT_TERMINATION_STATUS_INFEASIBLE: _status_str = "Infeasible"; break;
       default: _status_str = "Other"; break;
     }
     cuopt_bench::print_miplib_gap_stat(base_filename,
@@ -288,10 +596,7 @@ int run_single_file(std::string file_path,
   std::stringstream ss;
   int decimal_places = 2;
   double mip_gap     = solution.get_mip_gap();
-  int is_optimal     = solution.get_termination_status() ==
-                       cuopt::mathematical_optimization::mip_termination_status_t::Optimal
-                         ? 1
-                         : 0;
+  int is_optimal     = solution.termination_status == CUOPT_TERMINATION_STATUS_OPTIMAL ? 1 : 0;
   ss << std::fixed << std::setprecision(decimal_places) << base_filename << "," << sol_found << ","
      << obj_val << "," << benchmark_info.objective_of_initial_population << ","
      << benchmark_info.last_improvement_of_best_feasible << ","
@@ -299,6 +604,19 @@ int run_single_file(std::string file_path,
      << "\n";
   write_to_output_file(out_dir, base_filename, device, n_gpus, batch_id, ss.str());
   CUOPT_LOG_INFO("Results written to the file %s", base_filename.c_str());
+  if (out_dir != "") {
+    std::string csv_path =
+      out_dir + "/" + base_filename.substr(0, base_filename.find(".mps")) + "_incumbents.csv";
+    const auto csv_start = std::chrono::high_resolution_clock::now();
+    incumbent_tracker->write_csv(
+      csv_path, mps_data_model, settings.get_tolerances(), num_cpu_threads);
+    const auto csv_end = std::chrono::high_resolution_clock::now();
+    std::cerr << "Incumbent csv generation took "
+              << std::chrono::duration<double>(csv_end - csv_start).count() << " s ("
+              << incumbent_tracker->size() << " entries) -> " << csv_path << std::endl;
+    CUOPT_LOG_INFO(
+      "Incumbent trace (%zu entries) written to %s", incumbent_tracker->size(), csv_path.c_str());
+  }
   return sol_found;
 }
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ rapids_cmake_build_type(Release)
 option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc useful for cuda-memcheck / profiler" ON)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_LP_ONLY "Build only linear programming components, exclude routing and MIP-specific files" OFF)
+option(BUILD_MIP_BENCHMARKS "Build MIP benchmarks" OFF)
 option(SKIP_C_PYTHON_ADAPTERS "Skip building C and Python adapter files (cython_solve.cu and cuopt_c.cpp)" OFF)
 option(SKIP_ROUTING_BUILD "Skip building routing components" OFF)
 option(SKIP_GRPC_BUILD "Skip building gRPC and protobuf components" OFF)
@@ -795,6 +796,9 @@ target_link_libraries(cuopt_objs
 # - generate tests --------------------------------------------------------------------------------
 if (BUILD_TESTS)
     include(CTest)
+endif ()
+
+if (BUILD_TESTS OR (BUILD_MIP_BENCHMARKS AND NOT BUILD_LP_ONLY))
     add_library(cuopt_static STATIC $<TARGET_OBJECTS:cuopt_objs>)
     target_link_libraries(cuopt_static
             PUBLIC
@@ -837,6 +841,9 @@ if (BUILD_TESTS)
     if (TARGET KaMinPar)
         add_dependencies(cuopt_static KaMinPar)
     endif ()
+endif ()
+
+if (BUILD_TESTS)
     add_subdirectory(tests)
 endif (BUILD_TESTS)
 
@@ -1053,7 +1060,6 @@ if (NOT BUILD_LP_ONLY)
 endif ()
 
 
-option(BUILD_MIP_BENCHMARKS "Build MIP benchmarks" OFF)
 if (BUILD_MIP_BENCHMARKS AND NOT BUILD_LP_ONLY)
     add_executable(solve_MIP ../benchmarks/linear_programming/cuopt/run_mip.cpp)
     target_include_directories(solve_MIP

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -304,6 +304,25 @@ set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(pslp)
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVED})
 
+FetchContent_Declare(
+        highway
+        GIT_REPOSITORY "https://github.com/google/highway.git"
+        GIT_TAG "1.4.0"
+        GIT_PROGRESS TRUE
+        EXCLUDE_FROM_ALL
+        SYSTEM
+)
+
+set(HWY_ENABLE_CONTRIB OFF CACHE BOOL "" FORCE)
+set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(HWY_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+set(HWY_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+
+set(BUILD_SHARED_LIBS_SAVED ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
+FetchContent_MakeAvailable(highway)
+set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_SAVED})
+
 
 # dejavu - header-only graph automorphism library for MIP symmetry detection
 # https://github.com/markusa4/dejavu (header-only, skip its CMakeLists.txt)
@@ -663,6 +682,7 @@ target_include_directories(cuopt_objs PRIVATE
 target_include_directories(cuopt_objs SYSTEM PRIVATE
   "${pslp_SOURCE_DIR}/include"
   "${dejavu_SOURCE_DIR}"
+  "${highway_SOURCE_DIR}"
 )
 
 target_include_directories(cuopt_objs
@@ -687,6 +707,9 @@ target_include_directories(cuopt_objs
 # Link PSLP by file to avoid export dependency tracking
 target_link_libraries(cuopt_objs PRIVATE $<TARGET_FILE:PSLP>)
 add_dependencies(cuopt_objs PSLP)
+
+target_link_libraries(cuopt_objs PRIVATE $<TARGET_FILE:hwy>)
+add_dependencies(cuopt_objs hwy)
 
 # Link KaMinPar by file to avoid export dependency tracking (mirrors PSLP above).
 # KaMinPar is a from-source static library fully embedded into libcuopt.so; it is never
@@ -808,6 +831,8 @@ if (BUILD_TESTS)
     )
     target_link_libraries(cuopt_static PRIVATE $<TARGET_FILE:PSLP>)
     add_dependencies(cuopt_static PSLP)
+    target_link_libraries(cuopt_static PRIVATE $<TARGET_FILE:hwy>)
+    add_dependencies(cuopt_static hwy)
     target_link_libraries(cuopt_static PRIVATE $<TARGET_FILE:KaMinPar::KaMinPar>)
     if (TARGET KaMinPar)
         add_dependencies(cuopt_static KaMinPar)
@@ -852,6 +877,8 @@ target_link_libraries(cuopt
 )
 target_link_libraries(cuopt PRIVATE $<TARGET_FILE:PSLP>)
 add_dependencies(cuopt PSLP)
+target_link_libraries(cuopt PRIVATE $<TARGET_FILE:hwy>)
+add_dependencies(cuopt hwy)
 target_link_libraries(cuopt PRIVATE $<TARGET_FILE:KaMinPar::KaMinPar>)
 if (TARGET KaMinPar)
         add_dependencies(cuopt KaMinPar)

--- a/cpp/include/cuopt/mathematical_optimization/cpu_optimization_problem.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/cpu_optimization_problem.hpp
@@ -123,6 +123,12 @@ class cpu_optimization_problem_t : public optimization_problem_interface_t<i_t, 
   std::string get_objective_name() const override;
   std::string get_problem_name() const override;
   problem_category_t get_problem_category() const override;
+  /**
+   * @brief Whether any variable type is SEMI_CONTINUOUS.
+   *
+   * Cached in set_variable_types() / adopt_from_mps_data_model().
+   */
+  bool has_semi_continuous_variables() const noexcept;
   const std::vector<std::string>& get_variable_names() const override;
   const std::vector<std::string>& get_row_names() const override;
   const std::vector<i_t>& get_quadratic_objective_offsets() const override;
@@ -208,6 +214,7 @@ class cpu_optimization_problem_t : public optimization_problem_interface_t<i_t, 
 
  private:
   problem_category_t problem_category_ = problem_category_t::LP;
+  bool has_semi_continuous_variables_{false};
   bool maximize_{false};
   i_t n_vars_{0};
   i_t n_constraints_{0};

--- a/cpp/include/cuopt/mathematical_optimization/optimization_problem.hpp
+++ b/cpp/include/cuopt/mathematical_optimization/optimization_problem.hpp
@@ -284,6 +284,12 @@ class optimization_problem_t : public optimization_problem_interface_t<i_t, f_t>
   std::string get_objective_name() const override;
   std::string get_problem_name() const override;
   problem_category_t get_problem_category() const override;
+  /**
+   * @brief Whether any variable type is SEMI_CONTINUOUS.
+   *
+   * Cached in set_variable_types(); used to skip SC reformulation host probes.
+   */
+  bool has_semi_continuous_variables() const noexcept;
   const std::vector<std::string>& get_variable_names() const override;
   const std::vector<std::string>& get_row_names() const override;
   const std::vector<i_t>& get_quadratic_objective_offsets() const override;
@@ -391,6 +397,7 @@ class optimization_problem_t : public optimization_problem_interface_t<i_t, f_t>
   rmm::cuda_stream_view stream_view_;
 
   problem_category_t problem_category_ = problem_category_t::LP;
+  bool has_semi_continuous_variables_{false};
   bool maximize_{false};
   i_t n_vars_{0};
   i_t n_constraints_{0};

--- a/cpp/src/mip_heuristics/diversity/population.cu
+++ b/cpp/src/mip_heuristics/diversity/population.cu
@@ -198,7 +198,7 @@ std::vector<solution_t<i_t, f_t>> population_t<i_t, f_t>::get_external_solutions
 {
   std::lock_guard<std::mutex> lock(solution_mutex);
   std::vector<solution_t<i_t, f_t>> return_vector;
-  i_t counter                     = 0;
+  [[maybe_unused]] i_t counter    = 0;
   f_t new_best_feasible_objective = best_feasible_objective;
   f_t longest_wait_time           = 0;
   for (auto& queue : {external_solution_queue, external_solution_queue_cpufj}) {
@@ -264,41 +264,6 @@ bool population_t<i_t, f_t>::is_better_than_best_feasible(solution_t<i_t, f_t>& 
 }
 
 template <typename i_t, typename f_t>
-void population_t<i_t, f_t>::invoke_get_solution_callback(
-  solution_t<i_t, f_t>& sol, internals::get_solution_callback_t* callback)
-{
-  f_t user_objective = sol.get_user_objective();
-  f_t user_bound     = context.stats.get_solution_bound();
-  solution_t<i_t, f_t> temp_sol(sol);
-  problem_ptr->post_process_assignment(temp_sol.assignment);
-  if (problem_ptr->has_papilo_presolve_data()) {
-    problem_ptr->papilo_uncrush_assignment(temp_sol.assignment);
-  }
-
-  std::vector<f_t> user_objective_vec(1);
-  std::vector<f_t> user_bound_vec(1);
-  std::vector<f_t> user_assignment_vec(temp_sol.assignment.size());
-  user_objective_vec[0] = user_objective;
-  user_bound_vec[0]     = user_bound;
-  raft::copy(user_assignment_vec.data(),
-             temp_sol.assignment.data(),
-             temp_sol.assignment.size(),
-             temp_sol.handle_ptr->get_stream());
-  temp_sol.handle_ptr->sync_stream();
-  if (mip_solver_settings_accessor<i_t, f_t>::has_semi_continuous_callback_translation(
-        context.settings)) {
-    mip::strip_semi_continuous_auxiliaries_from_assignment(
-      user_assignment_vec,
-      mip_solver_settings_accessor<i_t, f_t>::get_semi_continuous_original_num_variables(
-        context.settings));
-  }
-  callback->get_solution(user_assignment_vec.data(),
-                         user_objective_vec.data(),
-                         user_bound_vec.data(),
-                         callback->get_user_data());
-}
-
-template <typename i_t, typename f_t>
 void population_t<i_t, f_t>::run_solution_callbacks(solution_t<i_t, f_t>& sol)
 {
   bool better_solution_found = is_better_than_best_feasible(sol);
@@ -308,15 +273,14 @@ void population_t<i_t, f_t>::run_solution_callbacks(solution_t<i_t, f_t>& sol)
       context.settings.benchmark_info_ptr->last_improvement_of_best_feasible = timer.elapsed_time();
     }
     CUOPT_LOG_DEBUG("Population: Found new best solution %g", sol.get_user_objective());
-    if (problem_ptr->branch_and_bound_callback != nullptr) {
-      problem_ptr->branch_and_bound_callback(sol.get_host_assignment(),
-                                             heuristics_origin_t::HEURISTICS);
-    }
-    for (auto callback : user_callbacks) {
-      if (callback->get_type() == internals::base_solution_callback_type::GET_SOLUTION) {
-        auto get_sol_callback = static_cast<internals::get_solution_callback_t*>(callback);
-        invoke_get_solution_callback(sol, get_sol_callback);
+    if (problem_ptr->branch_and_bound_callback != nullptr ||
+        context.solution_publication.enabled()) {
+      auto host_assignment = sol.get_host_assignment();
+      if (problem_ptr->branch_and_bound_callback != nullptr) {
+        problem_ptr->branch_and_bound_callback(host_assignment, heuristics_origin_t::HEURISTICS);
       }
+      context.solution_publication.publish_if_better(
+        problem_ptr, host_assignment, sol.get_objective());
     }
     // Save the best objective here even if callback handling later exits early.
     // This prevents older solutions from being reported as "new best" in subsequent callbacks.
@@ -869,7 +833,7 @@ void population_t<i_t, f_t>::print()
                   infeasibility_importance,
                   var_threshold,
                   problem_ptr->n_integer_vars);
-  i_t i = 0;
+  [[maybe_unused]] i_t i = 0;
   for (auto& index : indices) {
     if (index.first == 0 && solutions[0].first) {
       CUOPT_LOG_DEBUG(" Best feasible: %f", solutions[index.first].second.get_user_objective());

--- a/cpp/src/mip_heuristics/diversity/population.cuh
+++ b/cpp/src/mip_heuristics/diversity/population.cuh
@@ -160,9 +160,6 @@ class population_t {
 
   void diversity_step(i_t max_iterations_without_improvement);
 
-  void invoke_get_solution_callback(solution_t<i_t, f_t>& sol,
-                                    internals::get_solution_callback_t* callback);
-
   // does some consistency tests
   bool test_invariant();
 

--- a/cpp/src/mip_heuristics/local_search/local_search.cu
+++ b/cpp/src/mip_heuristics/local_search/local_search.cu
@@ -78,6 +78,7 @@ void local_search_t<i_t, f_t>::start_cpufj_scratch_threads(population_t<i_t, f_t
     cpu_fj->improvement_callback =
       [this, &population, problem_ptr = context.problem_ptr](
         f_t obj, const std::vector<f_t>& h_vec, double /*work_units*/) {
+        context.solution_publication.publish_if_better(problem_ptr, h_vec, obj);
         population.add_external_solution(h_vec, obj, solution_origin_t::CPUFJ);
         (void)problem_ptr;
         if (obj < this->local_search_best_obj) {
@@ -126,6 +127,7 @@ void local_search_t<i_t, f_t>::start_cpufj_lptopt_scratch_threads(
   scratch_cpu_fj_on_lp_opt->log_prefix = "******* scratch on LP optimal: ";
   scratch_cpu_fj_on_lp_opt->improvement_callback =
     [this, &population](f_t obj, const std::vector<f_t>& h_vec, double /*work_units*/) {
+      context.solution_publication.publish_if_better(context.problem_ptr, h_vec, obj);
       population.add_external_solution(h_vec, obj, solution_origin_t::CPUFJ);
       if (obj < this->local_search_best_obj) {
         CUOPT_LOG_DEBUG("******* New local search best obj %g, best overall %g",

--- a/cpp/src/mip_heuristics/presolve/semi_continuous.cu
+++ b/cpp/src/mip_heuristics/presolve/semi_continuous.cu
@@ -115,6 +115,8 @@ bool reformulate_semi_continuous(optimization_problem_t<i_t, f_t>& op_problem,
                                  std::vector<uint8_t>* used_fallback_big_m,
                                  std::vector<i_t>* semi_continuous_binary_to_original_indices)
 {
+  if (!op_problem.has_semi_continuous_variables()) { return false; }
+
   // 1. Identify semi-continuous variables
   auto var_types = op_problem.get_variable_types_host();
   auto var_lb    = op_problem.get_variable_lower_bounds_host();

--- a/cpp/src/mip_heuristics/presolve/trivial_presolve.cu
+++ b/cpp/src/mip_heuristics/presolve/trivial_presolve.cu
@@ -11,11 +11,15 @@
 namespace cuopt::mathematical_optimization::mip {
 
 #if MIP_INSTANTIATE_FLOAT
-template void trivial_presolve(problem_t<int, float>& problem, bool remap_cache_ids);
+template void trivial_presolve(problem_t<int, float>& problem,
+                               bool remap_cache_ids,
+                               bool compute_related_vars);
 #endif
 
 #if MIP_INSTANTIATE_DOUBLE
-template void trivial_presolve(problem_t<int, double>& problem, bool remap_cache_ids);
+template void trivial_presolve(problem_t<int, double>& problem,
+                               bool remap_cache_ids,
+                               bool compute_related_vars);
 #endif
 
 }  // namespace cuopt::mathematical_optimization::mip

--- a/cpp/src/mip_heuristics/presolve/trivial_presolve.cuh
+++ b/cpp/src/mip_heuristics/presolve/trivial_presolve.cuh
@@ -358,14 +358,17 @@ void test_reverse_matches(const problem_t<i_t, f_t>& pb)
 }
 
 template <typename i_t, typename f_t>
-void trivial_presolve(problem_t<i_t, f_t>& problem, bool remap_cache_ids = false)
+void trivial_presolve(problem_t<i_t, f_t>& problem,
+                      bool remap_cache_ids      = false,
+                      bool compute_related_vars = true)
 {
   cuopt_expects(problem.preprocess_called,
                 error_type_t::RuntimeError,
                 "preprocess_problem should be called before running the solver");
   update_from_csr(problem, remap_cache_ids);
   problem.recompute_auxilliary_data(
-    false);  // check problem representation later once cstr bounds are computed
+    false,
+    compute_related_vars);  // check problem representation later once cstr bounds are computed
   cuopt_func_call(test_reverse_matches(problem));
   pdlp::combine_constraint_bounds<i_t, f_t>(problem, problem.combined_bounds);
   // The problem has been solved by presolve. Mark its empty status as valid

--- a/cpp/src/mip_heuristics/problem/presolve_data.cu
+++ b/cpp/src/mip_heuristics/problem/presolve_data.cu
@@ -257,8 +257,8 @@ void presolve_data_t<i_t, f_t>::set_papilo_presolve_data(
 }
 
 template <typename i_t, typename f_t>
-void presolve_data_t<i_t, f_t>::papilo_uncrush_assignment(
-  problem_t<i_t, f_t>& problem, rmm::device_uvector<f_t>& assignment) const
+void presolve_data_t<i_t, f_t>::papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment,
+                                                          rmm::cuda_stream_view stream) const
 {
   if (papilo_presolve_ptr == nullptr) {
     CUOPT_LOG_INFO("Papilo presolve data not set, skipping uncrushing assignment");
@@ -266,15 +266,12 @@ void presolve_data_t<i_t, f_t>::papilo_uncrush_assignment(
   }
   cuopt_assert(assignment.size() == papilo_reduced_to_original_map.size(),
                "Papilo uncrush assignment size mismatch");
-  auto h_assignment = cuopt::host_copy(assignment, problem.handle_ptr->get_stream());
+  auto h_assignment = cuopt::host_copy(assignment, stream);
   std::vector<f_t> full_assignment;
   papilo_presolve_ptr->uncrush_primal_solution(h_assignment, full_assignment);
-  assignment.resize(full_assignment.size(), problem.handle_ptr->get_stream());
-  raft::copy(assignment.data(),
-             full_assignment.data(),
-             full_assignment.size(),
-             problem.handle_ptr->get_stream());
-  problem.handle_ptr->sync_stream();
+  assignment.resize(full_assignment.size(), stream);
+  raft::copy(assignment.data(), full_assignment.data(), full_assignment.size(), stream);
+  stream.synchronize();
 }
 
 #if MIP_INSTANTIATE_FLOAT || PDLP_INSTANTIATE_FLOAT

--- a/cpp/src/mip_heuristics/problem/presolve_data.cuh
+++ b/cpp/src/mip_heuristics/problem/presolve_data.cuh
@@ -122,8 +122,8 @@ class presolve_data_t {
                                 i_t original_num_variables);
   bool has_papilo_presolve_data() const { return papilo_presolve_ptr != nullptr; }
   i_t get_papilo_original_num_variables() const { return papilo_original_num_variables; }
-  void papilo_uncrush_assignment(problem_t<i_t, f_t>& problem,
-                                 rmm::device_uvector<f_t>& assignment) const;
+  void papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment,
+                                 rmm::cuda_stream_view stream) const;
 
   presolve_data_t(presolve_data_t&&)                 = default;
   presolve_data_t& operator=(presolve_data_t&&)      = default;

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -825,14 +825,20 @@ void problem_t<i_t, f_t>::check_problem_representation(bool check_transposed,
 }
 
 template <typename i_t, typename f_t>
-void problem_t<i_t, f_t>::recompute_auxilliary_data(bool check_representation)
+void problem_t<i_t, f_t>::recompute_auxilliary_data(bool check_representation,
+                                                    bool compute_related_vars)
 {
   raft::common::nvtx::range fun_scope("recompute_auxilliary_data");
   compute_n_integer_vars();
   compute_binary_var_table();
   compute_vars_with_objective_coeffs();
   // TODO: speedup compute related variables
-  compute_related_variables(related_vars_time_limit);
+  if (compute_related_vars) {
+    compute_related_variables(related_vars_time_limit);
+  } else {
+    related_variables.resize(0, handle_ptr->get_stream());
+    related_variables_offsets.resize(0, handle_ptr->get_stream());
+  }
   if (check_representation) cuopt_func_call(check_problem_representation(true));
 }
 
@@ -1300,6 +1306,7 @@ void problem_t<i_t, f_t>::recompute_objective_integrality()
       presolve_data.objective_scaling_factor /= scaling_factor;
       presolve_data.objective_offset *= scaling_factor;
       objective_is_integral = true;
+      compute_vars_with_objective_coeffs();
     }
   }
 }
@@ -1812,7 +1819,7 @@ void problem_t<i_t, f_t>::remove_given_variables(problem_t<i_t, f_t>& original_p
   compute_auxiliary_data();
   pdlp::combine_constraint_bounds<i_t, f_t>(*this, combined_bounds);
   handle_ptr->sync_stream();
-  recompute_auxilliary_data();
+  recompute_auxilliary_data(/*check_representation=*/true, /*compute_related_vars=*/false);
   cuopt_func_call(check_problem_representation(true));
 }
 
@@ -2193,9 +2200,10 @@ void problem_t<i_t, f_t>::set_papilo_presolve_data(
 }
 
 template <typename i_t, typename f_t>
-void problem_t<i_t, f_t>::papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment) const
+void problem_t<i_t, f_t>::papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment,
+                                                    rmm::cuda_stream_view stream) const
 {
-  presolve_data.papilo_uncrush_assignment(const_cast<problem_t&>(*this), assignment);
+  presolve_data.papilo_uncrush_assignment(assignment, stream);
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/mip_heuristics/problem/problem.cu
+++ b/cpp/src/mip_heuristics/problem/problem.cu
@@ -89,6 +89,8 @@ void problem_t<i_t, f_t>::op_problem_cstr_body(const optimization_problem_t<i_t,
 
   // Check before any modifications
   cuopt_func_call(check_problem_representation(false, false));
+  cuopt_assert(problem_.get_objective_scaling_factor() > 0,
+               "objective_scaling_factor is a magnitude; sense encodes min/max");
   // If maximization problem, convert the problem
   if (maximize) convert_to_maximization_problem(*this);
   if (is_mip) {

--- a/cpp/src/mip_heuristics/problem/problem.cuh
+++ b/cpp/src/mip_heuristics/problem/problem.cuh
@@ -81,7 +81,8 @@ class problem_t {
   i_t get_n_binary_variables();
   void check_problem_representation(bool check_transposed       = false,
                                     bool check_mip_related_data = true);
-  void recompute_auxilliary_data(bool check_representation = true);
+  void recompute_auxilliary_data(bool check_representation = true,
+                                 bool compute_related_vars = true);
   void compute_auxiliary_data();
   void compute_n_integer_vars();
   void compute_binary_var_table();
@@ -119,7 +120,12 @@ class problem_t {
   {
     return presolve_data.get_papilo_original_num_variables();
   }
-  void papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment) const;
+  void papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment,
+                                 rmm::cuda_stream_view stream) const;
+  void papilo_uncrush_assignment(rmm::device_uvector<f_t>& assignment) const
+  {
+    papilo_uncrush_assignment(assignment, handle_ptr->get_stream());
+  }
   void compute_transpose_of_problem();
   f_t get_user_obj_from_solver_obj(f_t solver_obj) const;
   f_t get_solver_obj_from_user_obj(f_t user_obj) const;

--- a/cpp/src/mip_heuristics/solution_publication.cuh
+++ b/cpp/src/mip_heuristics/solution_publication.cuh
@@ -32,9 +32,6 @@
 namespace cuopt::mathematical_optimization::mip {
 
 // Single point at which MIP incumbents are reported to the user get-solution callbacks.
-// The heuristic thread (through the population) and the branch-and-bound thread both publish
-// here, so the guard on the last published objective is shared and every incumbent is reported
-// once, at the moment it is found rather than when the heuristic thread next drains its queue.
 template <typename i_t, typename f_t>
 class solution_publication_t {
  public:
@@ -48,8 +45,6 @@ class solution_publication_t {
     }
   }
 
-  // Whether any get-solution callback is registered. Callers can use this to skip assembling
-  // the host assignment that publish_if_better would otherwise discard.
   bool enabled() const { return handle_ != nullptr; }
 
   void set_published_floor(f_t solver_objective)
@@ -58,11 +53,8 @@ class solution_publication_t {
     best_published_objective_ = solver_objective;
   }
 
-  // `assignment` and `solver_objective` are in problem_ptr's solver space, which is always
-  // oriented as a minimization. Returns whether the incumbent was published.
-  //
-  // Post-processing runs on a private stream, so this is safe to call from the branch-and-bound
-  // thread while the heuristic thread owns problem_ptr->handle_ptr's stream.
+  // `assignment` and `solver_objective` are in problem_ptr's solver space.
+  // Returns whether the incumbent was published.
   bool publish_if_better(problem_t<i_t, f_t>* problem_ptr,
                          const std::vector<f_t>& assignment,
                          f_t solver_objective)
@@ -103,7 +95,7 @@ class solution_publication_t {
           callback->get_type() != internals::base_solution_callback_type::GET_SOLUTION) {
         continue;
       }
-      // Each callback gets its own copies: the interface hands out mutable pointers.
+      // Each callback gets its own copies.
       std::vector<f_t> callback_assignment(user_assignment);
       std::vector<f_t> callback_objective(1, user_objective);
       std::vector<f_t> callback_bound(1, user_bound);
@@ -142,8 +134,7 @@ class solution_publication_t {
     auto stream = handle_->get_stream();
     rmm::device_uvector<f_t> d_assignment(assignment.size(), stream);
     raft::copy(d_assignment.data(), assignment.data(), assignment.size(), stream);
-    // post_process_assignment writes through problem_ptr->presolve_data.fixed_var_assignment,
-    // which both publishing threads share: the caller's lock is what keeps them apart.
+
     problem_ptr->post_process_assignment(d_assignment, true, stream);
     if (problem_ptr->has_papilo_presolve_data()) {
       problem_ptr->papilo_uncrush_assignment(d_assignment, stream);

--- a/cpp/src/mip_heuristics/solution_publication.cuh
+++ b/cpp/src/mip_heuristics/solution_publication.cuh
@@ -66,7 +66,7 @@ class solution_publication_t {
     std::lock_guard<std::mutex> lock(mutex_);
     cuopt_assert(assignment.size() == (size_t)problem_ptr->n_variables,
                  "Published assignment size must match the problem");
-    cuopt_func_call(audit_integrality(problem_ptr, assignment));
+    // cuopt_func_call(audit_integrality(problem_ptr, assignment));
     const auto& objective_variables    = problem_ptr->vars_with_objective_coeffs.first;
     const auto& objective_coefficients = problem_ptr->vars_with_objective_coeffs.second;
     cuopt_assert(objective_variables.size() == objective_coefficients.size(),

--- a/cpp/src/mip_heuristics/solution_publication.cuh
+++ b/cpp/src/mip_heuristics/solution_publication.cuh
@@ -1,0 +1,182 @@
+/* clang-format off */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* clang-format on */
+
+#pragma once
+
+#include <cuopt/mathematical_optimization/mip/solver_settings.hpp>
+#include <cuopt/mathematical_optimization/mip/solver_stats.hpp>
+#include <cuopt/mathematical_optimization/utilities/internals.hpp>
+
+#include <mip_heuristics/presolve/semi_continuous.cuh>
+#include <mip_heuristics/problem/problem.cuh>
+#include <mip_heuristics/utils.cuh>
+
+#include <utilities/copy_helpers.hpp>
+#include <utilities/logger.hpp>
+
+#include <thrust/iterator/permutation_iterator.h>
+#include <raft/core/handle.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace cuopt::mathematical_optimization::mip {
+
+// Single point at which MIP incumbents are reported to the user get-solution callbacks.
+// The heuristic thread (through the population) and the branch-and-bound thread both publish
+// here, so the guard on the last published objective is shared and every incumbent is reported
+// once, at the moment it is found rather than when the heuristic thread next drains its queue.
+template <typename i_t, typename f_t>
+class solution_publication_t {
+ public:
+  solution_publication_t(const mip_solver_settings_t<i_t, f_t>& settings,
+                         const solver_stats_t<i_t, f_t>& stats)
+    : settings_(settings), stats_(stats)
+  {
+    if (has_get_solution_callback()) {
+      RAFT_CUDA_TRY(cudaGetDevice(&device_id_));
+      handle_ = std::make_unique<raft::handle_t>();
+    }
+  }
+
+  // Whether any get-solution callback is registered. Callers can use this to skip assembling
+  // the host assignment that publish_if_better would otherwise discard.
+  bool enabled() const { return handle_ != nullptr; }
+
+  void set_published_floor(f_t solver_objective)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    best_published_objective_ = solver_objective;
+  }
+
+  // `assignment` and `solver_objective` are in problem_ptr's solver space, which is always
+  // oriented as a minimization. Returns whether the incumbent was published.
+  //
+  // Post-processing runs on a private stream, so this is safe to call from the branch-and-bound
+  // thread while the heuristic thread owns problem_ptr->handle_ptr's stream.
+  bool publish_if_better(problem_t<i_t, f_t>* problem_ptr,
+                         const std::vector<f_t>& assignment,
+                         f_t solver_objective)
+  {
+    if (handle_ == nullptr) { return false; }
+    cuopt_assert(problem_ptr != nullptr, "Publication problem pointer must not be null");
+    cuopt_assert(std::isfinite(solver_objective), "Published objective must be finite");
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    cuopt_assert(assignment.size() == (size_t)problem_ptr->n_variables,
+                 "Published assignment size must match the problem");
+    cuopt_func_call(audit_integrality(problem_ptr, assignment));
+    const auto& objective_variables    = problem_ptr->vars_with_objective_coeffs.first;
+    const auto& objective_coefficients = problem_ptr->vars_with_objective_coeffs.second;
+    cuopt_assert(objective_variables.size() == objective_coefficients.size(),
+                 "Objective support size mismatch");
+    [[maybe_unused]] const f_t reported_objective = solver_objective;
+    solver_objective                              = compensated_dot2(
+      objective_coefficients.data(),
+      thrust::make_permutation_iterator(assignment.data(), objective_variables.data()),
+      objective_variables.size());
+    cuopt_assert(std::isfinite(solver_objective), "Recomputed objective must be finite");
+    cuopt_assert(std::abs(solver_objective - reported_objective) <=
+                   f_t{1e-4} * std::max(f_t{1}, std::abs(solver_objective)),
+                 "published objective disagrees with the assignment it accompanies");
+
+    if (!(solver_objective < best_published_objective_)) { return false; }
+    best_published_objective_ = solver_objective;
+
+    const auto user_assignment = build_user_assignment(problem_ptr, assignment);
+    const f_t user_objective   = problem_ptr->get_user_obj_from_solver_obj(solver_objective);
+    const f_t user_bound       = stats_.get_solution_bound();
+    CUOPT_LOG_DEBUG(
+      "Publishing incumbent: objective %g, %lu variables", user_objective, user_assignment.size());
+
+    for (auto callback : settings_.get_mip_callbacks()) {
+      if (callback == nullptr ||
+          callback->get_type() != internals::base_solution_callback_type::GET_SOLUTION) {
+        continue;
+      }
+      // Each callback gets its own copies: the interface hands out mutable pointers.
+      std::vector<f_t> callback_assignment(user_assignment);
+      std::vector<f_t> callback_objective(1, user_objective);
+      std::vector<f_t> callback_bound(1, user_bound);
+      auto get_sol_callback = static_cast<internals::get_solution_callback_t*>(callback);
+      get_sol_callback->get_solution(callback_assignment.data(),
+                                     callback_objective.data(),
+                                     callback_bound.data(),
+                                     get_sol_callback->get_user_data());
+    }
+    return true;
+  }
+
+ private:
+  void audit_integrality(problem_t<i_t, f_t>* problem_ptr, const std::vector<f_t>& assignment)
+  {
+    // The B&B thread may never have selected a device of its own.
+    RAFT_CUDA_TRY(cudaSetDevice(device_id_));
+    const auto integer_variables =
+      cuopt::host_copy(problem_ptr->integer_indices, handle_->get_stream());
+    for (i_t variable : integer_variables) {
+      const f_t value = assignment[variable];
+      if (value == std::round(value)) continue;
+      CUOPT_LOG_DEBUG(
+        "Publishing incumbent: integer variable %d holds %.17g", (int)variable, (double)value);
+      cuopt_assert(false, "published integer variable is not exactly integral");
+      return;
+    }
+  }
+
+  // Lifts a solver-space assignment into the space the callbacks were set up for.
+  std::vector<f_t> build_user_assignment(problem_t<i_t, f_t>* problem_ptr,
+                                         const std::vector<f_t>& assignment)
+  {
+    // The B&B thread may never have selected a device of its own.
+    RAFT_CUDA_TRY(cudaSetDevice(device_id_));
+    auto stream = handle_->get_stream();
+    rmm::device_uvector<f_t> d_assignment(assignment.size(), stream);
+    raft::copy(d_assignment.data(), assignment.data(), assignment.size(), stream);
+    // post_process_assignment writes through problem_ptr->presolve_data.fixed_var_assignment,
+    // which both publishing threads share: the caller's lock is what keeps them apart.
+    problem_ptr->post_process_assignment(d_assignment, true, stream);
+    if (problem_ptr->has_papilo_presolve_data()) {
+      problem_ptr->papilo_uncrush_assignment(d_assignment, stream);
+    }
+    auto user_assignment = cuopt::host_copy(d_assignment, stream);
+    if (mip_solver_settings_accessor<i_t, f_t>::has_semi_continuous_callback_translation(
+          settings_)) {
+      strip_semi_continuous_auxiliaries_from_assignment(
+        user_assignment,
+        mip_solver_settings_accessor<i_t, f_t>::get_semi_continuous_original_num_variables(
+          settings_));
+    }
+    return user_assignment;
+  }
+
+  bool has_get_solution_callback() const
+  {
+    for (auto callback : settings_.get_mip_callbacks()) {
+      if (callback != nullptr &&
+          callback->get_type() == internals::base_solution_callback_type::GET_SOLUTION) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const mip_solver_settings_t<i_t, f_t>& settings_;
+  const solver_stats_t<i_t, f_t>& stats_;
+  int device_id_{0};
+  // Null when no get-solution callback is registered, which also disables publication.
+  std::unique_ptr<raft::handle_t> handle_;
+  std::mutex mutex_;
+  f_t best_published_objective_{std::numeric_limits<f_t>::max()};
+};
+
+}  // namespace cuopt::mathematical_optimization::mip

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -234,7 +234,11 @@ mip_solution_t<i_t, f_t> run_mip_solver(
     // It will be converted to the target solver-space at each consumption point.
     solver.context.initial_upper_bound          = initial_upper_bound;
     solver.context.initial_incumbent_assignment = initial_incumbent_assignment;
-    solver.context.symmetry                     = std::move(symmetry);
+    if (std::isfinite(initial_upper_bound)) {
+      solver.context.solution_publication.set_published_floor(
+        solver.context.problem_ptr->get_solver_obj_from_user_obj(initial_upper_bound));
+    }
+    solver.context.symmetry = std::move(symmetry);
     if (timer.check_time_limit()) {
       CUOPT_LOG_INFO("Time limit reached before main solve");
       mip::solution_t<i_t, f_t> sol(problem);

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -896,6 +896,14 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
       op_problem.get_handle_ptr()->get_stream()};
   }
 
+  // catch problem representation troubles early
+  try {
+    problem_checking_t<i_t, f_t>::check_problem_representation(op_problem);
+  } catch (const cuopt::logic_error& e) {
+    CUOPT_LOG_ERROR("Error in solve_mip: %s", e.what());
+    return mip_solution_t<i_t, f_t>{e, op_problem.get_handle_ptr()->get_stream()};
+  }
+
   // Run a very short burst of CPUFJ during the few dozen of milliseconds at solver init for very
   // small instances
   std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_heuristics;

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -904,6 +904,13 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
     return mip_solution_t<i_t, f_t>{e, op_problem.get_handle_ptr()->get_stream()};
   }
 
+  // Check for crossing bounds before the pre_solve_heuristics try to build a problem_t
+  if (problem_checking_t<i_t, f_t>::has_crossing_bounds(op_problem)) {
+    return mip_solution_t<i_t, f_t>(mip_termination_status_t::Infeasible,
+                                    solver_stats_t<i_t, f_t>{},
+                                    op_problem.get_handle_ptr()->get_stream());
+  }
+
   // Run a very short burst of CPUFJ during the few dozen of milliseconds at solver init for very
   // small instances
   std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_heuristics;

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -373,7 +373,7 @@ template <typename i_t, typename f_t>
 mip_solution_t<i_t, f_t> solve_mip_helper(
   optimization_problem_t<i_t, f_t>& op_problem,
   mip_solver_settings_t<i_t, f_t> const& settings_const,
-  const std::shared_ptr<mip::early_cpufj_t<i_t, f_t>>& pre_solve_probe)
+  const std::shared_ptr<mip::early_cpufj_t<i_t, f_t>>& pre_solve_heuristics)
 {
   try {
     mip_solver_settings_t<i_t, f_t> settings(settings_const);
@@ -407,7 +407,7 @@ mip_solution_t<i_t, f_t> solve_mip_helper(
 
     print_version_info();
 
-    if (pre_solve_probe) { pre_solve_probe->stop(); }
+    if (pre_solve_heuristics) { pre_solve_heuristics->stop(); }
 
     raft::common::nvtx::range fun_scope("Running solver");
     auto timer = timer_t(time_limit);
@@ -532,14 +532,10 @@ mip_solution_t<i_t, f_t> solve_mip_helper(
     std::vector<f_t> early_best_user_assignment;
     std::mutex early_callback_mutex;
 
-    // The probe published its incumbent already; adopt it as the early-heuristic best so the
-    // heuristics started below do not republish worse points, and so it reaches the initial
-    // bound and the end-of-solve fallback. Its solver space is op_problem's, matching
-    // early_best_objective.
-    if (pre_solve_probe && pre_solve_probe->solution_found()) {
-      early_best_user_obj        = pre_solve_probe->get_best_user_objective();
-      early_best_user_assignment = pre_solve_probe->get_best_assignment();
-      early_best_objective.store(pre_solve_probe->get_best_objective());
+    if (pre_solve_heuristics && pre_solve_heuristics->solution_found()) {
+      early_best_user_obj        = pre_solve_heuristics->get_best_user_objective();
+      early_best_user_assignment = pre_solve_heuristics->get_best_assignment();
+      early_best_objective.store(pre_solve_heuristics->get_best_objective());
     }
 
     std::unique_ptr<mip::early_cpufj_t<i_t, f_t>> early_cpufj;
@@ -900,7 +896,8 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
       op_problem.get_handle_ptr()->get_stream()};
   }
 
-  std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_probe;
+  // Run a very short burst of CPUFJ during the few dozen of milliseconds at solver init for very small instances
+  std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_heuristics;
   // Semi-continuous variables are only reformulated once solve_mip_helper is under way, so the
   // probe would search a relaxation that admits 0 < x < L and report it as an incumbent.
   if (settings_const.determinism_mode != CUOPT_MODE_DETERMINISTIC &&
@@ -912,7 +909,7 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
     for (auto callback : settings_const.get_mip_callbacks()) {
       callback->template setup<f_t>(op_problem.get_n_variables());
     }
-    pre_solve_probe = std::make_shared<mip::early_cpufj_t<i_t, f_t>>(
+    pre_solve_heuristics = std::make_shared<mip::early_cpufj_t<i_t, f_t>>(
       op_problem,
       settings_const.get_tolerances(),
       [mip_callbacks = settings_const.get_mip_callbacks(),
@@ -928,10 +925,10 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
           std::chrono::duration<double>(std::chrono::steady_clock::now() - probe_start).count());
       },
       mip::derive_seed(settings_const.seed, mip::rng_id_t::early_cpufj));
-    pre_solve_probe->start();
+    pre_solve_heuristics->start();
   }
-  cuopt::scope_guard release_probe([&pre_solve_probe] {
-    if (pre_solve_probe) { pre_solve_probe->stop(); }
+  cuopt::scope_guard release_probe([&pre_solve_heuristics] {
+    if (pre_solve_heuristics) { pre_solve_heuristics->stop(); }
   });
 
   mip_solution_t<i_t, f_t> sol(mip_termination_status_t::NoTermination,
@@ -946,12 +943,12 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
 
   // Creates the OpenMP thread pool. It will be shared across the entire MIP solver.
 #pragma omp parallel num_threads(num_threads) default(none) \
-  shared(sol, op_problem, settings_const, exception, pre_solve_probe)
+  shared(sol, op_problem, settings_const, exception, pre_solve_heuristics)
   {
 #pragma omp masked
     {
       try {
-        sol = solve_mip_helper<i_t, f_t>(op_problem, settings_const, pre_solve_probe);
+        sol = solve_mip_helper<i_t, f_t>(op_problem, settings_const, pre_solve_heuristics);
       } catch (const std::exception& e) {
         CUOPT_LOG_ERROR("Exception in MIP OpenMP region: %s", e.what());
         exception = std::current_exception();

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -29,6 +29,7 @@
 #include <pdlp/utils.cuh>
 #include <utilities/copy_helpers.hpp>
 #include <utilities/logger.hpp>
+#include <utilities/scope_guard.hpp>
 #include <utilities/version_info.hpp>
 
 #include <cuopt/mathematical_optimization/backend_selection.hpp>
@@ -64,6 +65,7 @@
 #include <cuda_profiler_api.h>
 #include <omp.h>
 
+#include <chrono>
 #include <cmath>
 #include <mutex>
 #include <sstream>
@@ -368,8 +370,10 @@ mip_solution_t<i_t, f_t> run_mip_solver(
 }
 
 template <typename i_t, typename f_t>
-mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_problem,
-                                          mip_solver_settings_t<i_t, f_t> const& settings_const)
+mip_solution_t<i_t, f_t> solve_mip_helper(
+  optimization_problem_t<i_t, f_t>& op_problem,
+  mip_solver_settings_t<i_t, f_t> const& settings_const,
+  const std::shared_ptr<mip::early_cpufj_t<i_t, f_t>>& pre_solve_probe)
 {
   try {
     mip_solver_settings_t<i_t, f_t> settings(settings_const);
@@ -402,6 +406,8 @@ mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_p
     init_handler(op_problem.get_handle_ptr());
 
     print_version_info();
+
+    if (pre_solve_probe) { pre_solve_probe->stop(); }
 
     raft::common::nvtx::range fun_scope("Running solver");
     auto timer = timer_t(time_limit);
@@ -525,6 +531,16 @@ mip_solution_t<i_t, f_t> solve_mip_helper(optimization_problem_t<i_t, f_t>& op_p
     f_t early_best_user_obj{std::numeric_limits<f_t>::infinity()};
     std::vector<f_t> early_best_user_assignment;
     std::mutex early_callback_mutex;
+
+    // The probe published its incumbent already; adopt it as the early-heuristic best so the
+    // heuristics started below do not republish worse points, and so it reaches the initial
+    // bound and the end-of-solve fallback. Its solver space is op_problem's, matching
+    // early_best_objective.
+    if (pre_solve_probe && pre_solve_probe->solution_found()) {
+      early_best_user_obj        = pre_solve_probe->get_best_user_objective();
+      early_best_user_assignment = pre_solve_probe->get_best_assignment();
+      early_best_objective.store(pre_solve_probe->get_best_objective());
+    }
 
     std::unique_ptr<mip::early_cpufj_t<i_t, f_t>> early_cpufj;
     std::unique_ptr<mip::early_gpufj_t<i_t, f_t>> early_gpufj;
@@ -884,6 +900,40 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
       op_problem.get_handle_ptr()->get_stream()};
   }
 
+  std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_probe;
+  // Semi-continuous variables are only reformulated once solve_mip_helper is under way, so the
+  // probe would search a relaxation that admits 0 < x < L and report it as an incumbent.
+  if (settings_const.determinism_mode != CUOPT_MODE_DETERMINISTIC &&
+      op_problem.get_problem_category() != problem_category_t::LP &&
+      op_problem.get_n_constraints() > 0 && !op_problem.has_semi_continuous_variables()) {
+    // The probe publishes before solve_mip_helper reaches its own setup() loop, and get_solution
+    // consumers size their view from n_variables. setup() only stores it, so the later call is a
+    // repeated store of the same count: no reformulation has run on either side of it.
+    for (auto callback : settings_const.get_mip_callbacks()) {
+      callback->template setup<f_t>(op_problem.get_n_variables());
+    }
+    pre_solve_probe = std::make_shared<mip::early_cpufj_t<i_t, f_t>>(
+      op_problem,
+      settings_const.get_tolerances(),
+      [mip_callbacks = settings_const.get_mip_callbacks(),
+       no_bound      = op_problem.get_sense() ? (f_t)1e20 : (f_t)-1e20,
+       probe_start   = std::chrono::steady_clock::now()](
+        f_t, f_t user_obj, const std::vector<f_t>& assignment, const char* heuristic_name) {
+        std::vector<f_t> user_assignment = assignment;
+        invoke_solution_callbacks(mip_callbacks, false, 0, user_obj, user_assignment, no_bound);
+        CUOPT_LOG_INFO(
+          "New solution from early primal heuristics (%s). Objective %+.6e. Time %.3f",
+          heuristic_name,
+          user_obj,
+          std::chrono::duration<double>(std::chrono::steady_clock::now() - probe_start).count());
+      },
+      mip::derive_seed(settings_const.seed, mip::rng_id_t::early_cpufj));
+    pre_solve_probe->start();
+  }
+  cuopt::scope_guard release_probe([&pre_solve_probe] {
+    if (pre_solve_probe) { pre_solve_probe->stop(); }
+  });
+
   mip_solution_t<i_t, f_t> sol(mip_termination_status_t::NoTermination,
                                solver_stats_t<i_t, f_t>{},
                                op_problem.get_handle_ptr()->get_stream());
@@ -896,12 +946,12 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
 
   // Creates the OpenMP thread pool. It will be shared across the entire MIP solver.
 #pragma omp parallel num_threads(num_threads) default(none) \
-  shared(sol, op_problem, settings_const, exception)
+  shared(sol, op_problem, settings_const, exception, pre_solve_probe)
   {
 #pragma omp masked
     {
       try {
-        sol = solve_mip_helper<i_t, f_t>(op_problem, settings_const);
+        sol = solve_mip_helper<i_t, f_t>(op_problem, settings_const, pre_solve_probe);
       } catch (const std::exception& e) {
         CUOPT_LOG_ERROR("Exception in MIP OpenMP region: %s", e.what());
         exception = std::current_exception();

--- a/cpp/src/mip_heuristics/solve.cu
+++ b/cpp/src/mip_heuristics/solve.cu
@@ -896,7 +896,8 @@ mip_solution_t<i_t, f_t> solve_mip(optimization_problem_t<i_t, f_t>& op_problem,
       op_problem.get_handle_ptr()->get_stream()};
   }
 
-  // Run a very short burst of CPUFJ during the few dozen of milliseconds at solver init for very small instances
+  // Run a very short burst of CPUFJ during the few dozen of milliseconds at solver init for very
+  // small instances
   std::shared_ptr<mip::early_cpufj_t<i_t, f_t>> pre_solve_heuristics;
   // Semi-continuous variables are only reformulated once solve_mip_helper is under way, so the
   // probe would search a relaxation that admits 0 < x < L and report it as an incumbent.

--- a/cpp/src/mip_heuristics/solver.cu
+++ b/cpp/src/mip_heuristics/solver.cu
@@ -308,8 +308,6 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
   mip::mip_status_t branch_and_bound_status = mip::mip_status_t::UNSET;
   user_problem_t<i_t, f_t> branch_and_bound_problem(context.problem_ptr->handle_ptr);
   context.problem_ptr->recompute_objective_integrality();
-  // Re-derived here because the call above is the last thing that moves the solver space, and the
-  // floor set before presolve is expressed in the space that preceded it.
   if (std::isfinite(context.initial_upper_bound)) {
     context.solution_publication.set_published_floor(
       context.problem_ptr->get_solver_obj_from_user_obj(context.initial_upper_bound));

--- a/cpp/src/mip_heuristics/solver.cu
+++ b/cpp/src/mip_heuristics/solver.cu
@@ -70,6 +70,10 @@ struct branch_and_bound_solution_helper_t {
 
   void solution_callback(std::vector<f_t>& solution, f_t objective)
   {
+    if (dm->context.settings.determinism_mode == CUOPT_MODE_OPPORTUNISTIC) {
+      dm->context.solution_publication.publish_if_better(
+        dm->context.problem_ptr, solution, objective);
+    }
     dm->population.add_external_solution(solution, objective, solution_origin_t::BRANCH_AND_BOUND);
   }
 
@@ -198,12 +202,8 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
   if (context.problem_ptr->empty) {
     CUOPT_LOG_INFO("Problem fully reduced in presolve");
     sol.set_problem_fully_reduced();
-    for (auto callback : context.settings.get_mip_callbacks()) {
-      if (callback->get_type() == internals::base_solution_callback_type::GET_SOLUTION) {
-        auto get_sol_callback = static_cast<internals::get_solution_callback_t*>(callback);
-        dm.population.invoke_get_solution_callback(sol, get_sol_callback);
-      }
-    }
+    context.solution_publication.publish_if_better(
+      context.problem_ptr, sol.get_host_assignment(), sol.get_objective());
     context.problem_ptr->post_process_solution(sol);
     return sol;
   }
@@ -248,12 +248,8 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
   if (run_presolve && context.problem_ptr->empty) {
     CUOPT_LOG_INFO("Problem full reduced in presolve");
     sol.set_problem_fully_reduced();
-    for (auto callback : context.settings.get_mip_callbacks()) {
-      if (callback->get_type() == internals::base_solution_callback_type::GET_SOLUTION) {
-        auto get_sol_callback = static_cast<internals::get_solution_callback_t*>(callback);
-        dm.population.invoke_get_solution_callback(sol, get_sol_callback);
-      }
-    }
+    context.solution_publication.publish_if_better(
+      context.problem_ptr, sol.get_host_assignment(), sol.get_objective());
     context.problem_ptr->post_process_solution(sol);
     return sol;
   }
@@ -284,12 +280,8 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
       sol.set_problem_fully_reduced();
     }
     if (opt_sol.get_termination_status() == pdlp_termination_status_t::Optimal) {
-      for (auto callback : context.settings.get_mip_callbacks()) {
-        if (callback->get_type() == internals::base_solution_callback_type::GET_SOLUTION) {
-          auto get_sol_callback = static_cast<internals::get_solution_callback_t*>(callback);
-          dm.population.invoke_get_solution_callback(sol, get_sol_callback);
-        }
-      }
+      context.solution_publication.publish_if_better(
+        context.problem_ptr, sol.get_host_assignment(), sol.get_objective());
     }
     context.problem_ptr->post_process_solution(sol);
     return sol;
@@ -316,6 +308,12 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
   mip::mip_status_t branch_and_bound_status = mip::mip_status_t::UNSET;
   user_problem_t<i_t, f_t> branch_and_bound_problem(context.problem_ptr->handle_ptr);
   context.problem_ptr->recompute_objective_integrality();
+  // Re-derived here because the call above is the last thing that moves the solver space, and the
+  // floor set before presolve is expressed in the space that preceded it.
+  if (std::isfinite(context.initial_upper_bound)) {
+    context.solution_publication.set_published_floor(
+      context.problem_ptr->get_solver_obj_from_user_obj(context.initial_upper_bound));
+  }
   if (context.settings.objective_step) { context.problem_ptr->compute_objective_step(); }
   if (context.problem_ptr->is_objective_integral()) {
     CUOPT_LOG_INFO("Objective function is integral, scale %g",
@@ -455,11 +453,11 @@ solution_t<i_t, f_t> mip_solver_t<i_t, f_t>::run_solver()
     if (context.settings.determinism_mode == CUOPT_MODE_OPPORTUNISTIC) {
       branch_and_bound->set_concurrent_lp_root_solve(true);
 
-      context.problem_ptr->branch_and_bound_callback =
-        std::bind(&mip::branch_and_bound_t<i_t, f_t>::set_solution_from_heuristics,
-                  branch_and_bound.get(),
-                  std::placeholders::_1,
-                  std::placeholders::_2);
+      context.problem_ptr->branch_and_bound_callback = [bb = branch_and_bound.get()](
+                                                         const std::vector<f_t>& solution,
+                                                         heuristics_origin_t origin) {
+        return bb->set_solution_from_heuristics(solution, origin);
+      };
     } else if (context.settings.determinism_mode == CUOPT_MODE_DETERMINISTIC) {
       branch_and_bound->set_concurrent_lp_root_solve(false);
       // TODO once deterministic GPU heuristics are integrated

--- a/cpp/src/mip_heuristics/solver_context.cuh
+++ b/cpp/src/mip_heuristics/solver_context.cuh
@@ -10,6 +10,7 @@
 #include <mip_heuristics/mip_constants.hpp>
 #include <mip_heuristics/problem/problem.cuh>
 #include <mip_heuristics/relaxed_lp/lp_state.cuh>
+#include <mip_heuristics/solution_publication.cuh>
 #include <utilities/work_limit_context.hpp>
 #include <utilities/work_unit_scheduler.hpp>
 
@@ -68,6 +69,8 @@ struct mip_solver_context_t {
   // Base seed, all random number generators derive a seed and strem from it.
   const uint64_t base_seed;
   solver_stats_t<i_t, f_t> stats;
+  // Every incumbent reported to the user goes through here, from whichever thread found it.
+  solution_publication_t<i_t, f_t> solution_publication{settings, stats};
   // Work limit context for tracking work units in deterministic mode (shared across all timers in
   // GPU heuristic loop)
   work_limit_context_t gpu_heur_loop{"GPUHeur"};

--- a/cpp/src/mip_heuristics/utils.cuh
+++ b/cpp/src/mip_heuristics/utils.cuh
@@ -11,6 +11,7 @@
 #include <thrust/logical.h>
 #include <thrust/transform_reduce.h>
 #include <cuopt/error.hpp>
+#include <mip_heuristics/utils.hpp>
 #include <pdlp/utils.cuh>
 #include <raft/random/rng_device.cuh>
 #include <random>
@@ -18,6 +19,8 @@
 #include <utilities/hashing.hpp>
 
 #include <cuopt/mathematical_optimization/mip/solver_settings.hpp>
+
+#include <cmath>
 
 #pragma once
 

--- a/cpp/src/mip_heuristics/utils.hpp
+++ b/cpp/src/mip_heuristics/utils.hpp
@@ -1,0 +1,46 @@
+/* clang-format off */
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* clang-format on */
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+
+#ifdef __CUDACC__
+#define CUOPT_MIP_HOST_DEVICE inline __host__ __device__
+#else
+#define CUOPT_MIP_HOST_DEVICE inline
+#endif
+
+namespace cuopt::mathematical_optimization::mip {
+
+// Ogita-Rump-Oishi Dot2. TwoProduct recovers the rounding of each coefficient-value product, which
+// a compensated summation over already-multiplied terms cannot see.
+// https://epubs.siam.org/doi/abs/10.1137/030601818
+template <typename UIt, typename VIt>
+__attribute__((optimize("no-fast-math"))) CUOPT_MIP_HOST_DEVICE auto compensated_dot2(UIt u_it,
+                                                                                      VIt v_it,
+                                                                                      std::size_t n)
+{
+  using f_t = decltype(u_it[0] * v_it[0]);
+  f_t p     = 0;
+  f_t s     = 0;
+  for (std::size_t k = 0; k < n; ++k) {
+    const f_t u = u_it[k];
+    const f_t v = v_it[k];
+    const f_t h = u * v;
+    const f_t t = p + h;
+    const f_t z = t - p;
+    s += ((p - (t - z)) + (h - z)) + fma(u, v, -h);
+    p = t;
+  }
+  return p + s;
+}
+
+}  // namespace cuopt::mathematical_optimization::mip
+
+#undef CUOPT_MIP_HOST_DEVICE

--- a/cpp/src/pdlp/cpu_optimization_problem.cpp
+++ b/cpp/src/pdlp/cpu_optimization_problem.cpp
@@ -45,6 +45,13 @@ problem_category_t problem_category_from_variable_types(const std::vector<var_t>
   return problem_category_t::LP;
 }
 
+bool has_semi_continuous_from_variable_types(const std::vector<var_t>& variable_types)
+{
+  return std::any_of(variable_types.begin(), variable_types.end(), [](var_t v) {
+    return v == var_t::SEMI_CONTINUOUS;
+  });
+}
+
 }  // namespace
 
 // ==============================================================================
@@ -232,7 +239,8 @@ void cpu_optimization_problem_t<i_t, f_t>::set_variable_types(const var_t* varia
   variable_types_.resize(size);
   std::copy(variable_types, variable_types + size, variable_types_.begin());
 
-  problem_category_ = problem_category_from_variable_types(variable_types_);
+  problem_category_              = problem_category_from_variable_types(variable_types_);
+  has_semi_continuous_variables_ = has_semi_continuous_from_variable_types(variable_types_);
 }
 
 template <typename i_t, typename f_t>
@@ -511,6 +519,12 @@ template <typename i_t, typename f_t>
 problem_category_t cpu_optimization_problem_t<i_t, f_t>::get_problem_category() const
 {
   return problem_category_;
+}
+
+template <typename i_t, typename f_t>
+bool cpu_optimization_problem_t<i_t, f_t>::has_semi_continuous_variables() const noexcept
+{
+  return has_semi_continuous_variables_;
 }
 
 template <typename i_t, typename f_t>
@@ -1171,7 +1185,8 @@ void cpu_optimization_problem_t<i_t, f_t>::adopt_from_mps_data_model(
   for (size_t i = 0; i < model.var_types_.size(); ++i) {
     variable_types_[i] = char_to_var_type(model.var_types_[i]);
   }
-  problem_category_ = problem_category_from_variable_types(variable_types_);
+  problem_category_              = problem_category_from_variable_types(variable_types_);
+  has_semi_continuous_variables_ = has_semi_continuous_from_variable_types(variable_types_);
 
   if (model.has_quadratic_constraints()) {
     move_quadratic_constraints_from_model(*this, model.quadratic_constraints_);

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -54,6 +54,8 @@
 
 namespace cuopt::mathematical_optimization {
 
+constexpr size_t host_variable_type_summary_limit = 50'000;
+
 template <typename i_t, typename f_t>
 optimization_problem_t<i_t, f_t>::optimization_problem_t(raft::handle_t const* handle_ptr)
   : handle_ptr_(handle_ptr),
@@ -101,6 +103,7 @@ optimization_problem_t<i_t, f_t>::optimization_problem_t(
     objective_name_{other.get_objective_name()},
     problem_name_{other.get_problem_name()},
     problem_category_{other.get_problem_category()},
+    has_semi_continuous_variables_{other.has_semi_continuous_variables()},
     var_names_{other.get_variable_names()},
     row_names_{other.get_row_names()},
     quadratic_constraints_{other.get_quadratic_constraints()}
@@ -285,14 +288,39 @@ void optimization_problem_t<i_t, f_t>::set_variable_types(const var_t* variable_
   variable_types_.resize(size, stream_view_);
   raft::copy(variable_types_.data(), variable_types, size, stream_view_);
 
-  // Auto-detect problem category based on variable types.
+  // Auto-detect problem category and cache presence of SEMI_CONTINUOUS vars.
   // SEMI_CONTINUOUS vars will be reformulated into binary + continuous before solving,
   // so a problem with only SC vars is treated as MIP.
-  i_t n_discrete = thrust::count_if(
-    handle_ptr_->get_thrust_policy(),
-    variable_types_.begin(),
-    variable_types_.end(),
-    [] __device__(auto val) { return val == var_t::INTEGER || val == var_t::SEMI_CONTINUOUS; });
+  // Prefer host-side for small instances to reduce latency between launch and first-feasible.
+  i_t n_discrete                     = 0;
+  bool has_semi_continuous_variables = false;
+  if ((size_t)size < host_variable_type_summary_limit) {
+    const auto h_variable_types = cuopt::host_copy(variable_types_, stream_view_);
+    for (const var_t val : h_variable_types) {
+      if (val == var_t::SEMI_CONTINUOUS) {
+        has_semi_continuous_variables = true;
+        ++n_discrete;
+      } else if (val == var_t::INTEGER) {
+        ++n_discrete;
+      }
+    }
+  } else {
+    auto is_discrete = [] __host__ __device__(var_t val) {
+      return val == var_t::INTEGER || val == var_t::SEMI_CONTINUOUS;
+    };
+    auto is_semi_continuous = [] __host__ __device__(var_t val) {
+      return val == var_t::SEMI_CONTINUOUS;
+    };
+    n_discrete                    = thrust::count_if(handle_ptr_->get_thrust_policy(),
+                                  variable_types_.begin(),
+                                  variable_types_.end(),
+                                  is_discrete);
+    has_semi_continuous_variables = thrust::count_if(handle_ptr_->get_thrust_policy(),
+                                                     variable_types_.begin(),
+                                                     variable_types_.end(),
+                                                     is_semi_continuous) > 0;
+  }
+  has_semi_continuous_variables_ = has_semi_continuous_variables;
   if (n_discrete == size) {
     problem_category_ = problem_category_t::IP;
   } else if (n_discrete > 0) {
@@ -578,6 +606,12 @@ template <typename i_t, typename f_t>
 problem_category_t optimization_problem_t<i_t, f_t>::get_problem_category() const
 {
   return problem_category_;
+}
+
+template <typename i_t, typename f_t>
+bool optimization_problem_t<i_t, f_t>::has_semi_continuous_variables() const noexcept
+{
+  return has_semi_continuous_variables_;
 }
 
 template <typename i_t, typename f_t>

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -305,20 +305,18 @@ void optimization_problem_t<i_t, f_t>::set_variable_types(const var_t* variable_
       }
     }
   } else {
-    auto is_discrete = [] __host__ __device__(var_t val) {
-      return val == var_t::INTEGER || val == var_t::SEMI_CONTINUOUS;
-    };
-    auto is_semi_continuous = [] __host__ __device__(var_t val) {
-      return val == var_t::SEMI_CONTINUOUS;
-    };
     n_discrete                    = thrust::count_if(handle_ptr_->get_thrust_policy(),
                                   variable_types_.begin(),
                                   variable_types_.end(),
-                                  is_discrete);
+                                  [] __host__ __device__(var_t val) {
+                                    return val == var_t::INTEGER || val == var_t::SEMI_CONTINUOUS;
+                                  });
     has_semi_continuous_variables = thrust::count_if(handle_ptr_->get_thrust_policy(),
                                                      variable_types_.begin(),
                                                      variable_types_.end(),
-                                                     is_semi_continuous) > 0;
+                                      [] __host__ __device__(var_t val) {
+                                      return val == var_t::SEMI_CONTINUOUS;
+                                    }) > 0;
   }
   has_semi_continuous_variables_ = has_semi_continuous_variables;
   if (n_discrete == size) {

--- a/cpp/src/pdlp/optimization_problem.cu
+++ b/cpp/src/pdlp/optimization_problem.cu
@@ -305,6 +305,8 @@ void optimization_problem_t<i_t, f_t>::set_variable_types(const var_t* variable_
       }
     }
   } else {
+    assert(handle_ptr_ != nullptr);
+
     n_discrete                    = thrust::count_if(handle_ptr_->get_thrust_policy(),
                                   variable_types_.begin(),
                                   variable_types_.end(),
@@ -314,9 +316,9 @@ void optimization_problem_t<i_t, f_t>::set_variable_types(const var_t* variable_
     has_semi_continuous_variables = thrust::count_if(handle_ptr_->get_thrust_policy(),
                                                      variable_types_.begin(),
                                                      variable_types_.end(),
-                                      [] __host__ __device__(var_t val) {
-                                      return val == var_t::SEMI_CONTINUOUS;
-                                    }) > 0;
+                                                     [] __host__ __device__(var_t val) {
+                                                       return val == var_t::SEMI_CONTINUOUS;
+                                                     }) > 0;
   }
   has_semi_continuous_variables_ = has_semi_continuous_variables;
   if (n_discrete == size) {

--- a/cpp/src/utilities/version_info.cpp
+++ b/cpp/src/utilities/version_info.cpp
@@ -213,7 +213,7 @@ static const char* get_simd_target()
 {
   const int64_t target = hwy::DispatchedTarget();
   switch (target) {
-    // AVX-512 is a much more commonly understood name than AVX3 or AVX10.2 
+    // AVX-512 is a much more commonly understood name than AVX3 or AVX10.2
     case HWY_AVX3:
     case HWY_AVX3_DL:
     case HWY_AVX3_ZEN4:

--- a/cpp/src/utilities/version_info.cpp
+++ b/cpp/src/utilities/version_info.cpp
@@ -26,8 +26,6 @@
 
 namespace cuopt {
 
-// Reads up to buf_size-1 bytes, NUL-terminates, strips trailing whitespace/NULs.
-// Returns bytes kept (excluding the terminator), or -1 on failure.
 static ssize_t read_file_buf(const char* path, char* buf, size_t buf_size)
 {
   if (buf_size == 0) return -1;
@@ -110,7 +108,7 @@ static void mark_cpus_from_list(const char* list, char visited[CPU_SETSIZE])
   }
 }
 
-// CPUs this process may run on (respects Slurm/cgroup cpusets, taskset, etc.).
+// CPUs this process may run on (respects slurm/cgroup cpusets, taskset, etc)
 static int get_allowed_cpus(int* cpus, int max_cpus)
 {
   cpu_set_t set;
@@ -215,6 +213,7 @@ static const char* get_simd_target()
 {
   const int64_t target = hwy::DispatchedTarget();
   switch (target) {
+    // AVX-512 is a much more commonly understood name than AVX3 or AVX10.2 
     case HWY_AVX3:
     case HWY_AVX3_DL:
     case HWY_AVX3_ZEN4:

--- a/cpp/src/utilities/version_info.cpp
+++ b/cpp/src/utilities/version_info.cpp
@@ -12,135 +12,216 @@
 #include <utilities/build_info.hpp>
 #include <utilities/logger.hpp>
 
-#include <fstream>
-#include <iomanip>
-#include <set>
-#include <sstream>
-#include <string>
-#include <thread>
+#include <hwy/per_target.h>
+#include <hwy/targets.h>
+
+#include <fcntl.h>
+#include <sched.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 namespace cuopt {
 
-static int get_physical_cores()
+// Reads up to buf_size-1 bytes, NUL-terminates, strips trailing whitespace/NULs.
+// Returns bytes kept (excluding the terminator), or -1 on failure.
+static ssize_t read_file_buf(const char* path, char* buf, size_t buf_size)
 {
-  std::ifstream cpuinfo("/proc/cpuinfo");
-  if (!cpuinfo.is_open()) return 0;
+  if (buf_size == 0) return -1;
+  const int fd = open(path, O_RDONLY);
+  if (fd < 0) return -1;
+  const ssize_t n = read(fd, buf, buf_size - 1);
+  close(fd);
+  if (n < 0) return -1;
+  buf[n] = '\0';
 
-  std::string line;
-  int physical_id = -1, core_id = -1;
-  std::set<std::pair<int, int>> cores;
-
-  while (std::getline(cpuinfo, line)) {
-    if (line.find("physical id") != std::string::npos) {
-      physical_id = std::stoi(line.substr(line.find(":") + 1));
-    } else if (line.find("core id") != std::string::npos) {
-      core_id = std::stoi(line.substr(line.find(":") + 1));
-    }
-
-    if (physical_id != -1 && core_id != -1) {
-      cores.insert({physical_id, core_id});
-      physical_id = -1;
-      core_id     = -1;
-    }
+  // Device-tree properties are often NUL-terminated without a trailing newline.
+  size_t len = 0;
+  while (len < (size_t)n && buf[len] != '\0') {
+    ++len;
   }
+  buf[len] = '\0';
+  while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r' || buf[len - 1] == ' ' ||
+                     buf[len - 1] == '\t')) {
+    buf[--len] = '\0';
+  }
+  return (ssize_t)len;
+}
 
-  if (cores.empty()) {
-    cpuinfo.clear();
-    cpuinfo.seekg(0);
-    while (std::getline(cpuinfo, line)) {
-      if (line.find("cpu cores") != std::string::npos) {
-        return std::stoi(line.substr(line.find(":") + 1));
+// Parses a kernel CPU list ("0-3,8,10-11") into cpus[0..max_cpus). Returns count written.
+static int parse_cpu_list(const char* list, int* cpus, int max_cpus)
+{
+  int count     = 0;
+  const char* p = list;
+  while (*p && count < max_cpus) {
+    while (*p == ',' || *p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') {
+      ++p;
+    }
+    if (*p == '\0') break;
+
+    char* end     = nullptr;
+    const long lo = std::strtol(p, &end, 10);
+    if (end == p) break;
+    p = end;
+
+    if (*p == '-') {
+      ++p;
+      const long hi = std::strtol(p, &end, 10);
+      if (end == p) break;
+      p = end;
+      for (long cpu = lo; cpu <= hi && count < max_cpus; ++cpu) {
+        cpus[count++] = (int)cpu;
       }
-    }
-    return 1;
-  }
-  return cores.size();
-}
-
-static std::string get_cpu_model_from_proc()
-{
-  std::ifstream cpuinfo("/proc/cpuinfo");
-  if (!cpuinfo.is_open()) return "";
-
-  std::string line;
-  while (std::getline(cpuinfo, line)) {
-    std::size_t pos = line.find("model name");
-    if (pos == std::string::npos) pos = line.find("Processor");
-    if (pos != std::string::npos) {
-      std::size_t colon = line.find(':', pos);
-      if (colon != std::string::npos) return line.substr(colon + 2);  // Skip ": "
+    } else {
+      cpus[count++] = (int)lo;
     }
   }
-  return "";
+  return count;
 }
 
-// From https://gcc.gnu.org/onlinedocs/gcc/x86-Built-in-Functions.html
-// Also supported by clang
-static std::string get_cpu_model_builtin()
+static void mark_cpus_from_list(const char* list, char visited[CPU_SETSIZE])
 {
-#if (defined(__x86_64__) || defined(__i386__)) && (defined(__GNUC__) || defined(__clang__))
-  __builtin_cpu_init();
-  return __builtin_cpu_is("amd")               ? "AMD CPU"
-         : __builtin_cpu_is("intel")           ? "Intel CPU"
-         : __builtin_cpu_is("atom")            ? "Intel Atom CPU"
-         : __builtin_cpu_is("slm")             ? "Intel Silvermont CPU"
-         : __builtin_cpu_is("core2")           ? "Intel Core 2 CPU"
-         : __builtin_cpu_is("corei7")          ? "Intel Core i7 CPU"
-         : __builtin_cpu_is("nehalem")         ? "Intel Core i7 Nehalem CPU"
-         : __builtin_cpu_is("westmere")        ? "Intel Core i7 Westmere CPU"
-         : __builtin_cpu_is("sandybridge")     ? "Intel Core i7 Sandy Bridge CPU"
-         : __builtin_cpu_is("ivybridge")       ? "Intel Core i7 Ivy Bridge CPU"
-         : __builtin_cpu_is("haswell")         ? "Intel Core i7 Haswell CPU"
-         : __builtin_cpu_is("broadwell")       ? "Intel Core i7 Broadwell CPU"
-         : __builtin_cpu_is("skylake")         ? "Intel Core i7 Skylake CPU"
-         : __builtin_cpu_is("skylake-avx512")  ? "Intel Core i7 Skylake AVX512 CPU"
-         : __builtin_cpu_is("cannonlake")      ? "Intel Core i7 Cannon Lake CPU"
-         : __builtin_cpu_is("icelake-client")  ? "Intel Core i7 Ice Lake Client CPU"
-         : __builtin_cpu_is("icelake-server")  ? "Intel Core i7 Ice Lake Server CPU"
-         : __builtin_cpu_is("cascadelake")     ? "Intel Core i7 Cascadelake CPU"
-         : __builtin_cpu_is("tigerlake")       ? "Intel Core i7 Tigerlake CPU"
-         : __builtin_cpu_is("cooperlake")      ? "Intel Core i7 Cooperlake CPU"
-         : __builtin_cpu_is("sapphirerapids")  ? "Intel Core i7 sapphirerapids CPU"
-         : __builtin_cpu_is("alderlake")       ? "Intel Core i7 Alderlake CPU"
-         : __builtin_cpu_is("rocketlake")      ? "Intel Core i7 Rocketlake CPU"
-         : __builtin_cpu_is("graniterapids")   ? "Intel Core i7 graniterapids CPU"
-         : __builtin_cpu_is("graniterapids-d") ? "Intel Core i7 graniterapids D CPU"
-         : __builtin_cpu_is("bonnell")         ? "Intel Atom Bonnell CPU"
-         : __builtin_cpu_is("silvermont")      ? "Intel Atom Silvermont CPU"
-         : __builtin_cpu_is("goldmont")        ? "Intel Atom Goldmont CPU"
-         : __builtin_cpu_is("goldmont-plus")   ? "Intel Atom Goldmont Plus CPU"
-         : __builtin_cpu_is("tremont")         ? "Intel Atom Tremont CPU"
-         : __builtin_cpu_is("sierraforest")    ? "Intel Atom Sierra Forest CPU"
-         : __builtin_cpu_is("grandridge")      ? "Intel Atom Grand Ridge CPU"
-         : __builtin_cpu_is("amdfam10h")       ? "AMD Family 10h CPU"
-         : __builtin_cpu_is("barcelona")       ? "AMD Family 10h Barcelona CPU"
-         : __builtin_cpu_is("shanghai")        ? "AMD Family 10h Shanghai CPU"
-         : __builtin_cpu_is("istanbul")        ? "AMD Family 10h Istanbul CPU"
-         : __builtin_cpu_is("btver1")          ? "AMD Family 14h CPU"
-         : __builtin_cpu_is("amdfam15h")       ? "AMD Family 15h CPU"
-         : __builtin_cpu_is("bdver1")          ? "AMD Family 15h Bulldozer version 1"
-         : __builtin_cpu_is("bdver2")          ? "AMD Family 15h Bulldozer version 2"
-         : __builtin_cpu_is("bdver3")          ? "AMD Family 15h Bulldozer version 3"
-         : __builtin_cpu_is("bdver4")          ? "AMD Family 15h Bulldozer version 4"
-         : __builtin_cpu_is("btver2")          ? "AMD Family 16h CPU"
-         : __builtin_cpu_is("amdfam17h")       ? "AMD Family 17h CPU"
-         : __builtin_cpu_is("znver1")          ? "AMD Family 17h Zen version 1"
-         : __builtin_cpu_is("znver2")          ? "AMD Family 17h Zen version 2"
-         : __builtin_cpu_is("amdfam19h")       ? "AMD Family 19h CPU"
-                                               : "Unknown";
-#else
-  return "Unknown";
-#endif
-}
+  const char* p = list;
+  while (*p) {
+    while (*p == ',' || *p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') {
+      ++p;
+    }
+    if (*p == '\0') break;
 
-static std::string get_cpu_model()
-{
-  if (auto model_from_proc = get_cpu_model_from_proc(); !model_from_proc.empty()) {
-    return model_from_proc;
-  } else if (auto model_from_builtin = get_cpu_model_builtin(); !model_from_builtin.empty()) {
-    return model_from_builtin;
+    char* end     = nullptr;
+    const long lo = std::strtol(p, &end, 10);
+    if (end == p) break;
+    p = end;
+
+    if (*p == '-') {
+      ++p;
+      const long hi = std::strtol(p, &end, 10);
+      if (end == p) break;
+      p = end;
+      for (long cpu = lo; cpu <= hi; ++cpu) {
+        if (cpu >= 0 && cpu < CPU_SETSIZE) { visited[cpu] = 1; }
+      }
+    } else if (lo >= 0 && lo < CPU_SETSIZE) {
+      visited[lo] = 1;
+    }
   }
-  return "Unknown";
+}
+
+// CPUs this process may run on (respects Slurm/cgroup cpusets, taskset, etc.).
+static int get_allowed_cpus(int* cpus, int max_cpus)
+{
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  int count = 0;
+  if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+    for (int cpu = 0; cpu < CPU_SETSIZE && count < max_cpus; ++cpu) {
+      if (CPU_ISSET(cpu, &set)) { cpus[count++] = cpu; }
+    }
+  }
+  if (count > 0) return count;
+
+  char buf[256];
+  if (read_file_buf("/sys/devices/system/cpu/online", buf, sizeof(buf)) < 0) return 0;
+  return parse_cpu_list(buf, cpus, max_cpus);
+}
+
+static int get_physical_cores(const int* allowed_cpus, int allowed_count)
+{
+  if (allowed_count <= 0) return 0;
+
+  char visited[CPU_SETSIZE];
+  std::memset(visited, 0, sizeof(visited));
+  int cores = 0;
+
+  for (int i = 0; i < allowed_count; ++i) {
+    const int cpu = allowed_cpus[i];
+    if (cpu < 0 || cpu >= CPU_SETSIZE || visited[cpu]) continue;
+
+    char path[128];
+    char buf[256];
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/topology/core_cpus_list", cpu);
+    ssize_t n = read_file_buf(path, buf, sizeof(buf));
+    if (n < 0) {
+      snprintf(
+        path, sizeof(path), "/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu);
+      n = read_file_buf(path, buf, sizeof(buf));
+    }
+
+    if (n >= 0) { mark_cpus_from_list(buf, visited); }
+    visited[cpu] = 1;
+    ++cores;
+  }
+
+  return cores > 0 ? cores : allowed_count;
+}
+
+static bool copy_stripped(char* dst, size_t dst_size, const char* src)
+{
+  if (dst_size == 0) return false;
+  size_t len = std::strlen(src);
+  while (len > 0 && (src[len - 1] == '\n' || src[len - 1] == '\r' || src[len - 1] == ' ')) {
+    --len;
+  }
+  if (len >= dst_size) len = dst_size - 1;
+  std::memcpy(dst, src, len);
+  dst[len] = '\0';
+  return len > 0;
+}
+
+static bool get_cpu_model_from_proc(char* out, size_t out_size)
+{
+  FILE* cpuinfo = fopen("/proc/cpuinfo", "r");
+  if (cpuinfo == nullptr) return false;
+
+  char line[512];
+  while (fgets(line, sizeof(line), cpuinfo) != nullptr) {
+    const char* field = std::strstr(line, "model name");
+    if (field == nullptr) field = std::strstr(line, "Processor");
+    if (field == nullptr) continue;
+
+    const char* colon = std::strchr(field, ':');
+    if (colon == nullptr) continue;
+    ++colon;
+    while (*colon == ' ' || *colon == '\t') {
+      ++colon;
+    }
+    const bool ok = copy_stripped(out, out_size, colon);
+    fclose(cpuinfo);
+    return ok;
+  }
+  fclose(cpuinfo);
+  return false;
+}
+
+static void get_cpu_model(char* out, size_t out_size)
+{
+  if (get_cpu_model_from_proc(out, out_size)) return;
+
+  char buf[256];
+  if (read_file_buf("/sys/firmware/devicetree/base/model", buf, sizeof(buf)) >= 0 ||
+      read_file_buf("/proc/device-tree/model", buf, sizeof(buf)) >= 0) {
+    if (copy_stripped(out, out_size, buf)) return;
+  }
+  if (read_file_buf("/sys/devices/virtual/dmi/id/product_name", buf, sizeof(buf)) >= 0) {
+    if (copy_stripped(out, out_size, buf)) return;
+  }
+  std::snprintf(out, out_size, "Unknown");
+}
+
+static const char* get_simd_target()
+{
+  const int64_t target = hwy::DispatchedTarget();
+  switch (target) {
+    case HWY_AVX3:
+    case HWY_AVX3_DL:
+    case HWY_AVX3_ZEN4:
+    case HWY_AVX3_SPR:
+    case HWY_AVX10_2: return "AVX-512";
+    default: return hwy::TargetName(target);
+  }
 }
 
 struct host_memory_info_t {
@@ -150,26 +231,28 @@ struct host_memory_info_t {
 
 static host_memory_info_t get_host_memory_info()
 {
-  std::ifstream meminfo("/proc/meminfo");
-  if (!meminfo.is_open()) return {};
+  FILE* meminfo = fopen("/proc/meminfo", "r");
+  if (meminfo == nullptr) return {};
 
-  std::string line;
+  char line[256];
   long total_kb     = 0;
   long available_kb = 0;
   long free_kb      = 0;
-  while (std::getline(meminfo, line)) {
-    std::istringstream fields(line);
-    std::string key;
+  int found         = 0;
+  while (found < 3 && fgets(line, sizeof(line), meminfo) != nullptr) {
     long value_kb = 0;
-    fields >> key >> value_kb;
-    if (key == "MemTotal:") {
+    if (std::sscanf(line, "MemTotal: %ld", &value_kb) == 1) {
       total_kb = value_kb;
-    } else if (key == "MemAvailable:") {
+      ++found;
+    } else if (std::sscanf(line, "MemAvailable: %ld", &value_kb) == 1) {
       available_kb = value_kb;
-    } else if (key == "MemFree:") {
+      ++found;
+    } else if (std::sscanf(line, "MemFree: %ld", &value_kb) == 1) {
       free_kb = value_kb;
+      ++found;
     }
   }
+  fclose(meminfo);
 
   if (available_kb == 0) { available_kb = free_kb; }
   constexpr double kb_per_gib = 1024.0 * 1024.0;
@@ -193,14 +276,19 @@ void print_version_info(int num_devices)
                  CUOPT_GIT_COMMIT_HASH,
                  CUOPT_CPU_ARCHITECTURE,
                  CUOPT_CUDA_ARCHITECTURES);
+
   const auto memory = get_host_memory_info();
-  CUOPT_LOG_INFO(
-    "CPU: %s, threads (physical/logical): %d/%d, RAM (available/total): %.2f / %.2f GiB",
-    get_cpu_model().c_str(),
-    get_physical_cores(),
-    std::thread::hardware_concurrency(),
-    memory.available_gb,
-    memory.total_gb);
+  int allowed_cpus[CPU_SETSIZE];
+  const int allowed_count = get_allowed_cpus(allowed_cpus, CPU_SETSIZE);
+  char cpu_model[256];
+  get_cpu_model(cpu_model, sizeof(cpu_model));
+  CUOPT_LOG_INFO("CPU: %s, threads: %dC/%dT, RAM usage: %.2f/%.2fGiB",
+                 cpu_model,
+                 get_physical_cores(allowed_cpus, allowed_count),
+                 allowed_count,
+                 std::max(0.0, memory.total_gb - memory.available_gb),
+                 memory.total_gb);
+  CUOPT_LOG_INFO("CPU SIMD target: %s", get_simd_target());
 
   for (int device_id = 0; device_id < num_devices; ++device_id) {
     cudaDeviceProp device_prop{};

--- a/cpp/tests/utilities/test_cli.cpp
+++ b/cpp/tests/utilities/test_cli.cpp
@@ -108,7 +108,7 @@ TEST_F(cli_test_t, basic_usage)
   std::string content((std::istreambuf_iterator<char>(sol)), std::istreambuf_iterator<char>());
   EXPECT_TRUE(content.find("Status:") != std::string::npos);
   EXPECT_TRUE(content.find("Objective value:") != std::string::npos);
-  EXPECT_TRUE(output.find("RAM (available/total):") != std::string::npos);
+  EXPECT_TRUE(output.find("RAM usage:") != std::string::npos);
 }
 
 TEST_F(cli_test_t, with_initial_solution)

--- a/thirdparty/THIRD_PARTY_LICENSES
+++ b/thirdparty/THIRD_PARTY_LICENSES
@@ -597,3 +597,217 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------------------------------------------------------------------------------------
+
+== highway Apache-2.0
+
+Files: cpp/build/_deps/highway-src
+
+Copyright (c) The Highway Project Authors. All rights reserved.
+
+Highway is dual-licensed under the Apache License 2.0 or the BSD 3-Clause License;
+cuOpt elects the Apache License 2.0, reproduced below.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
This PR introduces changes to improve the latency to the first incumbent, along with a unified solution publication object to ensure user callbacks receive a new incumbent as soon as it is found.

Also included are scaffolding changes to prepare for the coming CPUFJ primal integral improvements:

- Highway (SIMD library) integration + THIRD-PARTY-LICENCE changes
- run_mip.cpp harness changes to log incumbents as received by the user callback
- Common util functions (e.g. numerically compensated dot product)

This PR will be the first of a series of 4-5 PRs destined to merge the primal integral improvements into main.
Benchmarks pending

## Description
<!-- Add brief description here -->

## Issue
<!-- Add closes #ISSUE_NUMBER here, this would close the issue once PR is merged, if there is no issue, please feel free to remove this section -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cuopt/blob/HEAD/CONTRIBUTING.md).
- Testing
   - [ ] New or existing tests cover these changes
   - [ ] Added tests
   - [ ] Created an issue to follow-up
   - [ ] NA
- Documentation
   - [ ] The documentation is up to date with these changes
   - [ ] Added new documentation
   - [ ] NA
