### PR TITLE
add basic http proxy server that forwards to grpc

### DIFF
--- a/python/cuopt/cuopt/grpc/client/grpc_client.pyx
+++ b/python/cuopt/cuopt/grpc/client/grpc_client.pyx
@@ -305,7 +305,7 @@ cdef class Client:
         """Create a sibling connection with the same host/port/TLS settings."""
         return Client(self._host, self._port, tls=self._tls)
 
-    def submit(self, problem, SolverSettings settings not None):
+    def submit(self, problem, SolverSettings settings not None, enable_incumbents=None):
         """
         Submit a problem for solving and return its ``job_id``.
 
@@ -313,10 +313,16 @@ cdef class Client:
         :class:`~cuopt.linear_programming.data_model.DataModel`. The job runs
         asynchronously; use :meth:`wait` or :meth:`status` to track it and
         :meth:`result` to fetch the solution. Always :meth:`delete` when done.
+
+        ``enable_incumbents`` defaults to ``None``, which enables MIP incumbent
+        collection when ``settings`` already has MIP callbacks. Pass ``True``
+        or ``False`` to override (used by the HTTP proxy, which has no local
+        callback objects).
         """
         cdef DataModel data_model
         cdef grpc_submit_result_t submit_result
         cdef bint mip
+        cdef bint enable_incumbents_flag = False
 
         data_model = self._as_data_model(problem)
         data_model.variable_types = type_cast(
@@ -325,13 +331,14 @@ cdef class Client:
         mip = _is_mip(data_model.get_variable_types())
         prepare_solver_settings(settings, data_model, mip)
         data_model.set_data_model_view()
-        cdef bint enable_incumbents = False
-        if mip and settings.get_mip_callbacks():
-            enable_incumbents = True
+        if enable_incumbents is None:
+            enable_incumbents_flag = bool(mip and settings.get_mip_callbacks())
+        else:
+            enable_incumbents_flag = bool(enable_incumbents)
         submit_result = self._client.get().submit(
             data_model.c_data_model_view.get(),
             settings.c_solver_settings.get(),
-            enable_incumbents,
+            enable_incumbents_flag,
         )
         if not submit_result.success:
             raise GrpcError(submit_result.error_message.decode("utf-8"))

--- a/python/cuopt_server/cuopt_server/cuopt_proxy.py
+++ b/python/cuopt_server/cuopt_server/cuopt_proxy.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""gRPC-backed HTTP proxy for legacy LP/MILP clients (Series C, C10).
+
+This process speaks the self-hosted HTTP API and forwards solves to
+``cuopt_grpc_server``. It does not run a local job queue or worker pool.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+
+import cuopt_server.utils.settings as settings
+from cuopt_server._version import __version__
+from cuopt_server.utils.logutil import message_init
+
+log_fmt = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
+date_fmt = "%Y-%m-%d %H:%M:%S"
+
+
+def parse_args(argv=None):
+    ip = os.environ.get("CUOPT_SERVER_IP", "0.0.0.0")
+    port = os.environ.get("CUOPT_SERVER_PORT", 8000)
+    grpc_host = os.environ.get("CUOPT_GRPC_HOST", "127.0.0.1")
+    grpc_port = os.environ.get("CUOPT_GRPC_PORT", 5001)
+    log_level = os.environ.get("CUOPT_SERVER_LOG_LEVEL", "info")
+    log_file = os.environ.get("CUOPT_SERVER_LOG_FILE", "")
+    datadir = os.environ.get("CUOPT_DATA_DIR", "")
+    resultdir = os.environ.get("CUOPT_RESULT_DIR", "")
+    maxresult = os.environ.get("CUOPT_MAX_RESULT", 250)
+    resultmode = os.environ.get("CUOPT_RESULT_MODE", "644")
+    ssl_certfile = os.environ.get("CUOPT_SSL_CERTFILE", "")
+    ssl_keyfile = os.environ.get("CUOPT_SSL_KEYFILE", "")
+
+    levels = {
+        "critical": logging.CRITICAL,
+        "error": logging.ERROR,
+        "warning": logging.WARNING,
+        "info": logging.INFO,
+        "debug": logging.DEBUG,
+    }
+
+    parser = argparse.ArgumentParser(
+        prog="cuopt_proxy",
+        description=(
+            "HTTP proxy for legacy cuOpt LP/MILP clients. "
+            "Forwards jobs to cuopt_grpc_server."
+        ),
+    )
+    parser.add_argument(
+        "-i",
+        "--ip",
+        type=str,
+        help="Bind address (CUOPT_SERVER_IP)",
+        default=ip,
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        help="HTTP listen port (CUOPT_SERVER_PORT)",
+        default=int(port),
+    )
+    parser.add_argument(
+        "--grpc-host",
+        type=str,
+        help="cuopt_grpc_server host (CUOPT_GRPC_HOST)",
+        default=grpc_host,
+    )
+    parser.add_argument(
+        "--grpc-port",
+        type=int,
+        help="cuopt_grpc_server port (CUOPT_GRPC_PORT)",
+        default=int(grpc_port),
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        type=str,
+        choices=list(levels.keys()),
+        help="Log level (CUOPT_SERVER_LOG_LEVEL)",
+        default=log_level,
+    )
+    parser.add_argument(
+        "-f",
+        "--log-file",
+        type=str,
+        help="Log filename (CUOPT_SERVER_LOG_FILE)",
+        default=log_file,
+    )
+    parser.add_argument(
+        "-d",
+        "--data-dir",
+        type=str,
+        help="CUOPT_DATA_DIR for CUOPT-DATA-FILE uploads",
+        default=datadir,
+    )
+    parser.add_argument(
+        "-r",
+        "--result-dir",
+        type=str,
+        help="CUOPT_RESULT_DIR for large result files",
+        default=resultdir,
+    )
+    parser.add_argument(
+        "-m",
+        "--max-result",
+        type=int,
+        help="Result size threshold in KB (CUOPT_MAX_RESULT)",
+        default=int(maxresult),
+    )
+    parser.add_argument(
+        "-mo",
+        "--mode",
+        type=str,
+        help="Octal mode for result files (CUOPT_RESULT_MODE)",
+        default=resultmode,
+    )
+    parser.add_argument(
+        "--ssl-certfile",
+        type=str,
+        help="SSL certificate file (CUOPT_SSL_CERTFILE)",
+        default=ssl_certfile,
+    )
+    parser.add_argument(
+        "--ssl-keyfile",
+        type=str,
+        help="SSL key file (CUOPT_SSL_KEYFILE)",
+        default=ssl_keyfile,
+    )
+    args = parser.parse_args(argv)
+    args._log_level_int = levels[args.log_level]
+    return args
+
+
+def _configure_logging(args):
+    message_init()
+    handlers = []
+    if args.log_file:
+        handlers.append(logging.FileHandler(args.log_file))
+    else:
+        handlers.append(logging.StreamHandler(sys.stdout))
+    logging.basicConfig(
+        level=args._log_level_int,
+        format=log_fmt,
+        datefmt=date_fmt,
+        handlers=handlers,
+        force=True,
+    )
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    _configure_logging(args)
+    logging.info(f"cuOpt HTTP proxy {__version__}")
+
+    if args.data_dir:
+        settings.set_data_dir(args.data_dir)
+    settings.set_result_dir(args.result_dir, args.max_result, args.mode)
+
+    from cuopt.grpc.linear_programming import Client
+
+    from cuopt_server.proxy_webserver import run_server, set_grpc_client
+
+    logging.info(
+        f"Connecting to cuopt_grpc_server at {args.grpc_host}:{args.grpc_port}"
+    )
+    set_grpc_client(Client(args.grpc_host, args.grpc_port))
+    run_server(
+        args.ip,
+        args.port,
+        args.log_level,
+        args.ssl_certfile,
+        args.ssl_keyfile,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cuopt_server/cuopt_server/proxy_webserver.py
+++ b/python/cuopt_server/cuopt_server/proxy_webserver.py
@@ -1,0 +1,752 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FastAPI app for the gRPC-backed HTTP proxy (LP/MILP, C10)."""
+
+import logging
+import os
+import threading
+import time
+import uuid
+from typing import List, Optional
+
+import uvicorn
+from fastapi import FastAPI, Header, HTTPException, Path, Query, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import Response
+from pydantic import ValidationError
+
+import cuopt_server.utils.settings as settings
+from cuopt_server._version import __version__
+from cuopt_server.utils.client_version import check_client_version
+from cuopt_server.utils.data_definition import (
+    DeleteRequestModel,
+    DeleteResponse,
+    HealthResponse,
+    IdModel,
+    IdResponse,
+    IncumbentSolution,
+    IncumbentSolutionResponse,
+    LogResponse,
+    LogResponseModel,
+    RequestResponse,
+    RequestStatusModel,
+    SolutionResponse,
+    ValidationErrorResponse,
+    lp_example_data,
+    lp_msgpack_example_data,
+    lp_zlib_example_data,
+    lpschema,
+)
+from cuopt_server.utils.exceptions import (
+    exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
+)
+from cuopt_server.utils.http_codec import (
+    deserialize,
+    encode,
+    encode_bytes,
+    get_data,
+    get_format,
+    mime_json,
+    mime_msgpack,
+    mime_pickle,
+    mime_wild,
+    mime_zlib,
+)
+from cuopt_server.utils.http_envelope import make_response
+from cuopt_server.utils.linear_programming.conversion import (
+    create_data_model,
+    create_solver,
+    solution_to_legacy_http,
+)
+from cuopt_server.utils.linear_programming.data_definition import LPData
+from cuopt_server.utils.linear_programming.data_transformation import (
+    transform_lp_data,
+)
+from cuopt_server.utils.linear_programming.data_validation import (
+    validate_LP_data,
+)
+from cuopt_server.utils.local_files import (
+    file_result_message,
+    get_output_name,
+    load_optimization_file,
+    result_meets_threshold,
+    validate_file_path,
+    write_result_file,
+)
+
+app = FastAPI(
+    title="NVIDIA cuOpt HTTP proxy",
+    version=__version__,
+    docs_url="/cuopt/docs",
+    redoc_url="/cuopt/redoc",
+    openapi_url="/cuopt/openapi.json",
+)
+
+_grpc_client = None
+_jobs = {}
+_jobs_lock = threading.Lock()
+
+_ROUTING_KEYS = {
+    "cost_matrix_data",
+    "task_data",
+    "fleet_data",
+    "cost_waypoint_graph_data",
+    "travel_time_waypoint_graph_data",
+    "travel_time_matrix_data",
+    "solver_config",
+}
+
+_NOT_IMPLEMENTED = (
+    "This feature is not implemented on the gRPC HTTP proxy. "
+    "Use the legacy HTTP server (python -m cuopt_server.cuopt_service) "
+    "or a later proxy PR."
+)
+
+
+def set_grpc_client(client):
+    global _grpc_client
+    _grpc_client = client
+
+
+def get_grpc_client():
+    if _grpc_client is None:
+        raise HTTPException(
+            status_code=503, detail="gRPC client is not connected"
+        )
+    return _grpc_client
+
+
+def reset_proxy_state():
+    global _grpc_client
+    with _jobs_lock:
+        _jobs.clear()
+    _grpc_client = None
+
+
+def _store_job(job_id, meta):
+    with _jobs_lock:
+        _jobs[job_id] = meta
+
+
+def _get_job(job_id):
+    with _jobs_lock:
+        return _jobs.get(job_id)
+
+
+def _pop_job(job_id):
+    with _jobs_lock:
+        return _jobs.pop(job_id, None)
+
+
+def _update_job(job_id, **fields):
+    with _jobs_lock:
+        meta = _jobs.get(job_id)
+        if meta is not None:
+            meta.update(fields)
+        return meta
+
+
+@app.exception_handler(Exception)
+async def request_exception_handler(request, exc):
+    return exception_handler(exc)
+
+
+def _not_implemented(feature):
+    raise HTTPException(
+        status_code=501,
+        detail=f"{feature} is not supported. {_NOT_IMPLEMENTED}",
+    )
+
+
+def _require_uuid(id):
+    try:
+        uuid.UUID(id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="Invalid request id format"
+        )
+
+
+def _resolve_accept(accept, fallback=mime_json):
+    if not accept:
+        return fallback
+    if accept not in [mime_json, mime_msgpack, mime_zlib] + mime_wild:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported Accept value {accept}, "
+            f"supported values are {[mime_json, mime_msgpack, mime_zlib]}",
+        )
+    if accept in mime_wild:
+        return fallback
+    return accept
+
+
+def _status_name(status):
+    return getattr(status, "name", str(status))
+
+
+def _is_status(status, *names):
+    return _status_name(status) in names
+
+
+def _map_status(grpc_status):
+    name = _status_name(grpc_status)
+    mapping = {
+        "QUEUED": RequestStatusModel.queued,
+        "PROCESSING": RequestStatusModel.running,
+        "COMPLETED": RequestStatusModel.completed,
+        "FAILED": RequestStatusModel.aborted,
+        "CANCELLED": RequestStatusModel.aborted,
+    }
+    if name == "NOT_FOUND":
+        return None
+    return mapping.get(name, RequestStatusModel.aborted)
+
+
+def _looks_like_routing(data):
+    if not isinstance(data, dict):
+        return False
+    if "csr_constraint_matrix" in data:
+        return False
+    return bool((_ROUTING_KEYS - {"solver_config"}) & set(data.keys()))
+
+
+def _prepare_lp(data, warnings):
+    if isinstance(data, list):
+        _not_implemented("Batch LP (a JSON list of LP problems)")
+    if _looks_like_routing(data):
+        _not_implemented("Vehicle routing (VRP)")
+    try:
+        if isinstance(data, dict):
+            transform_lp_data(data)
+            lp_data = LPData.parse_obj(data)
+        else:
+            lp_data = data
+            transform_lp_data(lp_data)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=422,
+            detail="unable to validate optimization data stream, %s"
+            % (str(e)),
+        )
+    validate_LP_data(lp_data)
+    dm_warnings, data_model = create_data_model(lp_data)
+    warnings.extend(dm_warnings)
+    sw_warnings, solver_settings = create_solver(lp_data, None)
+    warnings.extend(sw_warnings)
+    return lp_data, data_model, solver_settings
+
+
+@app.get("/", responses=HealthResponse)
+@app.get("/cuopt/health", responses=HealthResponse)
+@app.get("/v2/health/ready", responses=HealthResponse)
+@app.get("/v2/health/live", responses=HealthResponse)
+def health():
+    return {"status": "RUNNING", "version": app.version}
+
+
+@app.get(
+    "/cuopt/log/{id}",
+    response_model=LogResponseModel,
+    responses=LogResponse,
+)
+def getsolverlogs(
+    id: str,
+    accept: str = Header(default="application/json"),
+    frombyte: Optional[int] = Query(default=0),
+):
+    try:
+        accept = _resolve_accept(accept)
+        _require_uuid(id)
+        if frombyte < 0:
+            raise HTTPException(
+                status_code=422, detail="frombyte must be >= 0"
+            )
+        meta = _get_job(id)
+        if meta is not None and meta.get("validation_only"):
+            raise HTTPException(
+                status_code=404, detail=f"log not found for request {id}"
+            )
+        if meta is not None and not meta.get("solver_logs"):
+            raise HTTPException(
+                status_code=404, detail=f"log not found for request {id}"
+            )
+        client = get_grpc_client()
+        try:
+            from cuopt.grpc.linear_programming import JobNotReadyError
+
+            lines = client.logs(id, frombyte)
+        except JobNotReadyError:
+            return encode({"log": [""], "nbytes": frombyte}, accept)
+        except Exception as e:
+            if "not found" in str(e).lower() or "NOT_FOUND" in str(e):
+                raise HTTPException(
+                    status_code=404, detail=f"log not found for request {id}"
+                )
+            raise
+        payload = "\n".join(lines)
+        return encode(
+            {"log": lines, "nbytes": frombyte + len(payload.encode())},
+            accept,
+        )
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.delete("/cuopt/log/{id}", responses=DeleteResponse)
+def deletesolverlogs(
+    id: str,
+    accept: str = Header(default="application/json"),
+):
+    try:
+        accept = _resolve_accept(accept)
+        _require_uuid(id)
+        # gRPC deletes logs with the job. HTTP DELETE log is a no-op 200.
+        return Response(status_code=200)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return exception_handler(e)
+
+
+@app.get(
+    "/cuopt/solution/{id}/incumbents",
+    response_model=List[IncumbentSolution],
+    responses=IncumbentSolutionResponse,
+)
+def getincumbent(
+    id: str,
+    accept: str = Header(default="application/json"),
+):
+    try:
+        accept = _resolve_accept(accept)
+        _require_uuid(id)
+        meta = _get_job(id)
+        if meta is not None and meta.get("validation_only"):
+            return encode(
+                [{"solution": [], "cost": None, "bound": None}], accept
+            )
+        client = get_grpc_client()
+        status = client.status(id)
+        if _is_status(status, "NOT_FOUND"):
+            raise HTTPException(status_code=404, detail=f"id {id} not found")
+        from_index = 0 if meta is None else meta.get("incumbent_next_index", 0)
+        entries = client.incumbents(id, from_index=from_index)
+        result = [
+            {
+                "solution": e.get("assignment", []),
+                "cost": e.get("objective"),
+                "bound": None,
+            }
+            for e in entries
+        ]
+        if entries:
+            next_index = max(e["index"] for e in entries) + 1
+            _update_job(id, incumbent_next_index=next_index)
+        terminal = not _is_status(status, "QUEUED", "PROCESSING")
+        if not result and terminal:
+            result = [{"solution": [], "cost": None, "bound": None}]
+        return encode(result, accept)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.post(
+    "/cuopt/solution",
+    response_model=IdModel,
+    responses=IdResponse,
+)
+async def postsolution():
+    _not_implemented("POST /cuopt/solution (uploaded solutions)")
+
+
+@app.delete("/cuopt/solution/{id}", responses=DeleteResponse)
+def deletesolution(
+    id: str = Path(...),
+    accept: str = Header(default="application/json"),
+):
+    try:
+        accept = _resolve_accept(accept)
+        _require_uuid(id)
+        meta = _pop_job(id)
+        if meta is not None and meta.get("validation_only"):
+            return Response(status_code=200)
+        client = get_grpc_client()
+        try:
+            client.delete(id)
+        except Exception as e:
+            if "not found" in str(e).lower() or "NOT_FOUND" in str(e):
+                raise HTTPException(
+                    status_code=404, detail=f"id {id} not found"
+                )
+            raise
+        return Response(status_code=200)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.delete(
+    "/cuopt/request/{id}",
+    response_model=DeleteRequestModel,
+    responses=ValidationErrorResponse,
+)
+def deleterequest(
+    id: str = Path(...),
+    accept: str = Header(default="application/json"),
+    running: Optional[bool] = Query(default=None),
+    queued: Optional[bool] = Query(default=None),
+    cached: Optional[bool] = Query(default=None),
+):
+    try:
+        accept = _resolve_accept(accept)
+        if id == "*":
+            _not_implemented("Wildcard DELETE /cuopt/request/*")
+        if running is not None or queued is not None or cached is not None:
+            _not_implemented(
+                "DELETE /cuopt/request flags running/queued/cached"
+            )
+        _require_uuid(id)
+        meta = _get_job(id)
+        counts = {"queued": 0, "running": 0, "cached": 0}
+        if meta is not None and meta.get("validation_only"):
+            return encode(counts, accept)
+        client = get_grpc_client()
+        status = client.status(id)
+        if _is_status(status, "NOT_FOUND"):
+            raise HTTPException(status_code=404, detail=f"id {id} not found")
+        if _is_status(status, "QUEUED"):
+            counts["queued"] = 1
+        elif _is_status(status, "PROCESSING"):
+            counts["running"] = 1
+        # gRPC cancel rejects completed jobs; HTTP abort of a finished
+        # request is a no-op 200 (solution remains until DELETE solution).
+        if _is_status(status, "QUEUED", "PROCESSING"):
+            client.cancel(id)
+        return encode(counts, accept)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.get(
+    "/cuopt/solution/{id}/warmstart",
+    include_in_schema=False,
+)
+def getwarmstart(id: str):
+    _not_implemented("GET /cuopt/solution/{id}/warmstart (C13)")
+
+
+@app.get(
+    "/cuopt/solution/{id}",
+    responses=SolutionResponse,
+)
+def getsolution(
+    id: str,
+    accept: str = Header(default="application/json"),
+):
+    try:
+        fallback = mime_json
+        meta = _get_job(id)
+        if meta is not None:
+            fallback = meta.get("accept", mime_json)
+        accept = _resolve_accept(accept, fallback)
+        _require_uuid(id)
+        if meta is not None and meta.get("validation_only"):
+            return encode(meta["validation_result"], accept, job_result=True)
+        client = get_grpc_client()
+        status = client.status(id)
+        if _is_status(status, "NOT_FOUND"):
+            raise HTTPException(status_code=404, detail=f"id {id} not found")
+        if _is_status(status, "QUEUED", "PROCESSING"):
+            return encode({"reqId": id}, accept)
+        sol = client.result(
+            id,
+            variable_names=(
+                None if meta is None else meta.get("variable_names")
+            ),
+        )
+        if sol is None:
+            return encode({"reqId": id}, accept)
+        inner = solution_to_legacy_http(sol, include_warmstart=False)
+        notes = []
+        try:
+            notes.append(sol.get_termination_reason())
+        except Exception:
+            pass
+        warnings = [] if meta is None else list(meta.get("warnings") or [])
+        solve_time = 0
+        if inner.get("solution"):
+            solve_time = inner["solution"].get("solver_time") or 0
+        envelope = make_response(
+            {"solver_response": inner},
+            warnings=warnings,
+            notes=notes,
+            reqId=id,
+            total_solve_time=solve_time,
+        )
+        resultdir, maxresult, mode = settings.get_result_dir()
+        result_file = "" if meta is None else meta.get("result_file") or ""
+        if result_file and resultdir:
+            raw = encode_bytes(envelope, accept)
+            if result_meets_threshold(
+                result_file, resultdir, len(raw), maxresult
+            ):
+                write_result_file(resultdir, result_file, raw, mode)
+                file_msg = file_result_message(
+                    result_file, warnings=warnings, notes=notes
+                )
+                file_msg["format"] = get_format(accept)
+                return encode(file_msg, accept, job_result=True)
+        return encode(envelope, accept, job_result=True)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.get(
+    "/cuopt/request/{id}",
+    response_model=RequestStatusModel,
+    responses=RequestResponse,
+)
+def getrequest(
+    id: str,
+    accept: str = Header(default="application/json"),
+):
+    try:
+        accept = _resolve_accept(accept)
+        _require_uuid(id)
+        meta = _get_job(id)
+        if meta is not None and meta.get("validation_only"):
+            return encode(RequestStatusModel.completed.value, accept)
+        client = get_grpc_client()
+        status = client.status(id)
+        mapped = _map_status(status)
+        if mapped is None or _is_status(status, "NOT_FOUND"):
+            raise HTTPException(status_code=404, detail=f"id {id} not found")
+        return encode(mapped.value, accept)
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+@app.post(
+    "/cuopt/cuopt",
+)
+async def post_cuopt_sync():
+    _not_implemented("POST /cuopt/cuopt (C12)")
+
+
+@app.post(
+    "/cuopt/request",
+    response_model=IdModel,
+    responses=IdResponse,
+    summary="Solve an LP/MILP problem via gRPC (self-hosted proxy)",
+    openapi_extra={
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": lpschema,
+                    "examples": {
+                        "LP request": {"value": lp_example_data},
+                    },
+                },
+                "application/vnd.msgpack": {
+                    "schema": {"type": "string", "format": "byte"},
+                    "examples": {
+                        "LP request compressed with msgpack": {
+                            "value": lp_msgpack_example_data
+                        },
+                    },
+                },
+                "application/zlib": {
+                    "schema": {"type": "string", "format": "byte"},
+                    "examples": {
+                        "LP request compressed with zlib": {
+                            "value": lp_zlib_example_data
+                        },
+                    },
+                },
+            },
+            "required": True,
+        }
+    },
+)
+async def postrequest(
+    request: Request,
+    cache: Optional[bool] = Query(default=False),
+    reqId: Optional[str] = Query(default=None),
+    initialId: Optional[List[str]] = Query(default=None),
+    warmstartId: Optional[str] = Query(default=None),
+    validation_only: Optional[bool] = Query(default=False),
+    incumbent_solutions: Optional[bool] = Query(default=False),
+    incumbent_set_solutions: Optional[bool] = Query(default=False),
+    solver_logs: Optional[bool] = Query(default=False),
+    cuopt_data_file: str = Header(default=None),
+    cuopt_result_file: str = Header(default=None),
+    client_version: str = Header(default=None),
+    accept: str = Header(default="application/json"),
+    content_type: str = Header(default="application/json"),
+    content_length: int = Header(default=0),
+):
+    ctype = content_type
+    sz = content_length
+    if cuopt_data_file is None:
+        cuopt_data_file = ""
+    if cuopt_result_file is None:
+        cuopt_result_file = ""
+    if client_version is None:
+        client_version = ""
+
+    warnings = check_client_version(client_version)
+
+    try:
+        accept = _resolve_accept(
+            accept, ctype if ctype != mime_pickle else mime_json
+        )
+        if cache:
+            _not_implemented("Query parameter cache")
+        if reqId:
+            _not_implemented("Query parameter reqId (cached-body solve)")
+        if initialId:
+            _not_implemented("Query parameter initialId (C11)")
+        if warmstartId:
+            _not_implemented("Query parameter warmstartId (C13)")
+        if incumbent_set_solutions:
+            _not_implemented("Query parameter incumbent_set_solutions")
+
+        sz = int(sz)
+        if sz == 0 and not cuopt_data_file:
+            raise HTTPException(
+                status_code=422, detail="Data length is zero and reqId not set"
+            )
+
+        if ctype not in [mime_json, mime_msgpack, mime_zlib, mime_pickle]:
+            raise HTTPException(
+                status_code=415,
+                detail=f"Unsupported Content-Type value {ctype}, "
+                f"supported values are "
+                f"{[mime_json, mime_msgpack, mime_zlib, mime_pickle]}",
+            )
+
+        file_path = ""
+        if cuopt_data_file:
+            file_path = validate_file_path(cuopt_data_file)
+
+        if file_path:
+            data = load_optimization_file(file_path, warnings)
+        else:
+            now = time.time()
+            buf = bytearray(sz)
+            await get_data(buf, request)
+            logging.debug(f"time to receive data {time.time() - now}")
+            data = deserialize(ctype, buf)
+
+        lp_data, data_model, solver_settings = _prepare_lp(data, warnings)
+        variable_names = lp_data.variable_names
+        resultdir, _, _ = settings.get_result_dir()
+        result_file = get_output_name(
+            resultdir, cuopt_data_file, cuopt_result_file
+        )
+
+        if validation_only:
+            job_id = str(uuid.uuid4())
+            notes = ["Input is valid"]
+            envelope = make_response(
+                {"solver_response": {"status": 0, "solution": {}}},
+                warnings=warnings,
+                notes=notes,
+                reqId=job_id,
+            )
+            _store_job(
+                job_id,
+                {
+                    "accept": accept,
+                    "warnings": warnings,
+                    "variable_names": variable_names,
+                    "result_file": result_file,
+                    "solver_logs": False,
+                    "incumbents_enabled": False,
+                    "incumbent_next_index": 0,
+                    "validation_only": True,
+                    "validation_result": envelope,
+                },
+            )
+            return encode({"reqId": job_id}, accept)
+
+        client = get_grpc_client()
+        job_id = client.submit(
+            data_model,
+            solver_settings,
+            enable_incumbents=bool(incumbent_solutions),
+        )
+        _store_job(
+            job_id,
+            {
+                "accept": accept,
+                "warnings": warnings,
+                "variable_names": variable_names,
+                "result_file": result_file,
+                "solver_logs": bool(solver_logs),
+                "incumbents_enabled": bool(incumbent_solutions),
+                "incumbent_next_index": 0,
+                "validation_only": False,
+            },
+        )
+        return encode({"reqId": job_id}, accept)
+
+    except (RequestValidationError, ValidationError) as e:
+        return encode(validation_exception_handler(e), accept)
+
+    except HTTPException as e:
+        return encode(http_exception_handler(e), accept)
+
+    except Exception as e:
+        return encode(exception_handler(e), accept)
+
+
+def run_server(ip, port, log_level, ssl_certfile, ssl_keyfile):
+    uvi_config = uvicorn.config.LOGGING_CONFIG
+    for uvilog in uvi_config["handlers"].keys():
+        uvi_config["handlers"][uvilog] = {
+            "class": "logging.NullHandler",
+        }
+    for uvilog in uvi_config["loggers"].keys():
+        uvi_config["loggers"][uvilog]["propagate"] = True
+
+    if len(ssl_certfile) > 0 and len(ssl_keyfile) > 0:
+        if not os.path.exists(ssl_certfile):
+            raise ValueError(f"File path '{ssl_certfile}' doesn't exist")
+        if not os.path.exists(ssl_keyfile):
+            raise ValueError(f"File path '{ssl_keyfile}' doesn't exist")
+    elif len(ssl_certfile) > 0 or len(ssl_keyfile) > 0:
+        raise ValueError(
+            "Need to provide both certfile and keyfile to enable SSL"
+        )
+    else:
+        ssl_certfile = None
+        ssl_keyfile = None
+
+    uvicorn.run(
+        "cuopt_server.proxy_webserver:app",
+        host=ip,
+        port=port,
+        log_config=uvi_config,
+        log_level=log_level,
+        ssl_keyfile=ssl_keyfile,
+        ssl_certfile=ssl_certfile,
+    )
+    logging.info("proxy webserver finished")

--- a/python/cuopt_server/cuopt_server/tests/test_grpc_http_proxy.py
+++ b/python/cuopt_server/cuopt_server/tests/test_grpc_http_proxy.py
@@ -1,0 +1,476 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cuopt_server.cuopt_proxy import parse_args
+from cuopt_server.proxy_webserver import (
+    app,
+    reset_proxy_state,
+    set_grpc_client,
+)
+from cuopt_server.utils.http_codec import mime_json, mime_msgpack, mime_zlib
+from cuopt_server.utils.http_envelope import make_response
+from cuopt_server.utils.linear_programming import conversion as lp_conversion
+
+
+def _lp():
+    return {
+        "csr_constraint_matrix": {
+            "offsets": [0, 2],
+            "indices": [0, 1],
+            "values": [1.0, 1.0],
+        },
+        "constraint_bounds": {
+            "upper_bounds": [5000.0],
+            "lower_bounds": [0.0],
+        },
+        "objective_data": {
+            "coefficients": [1.2, 1.7],
+            "scalability_factor": 1.0,
+            "offset": 0.0,
+        },
+        "variable_bounds": {
+            "upper_bounds": [3000.0, 5000.0],
+            "lower_bounds": [0.0, 0.0],
+        },
+        "maximize": False,
+        "variable_names": ["x", "y"],
+        "solver_config": {"time_limit": 5},
+    }
+
+
+class FakeJobStatus:
+    QUEUED = SimpleNamespace(name="QUEUED")
+    PROCESSING = SimpleNamespace(name="PROCESSING")
+    COMPLETED = SimpleNamespace(name="COMPLETED")
+    FAILED = SimpleNamespace(name="FAILED")
+    CANCELLED = SimpleNamespace(name="CANCELLED")
+    NOT_FOUND = SimpleNamespace(name="NOT_FOUND")
+
+
+class FakeSol:
+    def get_termination_status(self):
+        from cuopt.linear_programming.solver.solver_wrapper import (
+            LPTerminationStatus,
+        )
+
+        return LPTerminationStatus.Optimal
+
+    def get_primal_solution(self):
+        import numpy as np
+
+        return np.array([0.0, 0.0])
+
+    def get_dual_solution(self):
+        import numpy as np
+
+        return np.array([0.0])
+
+    def get_lp_stats(self):
+        return {"gap": 0.0}
+
+    def get_reduced_cost(self):
+        import numpy as np
+
+        return np.array([1.2, 1.7])
+
+    def get_milp_stats(self):
+        raise AttributeError
+
+    def get_pdlp_warm_start_data(self):
+        raise AttributeError
+
+    def get_problem_category(self):
+        return SimpleNamespace(name="LP")
+
+    def get_primal_objective(self):
+        return 0.0
+
+    def get_dual_objective(self):
+        return 0.0
+
+    def get_solve_time(self):
+        return 0.01
+
+    def get_solved_by(self):
+        return SimpleNamespace(name="PDLP")
+
+    def get_vars(self):
+        return {"x": 0.0, "y": 0.0}
+
+    def get_termination_reason(self):
+        return "Optimal"
+
+
+class FakeClient:
+    def __init__(self):
+        self.jobs = {}
+        self.submitted = []
+        self.cancelled = []
+        self.deleted = []
+        self._incumbents = {}
+        self._logs = {}
+
+    def submit(self, problem, settings, enable_incumbents=None):
+        job_id = str(uuid.uuid4())
+        self.jobs[job_id] = FakeJobStatus.COMPLETED
+        self.submitted.append(
+            {
+                "id": job_id,
+                "enable_incumbents": enable_incumbents,
+                "problem": problem,
+                "settings": settings,
+            }
+        )
+        return job_id
+
+    def status(self, job_id):
+        return self.jobs.get(job_id, FakeJobStatus.NOT_FOUND)
+
+    def result(self, job_id, variable_names=None):
+        if self.jobs.get(job_id) != FakeJobStatus.COMPLETED:
+            return None
+        return FakeSol()
+
+    def cancel(self, job_id):
+        self.cancelled.append(job_id)
+        if job_id in self.jobs:
+            self.jobs[job_id] = FakeJobStatus.CANCELLED
+
+    def delete(self, job_id):
+        self.deleted.append(job_id)
+        self.jobs.pop(job_id, None)
+
+    def logs(self, job_id, from_byte=0):
+        return list(self._logs.get(job_id, ["line1", "line2"]))
+
+    def incumbents(self, job_id, from_index=0):
+        entries = self._incumbents.get(job_id, [])
+        return [e for e in entries if e["index"] >= from_index]
+
+
+@pytest.fixture
+def proxy(monkeypatch):
+    import cuopt_server.proxy_webserver as pw
+
+    reset_proxy_state()
+    fake = FakeClient()
+    set_grpc_client(fake)
+    monkeypatch.setattr(
+        pw, "create_data_model", lambda lp: ([], SimpleNamespace())
+    )
+    monkeypatch.setattr(
+        pw, "create_solver", lambda lp, w: ([], SimpleNamespace())
+    )
+    client = TestClient(app)
+    yield client, fake
+    reset_proxy_state()
+
+
+def test_parse_args_defaults():
+    args = parse_args([])
+    assert args.port == 8000
+    assert args.grpc_host == "127.0.0.1"
+    assert args.grpc_port == 5001
+
+
+def test_parse_args_overrides():
+    args = parse_args(
+        [
+            "--ip",
+            "127.0.0.1",
+            "-p",
+            "9000",
+            "--grpc-host",
+            "gpu",
+            "--grpc-port",
+            "5002",
+        ]
+    )
+    assert args.ip == "127.0.0.1"
+    assert args.port == 9000
+    assert args.grpc_host == "gpu"
+    assert args.grpc_port == 5002
+
+
+def test_make_response_envelope():
+    r = make_response(
+        {"solver_response": {"status": "Optimal"}},
+        warnings=["w"],
+        notes=["n"],
+        reqId="abc",
+        total_solve_time=1.5,
+    )
+    assert r["reqId"] == "abc"
+    assert r["warnings"] == ["w"]
+    assert r["notes"] == ["n"]
+    assert r["response"]["total_solve_time"] == 1.5
+
+
+def test_solution_to_legacy_http_strips_warmstart():
+    res = lp_conversion.solution_to_legacy_http(FakeSol())
+    assert res["status"] == "Optimal"
+    assert "pdlpwarmstart_data" in res["solution"]
+    stripped = lp_conversion.solution_to_legacy_http(
+        FakeSol(), include_warmstart=False
+    )
+    assert "pdlpwarmstart_data" not in stripped["solution"]
+
+
+def test_health(proxy):
+    client, _ = proxy
+    for path in ("/", "/cuopt/health", "/v2/health/ready", "/v2/health/live"):
+        res = client.get(path)
+        assert res.status_code == 200, path
+        body = res.json()
+        assert body["status"] == "RUNNING"
+        assert "version" in body
+
+
+def test_submit_status_result_delete(proxy):
+    client, fake = proxy
+    lp = _lp()
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom", "Content-Type": mime_json},
+        json=lp,
+    )
+    assert res.status_code == 200, res.text
+    req_id = res.json()["reqId"]
+    uuid.UUID(req_id)
+    assert fake.submitted[0]["enable_incumbents"] is False
+
+    st = client.get(f"/cuopt/request/{req_id}")
+    assert st.status_code == 200
+    assert st.json() == "completed"
+
+    sol = client.get(f"/cuopt/solution/{req_id}")
+    assert sol.status_code == 200
+    body = sol.json()
+    assert body["reqId"] == req_id
+    assert body["response"]["solver_response"]["status"] == "Optimal"
+    assert (
+        "pdlpwarmstart_data"
+        not in body["response"]["solver_response"]["solution"]
+    )
+
+    deleted = client.delete(f"/cuopt/solution/{req_id}")
+    assert deleted.status_code == 200
+    assert req_id in fake.deleted
+
+
+def test_incumbents_cursor_and_sentinel(proxy):
+    client, fake = proxy
+    lp = _lp()
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        params={"incumbent_solutions": True},
+        json=lp,
+    )
+    req_id = res.json()["reqId"]
+    assert fake.submitted[0]["enable_incumbents"] is True
+    fake._incumbents[req_id] = [
+        {"index": 0, "objective": 2.0, "assignment": [1.0, 1.0]},
+        {"index": 1, "objective": 1.0, "assignment": [0.0, 1.0]},
+    ]
+    first = client.get(f"/cuopt/solution/{req_id}/incumbents")
+    assert first.status_code == 200
+    assert first.json() == [
+        {"solution": [1.0, 1.0], "cost": 2.0, "bound": None},
+        {"solution": [0.0, 1.0], "cost": 1.0, "bound": None},
+    ]
+    second = client.get(f"/cuopt/solution/{req_id}/incumbents")
+    assert second.json() == [{"solution": [], "cost": None, "bound": None}]
+
+
+def test_logs_and_log_delete_noop(proxy):
+    client, fake = proxy
+    lp = _lp()
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        params={"solver_logs": True},
+        json=lp,
+    )
+    req_id = res.json()["reqId"]
+    logs = client.get(f"/cuopt/log/{req_id}")
+    assert logs.status_code == 200
+    body = logs.json()
+    assert body["log"] == ["line1", "line2"]
+    assert body["nbytes"] > 0
+    assert client.delete(f"/cuopt/log/{req_id}").status_code == 200
+
+
+def test_cancel_request(proxy):
+    client, fake = proxy
+    lp = _lp()
+    req_id = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        json=lp,
+    ).json()["reqId"]
+    fake.jobs[req_id] = FakeJobStatus.PROCESSING
+    res = client.delete(f"/cuopt/request/{req_id}")
+    assert res.status_code == 200
+    assert res.json() == {"queued": 0, "running": 1, "cached": 0}
+    assert req_id in fake.cancelled
+
+
+def test_cancel_completed_is_noop(proxy):
+    client, fake = proxy
+    lp = _lp()
+    req_id = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        json=lp,
+    ).json()["reqId"]
+    res = client.delete(f"/cuopt/request/{req_id}")
+    assert res.status_code == 200
+    assert res.json() == {"queued": 0, "running": 0, "cached": 0}
+    assert req_id not in fake.cancelled
+
+
+def test_validation_only_skips_submit(proxy):
+    client, fake = proxy
+    lp = _lp()
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        params={"validation_only": True},
+        json=lp,
+    )
+    assert res.status_code == 200
+    req_id = res.json()["reqId"]
+    assert fake.submitted == []
+    st = client.get(f"/cuopt/request/{req_id}")
+    assert st.json() == "completed"
+    sol = client.get(f"/cuopt/solution/{req_id}").json()
+    assert sol["notes"] == ["Input is valid"]
+    assert sol["response"]["solver_response"]["status"] == 0
+
+
+@pytest.mark.parametrize(
+    "params,feature",
+    [
+        ({"cache": True}, "cache"),
+        ({"reqId": str(uuid.uuid4())}, "reqId"),
+        ({"initialId": str(uuid.uuid4())}, "initialId"),
+        ({"warmstartId": str(uuid.uuid4())}, "warmstartId"),
+        ({"incumbent_set_solutions": True}, "incumbent_set_solutions"),
+    ],
+)
+def test_dropped_query_params_are_501(proxy, params, feature):
+    client, _ = proxy
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        params=params,
+        json=_lp(),
+    )
+    assert res.status_code == 501, res.text
+    assert feature in res.json()["error"]
+
+
+def test_batch_lp_is_501(proxy):
+    client, _ = proxy
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        json=[_lp(), _lp()],
+    )
+    assert res.status_code == 501
+    assert "Batch LP" in res.json()["error"]
+
+
+def test_vrp_body_is_501(proxy):
+    client, _ = proxy
+    res = client.post(
+        "/cuopt/request",
+        headers={"CLIENT-VERSION": "custom"},
+        json={
+            "cost_matrix_data": {"data": {"1": [[0, 1], [1, 0]]}},
+            "task_data": {"task_locations": [1, 1]},
+        },
+    )
+    assert res.status_code == 501
+    assert "routing" in res.json()["error"].lower()
+
+
+def test_post_solution_and_warmstart_and_sync_are_501(proxy):
+    client, _ = proxy
+    assert client.post("/cuopt/solution", json={}).status_code == 501
+    assert (
+        client.get(f"/cuopt/solution/{uuid.uuid4()}/warmstart").status_code
+        == 501
+    )
+    assert client.post("/cuopt/cuopt", json={}).status_code == 501
+    assert client.delete("/cuopt/request/*").status_code == 501
+    assert (
+        client.delete(
+            f"/cuopt/request/{uuid.uuid4()}", params={"running": True}
+        ).status_code
+        == 501
+    )
+
+
+def test_msgpack_round_trip_headers(proxy):
+    import msgpack
+
+    client, _ = proxy
+    payload = msgpack.dumps(_lp())
+    res = client.post(
+        "/cuopt/request",
+        headers={
+            "CLIENT-VERSION": "custom",
+            "Content-Type": mime_msgpack,
+            "Accept": mime_msgpack,
+        },
+        content=payload,
+    )
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith(mime_msgpack)
+    body = msgpack.loads(res.content, strict_map_key=False)
+    assert "reqId" in body
+
+
+def test_zlib_accept(proxy):
+    import zlib
+
+    client, fake = proxy
+    res = client.post(
+        "/cuopt/request",
+        headers={
+            "CLIENT-VERSION": "custom",
+            "Accept": mime_zlib,
+        },
+        json=_lp(),
+    )
+    assert res.status_code == 200
+    body = json.loads(zlib.decompress(res.content))
+    assert "reqId" in body
+    sol = client.get(
+        f"/cuopt/solution/{body['reqId']}",
+        headers={"Accept": mime_zlib},
+    )
+    assert sol.status_code == 200
+    decoded = json.loads(zlib.decompress(sol.content))
+    assert decoded["response"]["solver_response"]["status"] == "Optimal"
+
+
+def test_unknown_id_is_404(proxy):
+    client, _ = proxy
+    missing = str(uuid.uuid4())
+    assert client.get(f"/cuopt/request/{missing}").status_code == 404
+    assert client.get(f"/cuopt/solution/{missing}").status_code == 404
+
+
+def test_invalid_id_is_400(proxy):
+    client, _ = proxy
+    assert client.get("/cuopt/request/not-a-uuid").status_code == 400

--- a/python/cuopt_server/cuopt_server/tests/test_http_codec.py
+++ b/python/cuopt_server/cuopt_server/tests/test_http_codec.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 import pickle
 import zlib
@@ -17,6 +18,7 @@ from cuopt_server.utils.http_codec import (
     deserialize,
     encode,
     encode_bytes,
+    get_data,
     get_format,
     mime_json,
     mime_msgpack,
@@ -133,6 +135,17 @@ def test_pickle_round_trip():
     encoded = pickle.dumps(sample_data)
     assert decode(mime_pickle, encoded) == sample_data
     assert deserialize(mime_pickle, encoded) == sample_data
+
+
+def test_get_data_streams_into_preallocated_buffer():
+    class FakeRequest:
+        async def stream(self):
+            for chunk in (b"abc", b"def", b"g"):
+                yield chunk
+
+    buf = bytearray(7)
+    asyncio.run(get_data(buf, FakeRequest()))
+    assert bytes(buf) == b"abcdefg"
 
 
 def test_pickle_forbidden_class():

--- a/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
+++ b/python/cuopt_server/cuopt_server/tests/test_utils_deprecated_boundary.py
@@ -110,3 +110,17 @@ def test_importing_cuopt_server_does_not_load_legacy_service():
         timeout=30,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_proxy_modules_do_not_import_deprecated():
+    pkg_root = _utils_root().parent
+    violations = []
+    for rel in ("proxy_webserver.py", "cuopt_proxy.py"):
+        path = pkg_root / rel
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for name in _imported_names(tree):
+            if _is_deprecated_import(name, path, _utils_root()):
+                violations.append(f"{rel}: {name}")
+            if "utils.deprecated" in name:
+                violations.append(f"{rel}: {name}")
+    assert violations == []

--- a/python/cuopt_server/cuopt_server/utils/client_version.py
+++ b/python/cuopt_server/cuopt_server/utils/client_version.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+
+from cuopt_server._version import __version__
+
+
+def check_client_version(client_vers):
+    logging.debug(f"client_vers is {client_vers} in check")
+    if os.environ.get("CUOPT_CHECK_CLIENT", True) in ["True", True]:
+        major, minor, *_ = __version__.split(".")
+        if client_vers == "custom":
+            return []
+        cv = (client_vers or "").split(".")
+        if len(cv) < 2:
+            logging.warning("Client version missing or bad format")
+            return [
+                "Client version missing or not the current format. "
+                f"Please upgrade your cuOpt client to '{major}.{minor}', "
+                "or set the client version to 'custom' "
+                "if this is a custom client."
+            ]
+        cmajor, cminor = cv[:2]
+        if (cmajor, cminor) != (major, minor):
+            logging.warning(f"Client version {cmajor}.{cminor} does not match")
+            return [
+                f"Client version is '{cmajor}.{cminor}' but server "
+                f"version is '{major}.{minor}'. Please use a matching client."
+            ]
+    return []

--- a/python/cuopt_server/cuopt_server/utils/deprecated/job_queue.py
+++ b/python/cuopt_server/cuopt_server/utils/deprecated/job_queue.py
@@ -16,7 +16,7 @@ from fastapi.responses import JSONResponse
 
 import cuopt_server.utils.deprecated.health_check as health_check
 import cuopt_server.utils.deprecated.request_filter as request_filter
-from cuopt_server._version import __version__
+from cuopt_server.utils.client_version import check_client_version
 from cuopt_server.utils.data_definition import (
     LPData,
     LPTupleData,
@@ -60,34 +60,6 @@ from cuopt_server.utils.routing.initial_solution import add_initial_sol
 
 
 msgpack_numpy.patch()
-
-
-def check_client_version(client_vers):
-    logging.debug(f"client_vers is {client_vers} in check")
-    if os.environ.get("CUOPT_CHECK_CLIENT", True) in ["True", True]:
-        major, minor, *_ = __version__.split(".")
-        matches = False
-        if client_vers == "custom":
-            return []
-        cv = client_vers.split(".")
-        if len(cv) < 2:
-            logging.warning("Client version missing or bad format")
-            return [
-                f"Client version missing or not the current format. "
-                f"Please upgrade your cuOpt client to '{major}.{minor}', "
-                "or set the client version to 'custom' "
-                "if this is a custom client."
-            ]
-        else:
-            cmajor, cminor = cv[:2]
-            matches = (cmajor, cminor) == (major, minor)
-        if not matches:
-            logging.warning(f"Client version {cmajor}.{cminor} does not match")
-            return [
-                f"Client version is '{cmajor}.{cminor}' but server "
-                f"version is '{major}.{minor}'. Please use a matching client."
-            ]
-    return []
 
 
 def get_solver_response(response):

--- a/python/cuopt_server/cuopt_server/utils/deprecated/linear_programming/solver.py
+++ b/python/cuopt_server/cuopt_server/utils/deprecated/linear_programming/solver.py
@@ -12,8 +12,6 @@ from cuopt.linear_programming.internals import (
 )
 from cuopt.linear_programming.solver.solver_wrapper import (
     ErrorStatus,
-    LPTerminationStatus,
-    MILPTerminationStatus,
 )
 from cuopt.utilities import (
     InputRuntimeError,
@@ -28,6 +26,7 @@ from cuopt_server.utils.linear_programming.conversion import (  # noqa: F401
     create_data_model,
     create_solver,
     ignored_warning,
+    solution_to_legacy_http,
 )
 
 
@@ -113,101 +112,8 @@ def solve(
 ):
     notes = []
 
-    def get_if_attribute_is_valid_else_none(attr):
-        try:
-            return attr()
-        except AttributeError:
-            return None
-
-    def extract_pdlpwarmstart_data(data):
-        if data is None:
-            return None
-        pdlpwarmstart_data = {
-            "current_primal_solution": data.current_primal_solution,
-            "current_dual_solution": data.current_dual_solution,
-            "initial_primal_average": data.initial_primal_average,
-            "initial_dual_average": data.initial_dual_average,
-            "current_ATY": data.current_ATY,
-            "sum_primal_solutions": data.sum_primal_solutions,
-            "sum_dual_solutions": data.sum_dual_solutions,
-            "last_restart_duality_gap_primal_solution": data.last_restart_duality_gap_primal_solution,  # noqa
-            "last_restart_duality_gap_dual_solution": data.last_restart_duality_gap_dual_solution,  # noqa
-            "initial_primal_weight": data.initial_primal_weight,
-            "initial_step_size": data.initial_step_size,
-            "total_pdlp_iterations": data.total_pdlp_iterations,
-            "total_pdhg_iterations": data.total_pdhg_iterations,
-            "last_candidate_kkt_score": data.last_candidate_kkt_score,
-            "last_restart_kkt_score": data.last_restart_kkt_score,
-            "sum_solution_weight": data.sum_solution_weight,
-            "iterations_since_last_restart": data.iterations_since_last_restart,  # noqa
-        }
-        return pdlpwarmstart_data
-
     def create_solution(sol):
-        solution = {}
-        status = sol.get_termination_status()
-        if status in (
-            LPTerminationStatus.Optimal,
-            LPTerminationStatus.IterationLimit,
-            LPTerminationStatus.TimeLimit,
-            MILPTerminationStatus.Optimal,
-            MILPTerminationStatus.FeasibleFound,
-        ):
-            primal_solution = get_if_attribute_is_valid_else_none(
-                sol.get_primal_solution
-            )
-            primal_solution = (
-                primal_solution
-                if primal_solution is None
-                else primal_solution.tolist()
-            )
-            dual_solution = get_if_attribute_is_valid_else_none(
-                sol.get_dual_solution
-            )
-            dual_solution = (
-                dual_solution
-                if dual_solution is None
-                else dual_solution.tolist()
-            )
-            lp_stats = get_if_attribute_is_valid_else_none(sol.get_lp_stats)
-            reduced_cost = get_if_attribute_is_valid_else_none(
-                sol.get_reduced_cost
-            )
-            reduced_cost = (
-                reduced_cost if reduced_cost is None else reduced_cost.tolist()
-            )
-            milp_stats = get_if_attribute_is_valid_else_none(
-                sol.get_milp_stats
-            )
-            pdlpwarmstart_data = get_if_attribute_is_valid_else_none(
-                sol.get_pdlp_warm_start_data
-            )
-            solution["problem_category"] = sol.get_problem_category().name
-            solution["primal_solution"] = primal_solution
-            solution["dual_solution"] = dual_solution
-            solution["primal_objective"] = get_if_attribute_is_valid_else_none(
-                sol.get_primal_objective
-            )
-            solution["dual_objective"] = get_if_attribute_is_valid_else_none(
-                sol.get_dual_objective
-            )
-            solution["solver_time"] = sol.get_solve_time()
-            solution["solved_by"] = sol.get_solved_by().name
-            solution["vars"] = sol.get_vars()
-            solution["lp_statistics"] = {} if lp_stats is None else lp_stats
-            solution["reduced_cost"] = reduced_cost
-
-            solution["pdlpwarmstart_data"] = extract_pdlpwarmstart_data(
-                pdlpwarmstart_data
-            )
-            solution["milp_statistics"] = (
-                {} if milp_stats is None else milp_stats
-            )
-
-        res = {
-            "status": status.name,
-            "solution": solution,
-        }
+        res = solution_to_legacy_http(sol)
         notes.append(sol.get_termination_reason())
         return res
 

--- a/python/cuopt_server/cuopt_server/utils/deprecated/solver.py
+++ b/python/cuopt_server/cuopt_server/utils/deprecated/solver.py
@@ -31,29 +31,12 @@ from cuopt_server.utils.deprecated.job_queue import (
     SolverBinaryResponse,
     SolverIntermediateResponse,
 )
+from cuopt_server.utils.http_envelope import make_response
 from cuopt_server.utils.logutil import set_ncaid, set_requestid, set_solverid
 from cuopt_server.utils.routing.conversion import (
     check_valid as check_valid,
     populate_optimization_data,
 )
-
-
-# Wrap the solver response in a dictionary with a "response"
-# field and add total_solve_time, request id, notes, and warnings to the
-# dictionary if those values are set.
-def make_response(
-    response, warnings=[], notes=[], reqId="", total_solve_time=0
-):
-    r = {"response": response}
-    if total_solve_time:
-        r["response"]["total_solve_time"] = total_solve_time
-    if reqId:
-        r["reqId"] = reqId
-    if warnings:
-        r["warnings"] = warnings
-    if notes:
-        r["notes"] = notes
-    return r
 
 
 # Validate LP data and call the LP solver

--- a/python/cuopt_server/cuopt_server/utils/http_codec.py
+++ b/python/cuopt_server/cuopt_server/utils/http_codec.py
@@ -113,6 +113,23 @@ def deserialize(ctype, buf):
     return data
 
 
+async def get_data(buf, request):
+    """Stream the request body into a pre-sized buffer.
+
+    Callers allocate ``buf`` from ``Content-Length`` (a ``bytearray`` or a
+    shared-memory view) so Starlette does not assemble a second copy via
+    ``request.body()``. Pydantic validation happens later, after
+    :func:`deserialize`.
+    """
+    pos = 0
+    try:
+        async for chunk in request.stream():
+            buf[pos : pos + len(chunk)] = chunk
+            pos = pos + len(chunk)
+    except Exception:
+        logging.debug("exception in get_data", exc_info=True)
+
+
 def encode_bytes(data, mime_type):
     # Write data to a byte array based on mime type
     if mime_type in [mime_json, mime_zlib]:

--- a/python/cuopt_server/cuopt_server/utils/http_envelope.py
+++ b/python/cuopt_server/cuopt_server/utils/http_envelope.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Wrap a solver payload in the legacy HTTP envelope used by
+# GET /cuopt/solution and validation_only responses.
+
+
+def make_response(
+    response, warnings=None, notes=None, reqId="", total_solve_time=0
+):
+    r = {"response": response}
+    if total_solve_time:
+        r["response"]["total_solve_time"] = total_solve_time
+    if reqId:
+        r["reqId"] = reqId
+    if warnings:
+        r["warnings"] = warnings
+    if notes:
+        r["notes"] = notes
+    return r

--- a/python/cuopt_server/cuopt_server/utils/linear_programming/conversion.py
+++ b/python/cuopt_server/cuopt_server/utils/linear_programming/conversion.py
@@ -6,6 +6,10 @@ import os
 
 from cuopt import linear_programming
 from cuopt.linear_programming.solver.solver_parameters import solver_params
+from cuopt.linear_programming.solver.solver_wrapper import (
+    LPTerminationStatus,
+    MILPTerminationStatus,
+)
 
 
 def ignored_warning(field):
@@ -137,3 +141,104 @@ def create_solver(LP_data, warmstart_data):
             warnings.append(ignored_warning("solution_file"))
 
     return warnings, solver_settings
+
+
+def _get_if_attribute_is_valid_else_none(attr):
+    try:
+        return attr()
+    except AttributeError:
+        return None
+
+
+def extract_pdlpwarmstart_data(data):
+    if data is None:
+        return None
+    return {
+        "current_primal_solution": data.current_primal_solution,
+        "current_dual_solution": data.current_dual_solution,
+        "initial_primal_average": data.initial_primal_average,
+        "initial_dual_average": data.initial_dual_average,
+        "current_ATY": data.current_ATY,
+        "sum_primal_solutions": data.sum_primal_solutions,
+        "sum_dual_solutions": data.sum_dual_solutions,
+        "last_restart_duality_gap_primal_solution": (
+            data.last_restart_duality_gap_primal_solution
+        ),
+        "last_restart_duality_gap_dual_solution": (
+            data.last_restart_duality_gap_dual_solution
+        ),
+        "initial_primal_weight": data.initial_primal_weight,
+        "initial_step_size": data.initial_step_size,
+        "total_pdlp_iterations": data.total_pdlp_iterations,
+        "total_pdhg_iterations": data.total_pdhg_iterations,
+        "last_candidate_kkt_score": data.last_candidate_kkt_score,
+        "last_restart_kkt_score": data.last_restart_kkt_score,
+        "sum_solution_weight": data.sum_solution_weight,
+        "iterations_since_last_restart": data.iterations_since_last_restart,
+    }
+
+
+def solution_to_legacy_http(sol, include_warmstart=True):
+    """Serialize a cuOpt LP/MILP Solution into the legacy HTTP shape.
+
+    Returns ``{"status": <enum name>, "solution": {...}}``. When the
+    termination status is not a solved/feasible case, ``solution`` is empty.
+    """
+    solution = {}
+    status = sol.get_termination_status()
+    if status in (
+        LPTerminationStatus.Optimal,
+        LPTerminationStatus.IterationLimit,
+        LPTerminationStatus.TimeLimit,
+        MILPTerminationStatus.Optimal,
+        MILPTerminationStatus.FeasibleFound,
+    ):
+        primal_solution = _get_if_attribute_is_valid_else_none(
+            sol.get_primal_solution
+        )
+        primal_solution = (
+            primal_solution
+            if primal_solution is None
+            else primal_solution.tolist()
+        )
+        dual_solution = _get_if_attribute_is_valid_else_none(
+            sol.get_dual_solution
+        )
+        dual_solution = (
+            dual_solution if dual_solution is None else dual_solution.tolist()
+        )
+        lp_stats = _get_if_attribute_is_valid_else_none(sol.get_lp_stats)
+        reduced_cost = _get_if_attribute_is_valid_else_none(
+            sol.get_reduced_cost
+        )
+        reduced_cost = (
+            reduced_cost if reduced_cost is None else reduced_cost.tolist()
+        )
+        milp_stats = _get_if_attribute_is_valid_else_none(sol.get_milp_stats)
+        pdlpwarmstart_data = _get_if_attribute_is_valid_else_none(
+            sol.get_pdlp_warm_start_data
+        )
+        solution["problem_category"] = sol.get_problem_category().name
+        solution["primal_solution"] = primal_solution
+        solution["dual_solution"] = dual_solution
+        solution["primal_objective"] = _get_if_attribute_is_valid_else_none(
+            sol.get_primal_objective
+        )
+        solution["dual_objective"] = _get_if_attribute_is_valid_else_none(
+            sol.get_dual_objective
+        )
+        solution["solver_time"] = sol.get_solve_time()
+        solution["solved_by"] = sol.get_solved_by().name
+        solution["vars"] = sol.get_vars()
+        solution["lp_statistics"] = {} if lp_stats is None else lp_stats
+        solution["reduced_cost"] = reduced_cost
+        if include_warmstart:
+            solution["pdlpwarmstart_data"] = extract_pdlpwarmstart_data(
+                pdlpwarmstart_data
+            )
+        solution["milp_statistics"] = {} if milp_stats is None else milp_stats
+
+    return {
+        "status": status.name,
+        "solution": solution,
+    }

--- a/python/cuopt_server/cuopt_server/webserver.py
+++ b/python/cuopt_server/cuopt_server/webserver.py
@@ -33,6 +33,7 @@ from pydantic import ValidationError
 import cuopt_server.utils.deprecated.health_check as health_check
 import cuopt_server.utils.settings as settings
 from cuopt_server._version import __version__
+from cuopt_server.utils.client_version import check_client_version
 from cuopt_server.utils.data_definition import (
     DeleteRequestModel,
     DeleteResponse,
@@ -71,6 +72,7 @@ from cuopt_server.utils.exceptions import (
 )
 from cuopt_server.utils.http_codec import (
     encode,
+    get_data,
     get_format,
     mime_json,
     mime_msgpack,
@@ -92,7 +94,6 @@ from cuopt_server.utils.deprecated.job_queue import (
     abort_all,
     abort_by_id,
     add_cache_entry,
-    check_client_version,
     delete_cache_entry,
     get_cache_content_type,
     get_incumbents_for_id,
@@ -1131,16 +1132,6 @@ async def postrequest(
 
     except Exception as e:
         return encode(exception_handler(e), accept)
-
-
-async def get_data(buf, request):
-    pos = 0
-    try:
-        async for chunk in request.stream():
-            buf[pos : pos + len(chunk)] = chunk
-            pos = pos + len(chunk)
-    except Exception:
-        print("exception in get_data")
 
 
 async def get_body(request: Request):


### PR DESCRIPTION
This initial version of the server is LP/MIP only. VRP and additional features will be added in a series of changes.

The server was tested locally by taking the current LP/MIP tests from cuopt_sh CLI tests from CI and running them against the proxy server, plus additional tests to cover the entire API surface of the proxy server. 67 tests in all.  Those tests are not include here -- in a future PR, once the proxy server is fully implemented, we'll switch the CLI tests in CI to run against the proxy server / grpc server combination instead of the legacy http server. 