### PR TITLE
[TEST] Use system GNU libgomp instead of bundled LLVM libomp for libcuopt wheel

### DIFF
--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -28,13 +28,29 @@ fi
 # Install Protobuf + gRPC (protoc + grpc_cpp_plugin)
 bash ci/utils/install_protobuf_grpc.sh
 
-# EXPERIMENT: use the toolset's GNU libgomp instead of bundling LLVM libomp, to test whether
-# the constraint that motivated the LLVM switch (an outdated system GCC/libgomp on the Rocky
-# Linux wheel build image) still holds now that the build already requires a GCC new enough
-# for C++20. Matching the system libgomp also matches what cuDSS's threading layer
-# (libcudss_mtlayer_gomp.so.0) loads at runtime, avoiding a dual-OpenMP-runtime conflict.
-# See https://github.com/NVIDIA/cuopt/issues/1219
-export SKBUILD_CMAKE_ARGS=""
+# EXPERIMENT (#1219): use GNU libgomp instead of bundling LLVM libomp, to test whether the
+# constraint that motivated the LLVM switch in #1429 still holds. It doesn't fully: GNU
+# libgomp has implemented the OpenMP 5.0 detached-task runtime (omp_fulfill_event) that the
+# fast MPS parser needs since GCC 9, but the *default* '-lgomp' resolution on the Rocky Linux
+# 8 wheel build image picks up the base OS's pre-5.0 libgomp rather than the SCL gcc-toolset
+# compiler's own newer one. Resolve a libgomp.so that actually exports the symbol we need,
+# the same way the (now-removed) LLVM libomp override resolved a concrete versioned ELF file
+# instead of trusting default discovery.
+LIBGOMP_LIBRARY="$(
+    { ldconfig -p | awk '$1 ~ /^libgomp\.so(\.[0-9]+)*$/ { print $NF }'
+      find /opt/rh /usr -name 'libgomp.so.1*' 2>/dev/null
+    } | sort -u | while read -r candidate; do
+        nm -D "${candidate}" 2>/dev/null | grep -q ' T omp_fulfill_event$' && echo "${candidate}" && break
+    done
+)" || true
+if [[ "${LIBGOMP_LIBRARY}" != /* || ! -f "${LIBGOMP_LIBRARY}" ]]; then
+    echo "Could not resolve a GNU libgomp with OpenMP 5.0 detached-task support (omp_fulfill_event)" >&2
+    exit 1
+fi
+
+echo "Using GNU libgomp runtime: ${LIBGOMP_LIBRARY}"
+
+export SKBUILD_CMAKE_ARGS="-DOpenMP_gomp_LIBRARY:FILEPATH=${LIBGOMP_LIBRARY}"
 
 # OpenSSL 3 hints for libcuopt's own find_package(OpenSSL).
 #

--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -36,10 +36,20 @@ bash ci/utils/install_protobuf_grpc.sh
 # compiler's own newer one. Resolve a libgomp.so that actually exports the symbol we need,
 # the same way the (now-removed) LLVM libomp override resolved a concrete versioned ELF file
 # instead of trusting default discovery.
-LIBGOMP_LIBRARY="$(
+LIBGOMP_CANDIDATES="$(
     { ldconfig -p | awk '$1 ~ /^libgomp\.so(\.[0-9]+)*$/ { print $NF }'
       find /opt/rh /usr -name 'libgomp.so.1*' 2>/dev/null
-    } | sort -u | while read -r candidate; do
+    } | sort -u
+)"
+echo "libgomp candidates found:" >&2
+echo "${LIBGOMP_CANDIDATES}" >&2
+for candidate in ${LIBGOMP_CANDIDATES}; do
+    echo "--- nm -D ${candidate} | grep omp_fulfill_event ---" >&2
+    nm -D "${candidate}" 2>&1 | grep -i omp_fulfill_event >&2 || echo "(no match; nm exit $?)" >&2
+done
+
+LIBGOMP_LIBRARY="$(
+    for candidate in ${LIBGOMP_CANDIDATES}; do
         nm -D "${candidate}" 2>/dev/null | grep -qE ' T omp_fulfill_event(@|$)' && echo "${candidate}" && break
     done
 )" || true

--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -40,7 +40,7 @@ LIBGOMP_LIBRARY="$(
     { ldconfig -p | awk '$1 ~ /^libgomp\.so(\.[0-9]+)*$/ { print $NF }'
       find /opt/rh /usr -name 'libgomp.so.1*' 2>/dev/null
     } | sort -u | while read -r candidate; do
-        nm -D "${candidate}" 2>/dev/null | grep -q ' T omp_fulfill_event$' && echo "${candidate}" && break
+        nm -D "${candidate}" 2>/dev/null | grep -qE ' T omp_fulfill_event(@|$)' && echo "${candidate}" && break
     done
 )" || true
 if [[ "${LIBGOMP_LIBRARY}" != /* || ! -f "${LIBGOMP_LIBRARY}" ]]; then

--- a/ci/build_wheel_libcuopt.sh
+++ b/ci/build_wheel_libcuopt.sh
@@ -17,34 +17,24 @@ fi
 # Install Boost and TBB
 bash ci/utils/install_boost_tbb.sh
 
-# Install libuuid and LLVM's OpenMP runtime
+# Install libuuid (needed by cuopt_grpc_server)
 if command -v dnf &> /dev/null; then
-    # LLVM Toolset is distributed as a module on Rocky/RHEL 8.
-    dnf module install -y llvm-toolset
-    dnf install -y libuuid-devel libomp-devel
+    dnf install -y libuuid-devel
 elif command -v apt-get &> /dev/null; then
     apt-get update
-    apt-get install -y uuid-dev libomp-dev
+    apt-get install -y uuid-dev
 fi
 
 # Install Protobuf + gRPC (protoc + grpc_cpp_plugin)
 bash ci/utils/install_protobuf_grpc.sh
 
-# Compile with GCC, but use LLVM libomp as the OpenMP runtime bundled in the wheel. Resolve the
-# versioned ELF library rather than an unversioned linker script or compiler-toolset indirection.
-LIBOMP_LIBRARY="$(
-    ldconfig -p |
-        awk '$1 ~ /^libomp\.so(\.[0-9]+)*$/ && !library { library = $NF }
-             END { print library }'
-)"
-if [[ "${LIBOMP_LIBRARY}" != /* || ! -f "${LIBOMP_LIBRARY}" ]]; then
-    echo "Could not resolve the LLVM OpenMP runtime: '${LIBOMP_LIBRARY}'" >&2
-    exit 1
-fi
-
-echo "Using LLVM OpenMP runtime: ${LIBOMP_LIBRARY}"
-
-export SKBUILD_CMAKE_ARGS="-DOpenMP_gomp_LIBRARY:FILEPATH=${LIBOMP_LIBRARY}"
+# EXPERIMENT: use the toolset's GNU libgomp instead of bundling LLVM libomp, to test whether
+# the constraint that motivated the LLVM switch (an outdated system GCC/libgomp on the Rocky
+# Linux wheel build image) still holds now that the build already requires a GCC new enough
+# for C++20. Matching the system libgomp also matches what cuDSS's threading layer
+# (libcudss_mtlayer_gomp.so.0) loads at runtime, avoiding a dual-OpenMP-runtime conflict.
+# See https://github.com/NVIDIA/cuopt/issues/1219
+export SKBUILD_CMAKE_ARGS=""
 
 # OpenSSL 3 hints for libcuopt's own find_package(OpenSSL).
 #
@@ -114,6 +104,10 @@ EXCLUDE_ARGS=(
   # 22.04+, RHEL/Rocky 9+, manylinux_2_28+ with openssl3, Debian 12+).
   --exclude "libssl.so.3"
   --exclude "libcrypto.so.3"
+  # EXPERIMENT (#1219): don't bundle/hash-rename libgomp. Resolving it from the host at
+  # runtime instead keeps cuOpt on the same libgomp.so.1 instance that cuDSS's threading
+  # layer (libcudss_mtlayer_gomp.so.0) loads, instead of two independent OpenMP runtimes.
+  --exclude "libgomp.so.*"
 )
 
 ci/build_wheel.sh libcuopt ${package_dir}


### PR DESCRIPTION
## Summary

Experiment for #1219 (dual-OpenMP-runtime SIGSEGV; also relevant to #1768). The LLVM libomp switch in #1429 was a workaround for an outdated system GCC/libgomp on the Rocky Linux wheel build image. Since the build already requires a C++20-capable GCC (newer toolset via SCL), that constraint may no longer hold — worth testing directly rather than assuming.

This removes the `OpenMP_gomp_LIBRARY` override and the LLVM toolset install in `ci/build_wheel_libcuopt.sh`, letting libcuopt link the toolset's own GNU libgomp, and excludes `libgomp.so.*` from the auditwheel bundle (same treatment as OpenSSL) so it resolves from the host at runtime instead of being vendored/hash-renamed. This matches what cuDSS's `libcudss_mtlayer_gomp.so.0` already loads, eliminating the dual-runtime conflict.

Draft PR to run wheel-build/wheel-test CI and check for regressions (build success, fast MPS parser correctness/perf, sequential-solve stability) before deciding whether to land this for real.

## Test plan
- [ ] `wheel-build-libcuopt` / `wheel-build-cuopt` succeed
- [ ] `wheel-tests-cuopt` passes, including fast MPS parser tests
- [ ] Manually check the built wheel no longer bundles a hash-renamed libgomp, and only one `libgomp.so.1` is loaded at runtime alongside cuDSS