### PR TITLE
Keep permanent utils from importing the legacy HTTP runtime.

### DIFF
--- a/python/cuopt_server/cuopt_server/__init__.py
+++ b/python/cuopt_server/cuopt_server/__init__.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from cuopt_server import cuopt_service
 from cuopt_server._version import (
     __git_commit__,
     __version__,

--- a/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
+++ b/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
@@ -49,8 +49,10 @@ def _is_deprecated_import(name, file_path, utils_root):
         return True
     if not name.startswith("."):
         return False
-    rel = file_path.parent.relative_to(utils_root)
-    parts = list(rel.parts)
+    # Resolve relative to the cuopt_server package so imports that leave
+    # utils/ (e.g. from ..utils.deprecated) are still detected.
+    pkg_root = utils_root.parent
+    parts = list(file_path.parent.relative_to(pkg_root).parts)
     dots = len(name) - len(name.lstrip("."))
     remainder = name[dots:]
     up = dots - 1
@@ -60,7 +62,21 @@ def _is_deprecated_import(name, file_path, utils_root):
     target = list(base)
     if remainder:
         target.extend(p for p in remainder.split(".") if p)
-    return bool(target) and target[0] == "deprecated"
+    return (
+        len(target) >= 2 and target[0] == "utils" and target[1] == "deprecated"
+    )
+
+
+def test_relative_import_of_deprecated_is_detected():
+    utils_root = _utils_root()
+    in_utils = utils_root / "http_codec.py"
+    in_routing = utils_root / "routing" / "conversion.py"
+    assert _is_deprecated_import(".deprecated", in_utils, utils_root)
+    assert _is_deprecated_import("..utils.deprecated", in_utils, utils_root)
+    assert _is_deprecated_import(
+        "..deprecated.job_queue", in_routing, utils_root
+    )
+    assert not _is_deprecated_import("..logutil", in_utils, utils_root)
 
 
 def test_permanent_utils_do_not_import_deprecated():
@@ -76,7 +92,7 @@ def test_permanent_utils_do_not_import_deprecated():
 
 def test_importing_cuopt_server_does_not_load_legacy_service():
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(_utils_root().parents[2]) + (
+    env["PYTHONPATH"] = str(_utils_root().parents[1]) + (
         os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
     )
     probe = (

--- a/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
+++ b/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import cuopt_server.utils as utils_pkg
+
+
+def _utils_root():
+    return Path(utils_pkg.__file__).resolve().parent
+
+
+def _permanent_python_files():
+    root = _utils_root()
+    for path in root.rglob("*.py"):
+        try:
+            path.relative_to(root / "deprecated")
+        except ValueError:
+            yield path
+        else:
+            continue
+
+
+def _imported_names(tree):
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            prefix = "." * node.level
+            names.append(prefix + module)
+            for alias in node.names:
+                if module:
+                    names.append(prefix + module + "." + alias.name)
+                else:
+                    names.append(prefix + alias.name)
+    return names
+
+
+def _is_deprecated_import(name, file_path, utils_root):
+    if name.startswith("cuopt_server.utils.deprecated"):
+        return True
+    if name == "cuopt_server.utils.deprecated":
+        return True
+    if not name.startswith("."):
+        return False
+    rel = file_path.parent.relative_to(utils_root)
+    parts = list(rel.parts)
+    dots = len(name) - len(name.lstrip("."))
+    remainder = name[dots:]
+    up = dots - 1
+    if up > len(parts):
+        return False
+    base = parts[: len(parts) - up]
+    target = list(base)
+    if remainder:
+        target.extend(p for p in remainder.split(".") if p)
+    return bool(target) and target[0] == "deprecated"
+
+
+def test_permanent_utils_do_not_import_deprecated():
+    utils_root = _utils_root()
+    violations = []
+    for path in _permanent_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for name in _imported_names(tree):
+            if _is_deprecated_import(name, path, utils_root):
+                violations.append(f"{path.relative_to(utils_root)}: {name}")
+    assert violations == []
+
+
+def test_importing_cuopt_server_does_not_load_legacy_service():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_utils_root().parents[2]) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    probe = (
+        "import sys\n"
+        "import cuopt_server\n"
+        "loaded = [m for m in sys.modules if m.startswith('cuopt_server')]\n"
+        "assert 'cuopt_server.cuopt_service' not in sys.modules, loaded\n"
+        "assert not any('utils.deprecated' in m for m in sys.modules), loaded\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr

--- a/python/cuopt_server/cuopt_server/utils/deprecated/__init__.py
+++ b/python/cuopt_server/cuopt_server/utils/deprecated/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Legacy-only cuOpt HTTP server modules. Permanent utils must not import
-# this package. Deleting the old server is: remove cuopt_service.py,
-# webserver.py, this package, and tests/deprecated/.
+# this package (see tests/test_utils_deprecated_boundary.py). Deleting the
+# old server is: remove cuopt_service.py, webserver.py, this package, and
+# tests that exist only for the local job queue.


### PR DESCRIPTION
Drop the eager cuopt_service import from the package init so loading cuopt_server no longer pulls in the job queue.
Also run a test that can be removed later that ensures the new proxy server does not touch anything in the deprecated directory.
