### PR TITLE
Bump cuopt-java compile target from Java 11 to Java 17

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -295,7 +295,7 @@ dependencies:
       - output_types: conda
         packages:
           - maven
-          - openjdk=11.*
+          - openjdk=17.*
   test_cpp:
     common:
       - output_types: [conda]

--- a/docs/cuopt/source/cuopt-java/quick-start.rst
+++ b/docs/cuopt/source/cuopt-java/quick-start.rst
@@ -11,7 +11,7 @@ Requirements
 
 The Java module requires:
 
-* Java 11 or newer, with ``JAVA_HOME`` pointing to a JDK;
+* Java 17 or newer, with ``JAVA_HOME`` pointing to a JDK;
 * a C++20 compiler;
 * an existing cuOpt installation containing ``libcuopt.so``; and
 * a CUDA-enabled runtime for solving problems.
@@ -24,7 +24,7 @@ the JNI library. The standalone native build links to
 .. code-block:: bash
 
    cd /path/to/cuopt/java/cuopt
-   export JAVA_HOME=/path/to/jdk-11
+   export JAVA_HOME=/path/to/jdk-17
    export CUOPT_PREFIX=/path/to/cuopt/conda/environment
    bash scripts/build_native.sh
 
@@ -45,7 +45,7 @@ at the directory containing the built native library:
 .. code-block:: bash
 
    cd java/cuopt
-   export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+   export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
    export CUOPT_PREFIX=/path/to/cuopt/conda/environment
    export LD_LIBRARY_PATH=$CUOPT_PREFIX/targets/x86_64-linux/lib:$CUOPT_PREFIX/lib:build/native
    mvn test -Dcuopt.native.dir=build/native
@@ -55,7 +55,7 @@ The helper script combines the native build and Maven test steps:
 .. code-block:: bash
 
    cd /path/to/cuopt/java/cuopt
-   export JAVA_HOME=/path/to/jdk-11
+   export JAVA_HOME=/path/to/jdk-17
    export CUOPT_PREFIX=/path/to/cuopt/conda/environment
    bash scripts/test.sh
 

--- a/java/cuopt/README.md
+++ b/java/cuopt/README.md
@@ -30,7 +30,7 @@ CUOPT_PREFIX=/path/to/cuopt/conda/environment bash scripts/test.sh
 ```
 
 `build_native.sh` builds `libcuopt_jni.so` in `build/native`. `test.sh` builds
-that library and runs the Maven tests. Java 11 or newer and a C++20 compiler
+that library and runs the Maven tests. Java 17 or newer and a C++20 compiler
 are required. Native solve tests require a CUDA driver and skip automatically
 when one is unavailable.
 

--- a/java/cuopt/TESTS.md
+++ b/java/cuopt/TESTS.md
@@ -20,7 +20,7 @@ Build the JNI library and run all Java tests with:
 
 ```bash
 cd /path/to/cuopt/java/cuopt
-export JAVA_HOME=/path/to/jdk-11
+export JAVA_HOME=/path/to/jdk-17
 export CUOPT_PREFIX=/path/to/cuopt/conda/environment
 bash scripts/test.sh
 ```

--- a/java/cuopt/pom.xml
+++ b/java/cuopt/pom.xml
@@ -40,7 +40,7 @@ SPDX-License-Identifier: Apache-2.0
   </scm>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.jupiter.version>5.11.4</junit.jupiter.version>
   </properties>

--- a/java/cuopt/scripts/java_home.sh
+++ b/java/cuopt/scripts/java_home.sh
@@ -15,7 +15,7 @@ cuopt_java_setup_home() {
   fi
 
   if [[ ! -x "${JAVA_HOME:-}/bin/${required_binary}" ]]; then
-    echo "JAVA_HOME must point to a JDK containing bin/${required_binary} (Java 11 is required)." >&2
+    echo "JAVA_HOME must point to a JDK containing bin/${required_binary} (Java 17 is required)." >&2
     exit 1
   fi
 }

--- a/java/cuopt/scripts/java_home.sh
+++ b/java/cuopt/scripts/java_home.sh
@@ -4,6 +4,7 @@
 
 cuopt_java_setup_home() {
   local required_binary="${1:-javac}"
+  local required_major_version=17
 
   if [[ -z "${JAVA_HOME:-}" ]]; then
     local javac_path
@@ -15,7 +16,25 @@ cuopt_java_setup_home() {
   fi
 
   if [[ ! -x "${JAVA_HOME:-}/bin/${required_binary}" ]]; then
-    echo "JAVA_HOME must point to a JDK containing bin/${required_binary} (Java 17 is required)." >&2
+    echo "JAVA_HOME must point to a JDK containing bin/${required_binary} (Java ${required_major_version} or newer is required)." >&2
+    exit 1
+  fi
+
+  # java -version prints "17.0.20" or the older "1.8.0_292" scheme; normalize
+  # both to a bare major version before comparing.
+  local version_line version_string major_version
+  version_line="$("${JAVA_HOME}/bin/java" -version 2>&1 | head -n1)"
+  version_string="$(printf '%s\n' "${version_line}" | sed -n 's/.*version "\([^"]*\)".*/\1/p')"
+  if [[ "${version_string}" == 1.* ]]; then
+    major_version="${version_string#1.}"
+    major_version="${major_version%%.*}"
+  else
+    major_version="${version_string%%.*}"
+    major_version="${major_version%%-*}"
+  fi
+
+  if [[ ! "${major_version}" =~ ^[0-9]+$ ]] || (( major_version < required_major_version )); then
+    echo "JAVA_HOME (${JAVA_HOME}) reports '${version_line}', but Java ${required_major_version} or newer is required." >&2
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary
- `java/cuopt/pom.xml` compiled against `maven.compiler.release=11`, but the JNI bindings were hand-written specifically to support Java 17 (see the rationale comment already in `cuopt_jni.cpp`, which also notes moving to the FFM API and Java 22 is tracked in #1794). This aligns the actual compile target with that documented intent.
- Updates the CI conda `openjdk` pin (`dependencies.yaml`, `java` file-key) from 11 to 17, and the `JAVA_HOME`/error-message references in `java_home.sh`, `README.md`, `TESTS.md`, and `docs/cuopt/source/cuopt-java/quick-start.rst`.
- cuopt-java is still experimental/unpublished (no Maven Central release yet), so this is a build-target change only — no external consumers are affected today.

Note: this raises the floor — a JVM cannot run bytecode compiled at a higher `--release` than itself, so this drops support for Java 11 runtimes in favor of Java 17+. No downstream consumer requiring <17 was found referenced anywhere in the repo.

## Test plan
- [x] `mvn -DskipTests compile` succeeds with `JAVA_HOME` pointed at a JDK 17 install
- [x] Verified compiled class file major version is 61 (Java 17) via `javap -verbose`
- [ ] CI: `java-build` / `conda-java-tests` workflows pass with the updated `openjdk=17.*` pin