### PR TITLE
ci(thirdparty-cvxpy): fix cwd import-shadowing that masked the installed wheel

### DIFF
--- a/ci/thirdparty-testing/run_cvxpy_tests.sh
+++ b/ci/thirdparty-testing/run_cvxpy_tests.sh
@@ -21,11 +21,8 @@ fi
 git clone https://github.com/cvxpy/cvxpy.git
 pushd ./cvxpy || exit 1
 
-# cvxpy's native '_cvxcore' extension is compiled with the system g++ during
-# 'pip wheel' (plain setuptools Extension, not cmake/ninja/meson). Without it,
-# 'pip wheel' fails loudly (see #1747). Install it here so the build step
-# below actually produces a working extension instead of failing at import
-# time from a downstream, confusing spot.
+# cvxpy compiles its '_cvxcore' extension with g++ during 'pip wheel'; without
+# it the build fails loudly (see #1747).
 if ! command -v g++ >/dev/null 2>&1; then
     echo "g++ not found; attempting to install build-essential"
     if command -v apt-get >/dev/null 2>&1; then
@@ -44,13 +41,8 @@ pip wheel \
     -w dist \
     .
 
-# 'pip wheel' can report "Successfully built cvxpy" even when the native
-# '_cvxcore' extension failed to build or was silently skipped (e.g. cvxpy's
-# setup.py omits ext_modules entirely when the PYODIDE env var is set) --
-# there is no compile error in that case, just a wheel missing the .so.
-# Downstream that surfaces as a confusing
-# "ImportError: cannot import name '_cvxcore'" deep inside the test run, so
-# check for it explicitly and fail loudly right here instead.
+# Fail loudly here if the wheel is missing the compiled extension, rather
+# than downstream as a confusing test-time ImportError.
 cvxpy_wheel="$(echo ./dist/cvxpy*.whl)"
 if ! python -m zipfile -l "${cvxpy_wheel}" | grep -q 'cvxpy/cvxcore/python/_cvxcore.*\.so'; then
     echo "FATAL: built cvxpy wheel '${cvxpy_wheel}' does not contain a compiled"
@@ -72,6 +64,17 @@ python -m pip install \
 # ensure that environment is still consistent (i.e. cvxpy requirements do not conflict with cuopt's)
 pip check
 
+RAPIDS_TESTS_DIR="${RAPIDS_TESTS_DIR:-${PWD}/test-results}"
+mkdir -p "${RAPIDS_TESTS_DIR}"
+
+# Leave the clone: cwd is 'cvxpy/' containing a 'cvxpy/' package
+# subdirectory, and Python puts cwd first on sys.path, so importing 'cvxpy'
+# from here silently shadows the installed wheel with the uncompiled source
+# tree -- producing "ImportError: cannot import name '_cvxcore'" even on a
+# perfectly good build/install. This is the actual root cause of the
+# nightly failure fixed here.
+popd
+
 # Belt-and-braces: verify the installed cvxpy can actually load its native
 # backend before running any tests, so a broken extension fails here with a
 # clear message instead of as a wall of downstream test ImportErrors.
@@ -84,18 +87,18 @@ if ! python -c "from cvxpy.cvxcore.python.cppbackend import build_matrix" 2>"${c
 fi
 rm -f "${cvxcore_import_check_log}"
 
-RAPIDS_TESTS_DIR="${RAPIDS_TESTS_DIR:-${PWD}/test-results}"
-mkdir -p "${RAPIDS_TESTS_DIR}"
-
 echo "running 'cvxpy' tests"
 pytest_rc=0
+# --pyargs (module path, not a filesystem path) avoids pytest re-inserting
+# the clone root onto sys.path via its rootdir walk-up, which would
+# reintroduce the shadowing above even with cwd fixed.
 timeout 3m python -m pytest \
     --verbose \
     --capture=no \
     --error-for-skips \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-thirdparty-cvxpy.xml" \
     -k "TestCUOPT" \
-    ./cvxpy/tests/test_conic_solvers.py || pytest_rc=$?
+    --pyargs cvxpy.tests.test_conic_solvers || pytest_rc=$?
 
 # pytest's normal exit codes are 0-5 (passed / failed / interrupted /
 # internal error / usage / no tests collected). Anything beyond that

--- a/ci/thirdparty-testing/run_cvxpy_tests.sh
+++ b/ci/thirdparty-testing/run_cvxpy_tests.sh
@@ -20,9 +20,46 @@ fi
 
 git clone https://github.com/cvxpy/cvxpy.git
 pushd ./cvxpy || exit 1
+
+# cvxpy's native '_cvxcore' extension is compiled with the system g++ during
+# 'pip wheel' (plain setuptools Extension, not cmake/ninja/meson). Without it,
+# 'pip wheel' fails loudly (see #1747). Install it here so the build step
+# below actually produces a working extension instead of failing at import
+# time from a downstream, confusing spot.
+if ! command -v g++ >/dev/null 2>&1; then
+    echo "g++ not found; attempting to install build-essential"
+    if command -v apt-get >/dev/null 2>&1; then
+        SUDO=""
+        if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+            SUDO="sudo"
+        fi
+        ${SUDO} apt-get update -y && ${SUDO} apt-get install -y --no-install-recommends build-essential
+    else
+        echo "FATAL: no apt-get available to install a C++ compiler; cannot build cvxpy's _cvxcore extension"
+        exit 1
+    fi
+fi
+
 pip wheel \
     -w dist \
     .
+
+# 'pip wheel' can report "Successfully built cvxpy" even when the native
+# '_cvxcore' extension failed to build or was silently skipped (e.g. cvxpy's
+# setup.py omits ext_modules entirely when the PYODIDE env var is set) --
+# there is no compile error in that case, just a wheel missing the .so.
+# Downstream that surfaces as a confusing
+# "ImportError: cannot import name '_cvxcore'" deep inside the test run, so
+# check for it explicitly and fail loudly right here instead.
+cvxpy_wheel="$(echo ./dist/cvxpy*.whl)"
+if ! python -m zipfile -l "${cvxpy_wheel}" | grep -q 'cvxpy/cvxcore/python/_cvxcore.*\.so'; then
+    echo "FATAL: built cvxpy wheel '${cvxpy_wheel}' does not contain a compiled"
+    echo "       '_cvxcore' extension (.so). The build likely silently skipped"
+    echo "       compiling it -- check for a missing/broken C++ toolchain or an"
+    echo "       unexpected 'PYODIDE' env var. Wheel contents:"
+    python -m zipfile -l "${cvxpy_wheel}"
+    exit 1
+fi
 
 # NOTE: installing cvxpy[CUOPT] alongside CI artifacts is helpful to catch dependency conflicts
 echo "installing 'cvxpy' with cuopt"
@@ -30,10 +67,22 @@ python -m pip install \
     --constraint "${PIP_CONSTRAINT}" \
     --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
     'pytest-error-for-skips>=2.0.2' \
-    "$(echo ./dist/cvxpy*.whl)[CUOPT,testing]"
+    "${cvxpy_wheel}[CUOPT,testing]"
 
 # ensure that environment is still consistent (i.e. cvxpy requirements do not conflict with cuopt's)
 pip check
+
+# Belt-and-braces: verify the installed cvxpy can actually load its native
+# backend before running any tests, so a broken extension fails here with a
+# clear message instead of as a wall of downstream test ImportErrors.
+cvxcore_import_check_log="$(mktemp)"
+if ! python -c "from cvxpy.cvxcore.python.cppbackend import build_matrix" 2>"${cvxcore_import_check_log}"; then
+    echo "FATAL: installed cvxpy cannot import its '_cvxcore' native backend:"
+    cat "${cvxcore_import_check_log}"
+    rm -f "${cvxcore_import_check_log}"
+    exit 1
+fi
+rm -f "${cvxcore_import_check_log}"
 
 RAPIDS_TESTS_DIR="${RAPIDS_TESTS_DIR:-${PWD}/test-results}"
 mkdir -p "${RAPIDS_TESTS_DIR}"


### PR DESCRIPTION
Fixes the nightly `thirdparty cvxpy` failure (`ImportError: cannot import name '_cvxcore'`).

Root cause: `run_cvxpy_tests.sh` ran pytest from inside the cloned `cvxpy/` directory, so Python's cwd-first `sys.path` shadowed the installed wheel with the uncompiled source clone.

Fix: `popd` out of the clone before testing, and use `--pyargs` so pytest can't reintroduce the same shadowing via its rootdir walk-up.
