### PR TITLE
fix(docker): keep libgomp1 in the Ubuntu runtime image (cuDSS threading layer, #1670)

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -65,10 +65,17 @@ ARG PYTHON_SHORT_VER
 
 # Install gcc (needed to build psutils), pip-install cuopt, then remove gcc
 # — all in one layer so the build-only dep never persists in the final image.
+#
+# libgomp1 is a *runtime* dependency and is installed explicitly, in the same
+# command as gcc, so that `apt-get purge --autoremove gcc` keeps it: cuDSS's
+# threading layer (libcudss_mtlayer_gomp) dlopens libgomp.so.1, and without it
+# the MIP/LP solver process dies in cudssSetThreadingLayer (status 3) as soon as
+# barrier runs — see NVIDIA/cuopt#1670. Earlier images only had libgomp1 as a
+# side effect of gcc; the purge removed it.
 RUN \
     cuda_suffix=cu$(echo ${CUDA_VER} | cut -d'.' -f1) && \
     apt-get update \
-    && apt-get install -y --no-install-recommends gcc \
+    && apt-get install -y --no-install-recommends gcc libgomp1 \
     && python -m pip install \
       --extra-index-url https://pypi.nvidia.com \
       --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \


### PR DESCRIPTION
Closes #1670.

### What happens

On the 26.08 `-cu12` / `-cu13` Ubuntu images, any LP/MIP whose root relaxation reaches the barrier method dies inside cuDSS:

    Solving LP root relaxation in concurrent mode
    ...
    FAILED: CUDSS call ended unsuccessfully with status = 3, details: "cudssSetThreadingLayer"
    INFO cuopt received signal 17
    INFO {'cuopt_complete': -1}
    INFO Starting new process with pid 155

The REST client only sees `{'error': '<id> was aborted', 'error_result': True}`. Small problems pass because dual simplex / PDLP finish the root LP before barrier initialises cuDSS; large ones fail every time. Same model, same machine, 26.04 image: fine.

### Why

cuDSS's threading layer (`libcudss_mtlayer_gomp.so`) dlopens `libgomp.so.1`, and the 26.08 image does not have it:

    $ ldd .../nvidia/cu13/lib/libcudss_mtlayer_gomp.so.0 | grep gomp
    libgomp.so.1 => not found
    $ dpkg -l libgomp1   # not installed

`ci/docker/Dockerfile` installs `gcc` to build psutil and purges it in the same layer (`apt-get purge -y --autoremove gcc`, since #1602). libgomp1 was only ever present as a dependency of gcc, so the autoremove takes it too. 26.04 had it by that side effect.

### Fix

Install `libgomp1` explicitly in the same `apt-get install` as gcc. apt then marks it as manually installed and the purge keeps it. One word in the Dockerfile plus a comment.

Verified the apt semantics on `ubuntu:24.04` (the `LINUX_VER` CI builds with):

| install | after `apt-get purge -y --autoremove gcc` |
|---|---|
| `gcc` (today) | libgomp1 gone |
| `gcc libgomp1` (this PR) | `ii libgomp1:arm64 14.2.0-4ubuntu2~24.04` |

`Dockerfile.ubi` is unchanged: UBI 10's base image already ships `libgomp` and `dnf remove gcc` leaves it in place (checked the same way).

### Testing

- The equivalent runtime fix (official 26.8.0-cu12 image + `apt-get install libgomp1`) has been running on a DGX Spark (GB10, arm64, driver 580) for a week of MIP solves — 67k-binary facility-location models, 45–300 s, REST and gRPC — with no cuDSS failure; the same models abort within a second on the unmodified image.
- I have not run the full `build_images` workflow; the change is confined to the apt line.

### Not in this PR

A failed `cudssSetThreadingLayer` currently ends the solver process. Falling back to single-threaded cuDSS would turn a missing library into a slower solve instead of an aborted job; that is a libcuopt change and out of scope here.